### PR TITLE
Flowfile attribute <-> pulsar message property and message key mapping

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/MessageTuple.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/MessageTuple.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.    See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.    You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import java.util.Map;
+
+public class MessageTuple<T> {
+    private String topic;
+    private String key;
+    private Map<String, String> properties;
+    private T content;
+
+    public MessageTuple(String topic, String key, Map<String, String> properties, T content) {
+        this.topic = topic;
+        this.key = key;
+        this.properties = properties;
+        this.content = content;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public T getContent() {
+        return content;
+    }
+}

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/PropertyMappingUtils.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/PropertyMappingUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.    See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.    You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import java.util.function.Function;
+
+import org.apache.nifi.util.StringUtils;
+
+
+public final class PropertyMappingUtils {
+
+    private PropertyMappingUtils() {
+    }
+
+    /**
+     * Given a comma-delimited list of key mappings and a value extraction function,
+     * yields a map of <destkey>=<value>.
+     * @param mappings a comma-delimited list of <destkey>[=<srckey>] mappings. If no <srckey> is explicitly
+     *   specified, then it is assumed that the destkey should also be used as the source key.   
+     * @param mapper a function that, given a source key, should return the corresponding value
+     * @return the <destkey>=<value> map
+     */
+    public static Map<String, String> getMappedValues(String mappings, Function<String, String> mapper) {
+        Map<String, String> values = new HashMap<String, String>();
+
+        if (!StringUtils.isBlank(mappings)) {
+            Arrays.stream(mappings.split(",", -1))
+                .map((m) -> m.split("=", 2))
+                .forEach((kvp) -> {
+                    if (!StringUtils.isBlank(kvp[0])) {
+                        String value = null;
+
+                        if (kvp.length > 1 && !StringUtils.isBlank(kvp[1])) {
+                            value = mapper.apply(kvp[1]);
+                        }
+                        else {
+                            value = mapper.apply(kvp[0]);
+                        }
+
+                        if (value != null) {
+                            values.put(kvp[0], value);
+                        }
+                    }
+                });
+        }
+
+        return values;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/TestPropertyMappingUtils.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/TestPropertyMappingUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.    See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.    You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import java.util.function.Function;
+
+import static org.apache.nifi.processors.pulsar.PropertyMappingUtils.getMappedValues;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestPropertyMappingUtils {
+    private Map<String, String> values = new HashMap<>();    
+    private Function<String, String> func = new Function<String, String>() {
+        public String apply(String s) {
+            return values.get(s);
+        }
+    };
+
+    @Before
+    public void setUp() {
+        values.clear();
+    }
+
+    @Test
+    public void blankMappingsTest() {
+        assertEquals(0, getMappedValues(" ", func).size());
+    }
+
+    @Test
+    public void nullMappingsTest() {
+        assertEquals(0, getMappedValues(null, func).size());
+    }
+
+    @Test
+    public void blankMappedAttributeNameTest() {
+        values.put("prop", "val");
+
+        Map<String, String> props = getMappedValues("prop= ", func);
+        assertEquals(1, props.size());
+        assertEquals("val", props.get("prop"));
+    }
+
+    @Test
+    public void mappedAttributeTest() {
+        values.put("attr", "val");
+
+        Map<String, String> props = getMappedValues("prop=attr", func);
+        assertEquals(1, props.size());
+        assertEquals("val", props.get("prop"));
+    }
+
+    @Test
+    public void blankPropertyNameTest() {
+        Map<String, String> props = getMappedValues(" =attr", func);
+        assertEquals(0, props.size());
+    }
+
+    @Test
+    public void propertyNameOnlyTest() {
+        values.put("prop", "val");
+
+        Map<String, String> props = getMappedValues("prop", func);
+        assertEquals(1, props.size());
+        assertEquals("val", props.get("prop"));
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestPublishPulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestPublishPulsar.java
@@ -17,14 +17,25 @@
 package org.apache.nifi.processors.pulsar.pubsub;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunners;
 
 import org.apache.pulsar.client.api.Producer;
 
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestPublishPulsar extends AbstractPulsarProcessorTest<byte[]> {
 
@@ -36,5 +47,64 @@ public class TestPublishPulsar extends AbstractPulsarProcessorTest<byte[]> {
         mockProducer = mock(Producer.class);
         runner = TestRunners.newTestRunner(PublishPulsar.class);
         addPulsarClientService();
+    }
+
+    protected void doMappedPropertiesTest() throws UnsupportedEncodingException {
+        mockClientService.setMockProducer(mockProducer);
+
+        final String content = "some content";
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("prop", "val");
+
+        runner.setProperty(PublishPulsar.TOPIC, "my-topic");
+        runner.setProperty(PublishPulsar.MAPPED_MESSAGE_PROPERTIES, "prop");
+        runner.enqueue(content.getBytes("UTF-8"), attributes );
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS);
+
+        Map<String, String> expectedProperties = new HashMap<String, String>();
+        expectedProperties.put("prop", "val");
+        // Verify that we sent the data to topic-b.
+        verify(mockClientService.getMockTypedMessageBuilder()).properties(expectedProperties);
+    }
+
+    protected void doMessageKeyTest() throws UnsupportedEncodingException {
+        mockClientService.setMockProducer(mockProducer);
+
+        final String content = "some content";
+        Map<String, String> attributes1 = new HashMap<String, String>();
+        attributes1.put("prop", "val");
+
+        Map<String, String> attributes2 = new HashMap<String, String>();
+
+        runner.setProperty(PublishPulsar.TOPIC, "my-topic");
+        runner.setProperty(PublishPulsar.MESSAGE_KEY, "${prop}");
+        runner.enqueue(content.getBytes("UTF-8"), attributes1 );
+        runner.enqueue(content.getBytes("UTF-8"), attributes2 );
+
+        runner.run(2);
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS);
+
+        // Verify that we sent the data to topic-b.
+        verify(mockClientService.getMockTypedMessageBuilder(), times(1)).key("val");
+    }
+
+    @Test
+    public void dynamicTopicTest() throws UnsupportedEncodingException, PulsarClientException {
+        when(mockProducer.getTopic()).thenReturn("topic-b");
+        mockClientService.setMockProducer(mockProducer);
+
+        runner.setProperty(PublishPulsar.TOPIC, "${topic}");
+
+        final String content = "some content";
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("topic", "topic-b");
+
+        runner.enqueue(content.getBytes("UTF-8"), attributes );
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS);
+
+        // Verify that we sent the data to topic-b.
+        verify(mockClientService.getMockProducerBuilder(), times(1)).topic("topic-b");
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
@@ -92,4 +92,11 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         // Verify that the consumer was closed
         verify(mockClientService.getMockConsumer(), times(1)).close();
     }
+
+    @Test
+    public void mappedAttributesTest() throws PulsarClientException {
+        runner.setProperty(ConsumePulsar.ASYNC_ENABLED, Boolean.toString(true));
+
+        super.doMappedAttributesTest();
+    }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
 import org.apache.nifi.processors.pulsar.pubsub.TestConsumePulsarRecord;
 import org.apache.nifi.util.MockFlowFile;
@@ -141,5 +142,12 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
        String flowFileContents = new String(runner.getContentAsByteArray(results.get(0)));
        assertTrue(flowFileContents.startsWith(expected.toString(), 0));
+    }
+
+    @Test
+    public void mappedAttributesTest() throws PulsarClientException {
+        runner.setProperty(ConsumePulsar.ASYNC_ENABLED, Boolean.toString(true));
+
+        super.doMappedAttributesTest();
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.pulsar.pubsub.mocks;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -42,6 +43,7 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.OngoingStubbing;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -146,27 +148,30 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
 
     private void defineDefaultProducerBehavior() {
         try {
-           when(mockProducer.send(Matchers.argThat(new ArgumentMatcher<T>() {
-                @Override
-                public boolean matches(Object argument) {
-                    return true;
-                }
-            }))).thenReturn(mockMessageId);
+            // when(mockProducer.send(Matchers.argThat(new ArgumentMatcher<T>() {
+            //    @Override
+            //    public boolean matches(Object argument) {
+            //        return true;
+            //    }
+            // }))).thenReturn(mockMessageId);
 
             future = CompletableFuture.supplyAsync(() -> {
                 return mock(MessageId.class);
             });
 
-            when(mockProducer.sendAsync(Matchers.argThat(new ArgumentMatcher<T>() {
-                @Override
-                public boolean matches(Object argument) {
-                    return true;
-                }
-            }))).thenReturn(future);
+            // when(mockProducer.sendAsync(Matchers.argThat(new ArgumentMatcher<T>() {
+            //    @Override
+            //    public boolean matches(Object argument) {
+            //        return true;
+            //    }
+            // }))).thenReturn(future);
 
             when(mockProducer.isConnected()).thenReturn(true);
             when(mockProducer.newMessage()).thenReturn(mockTypedMessageBuilder);
+            when(mockTypedMessageBuilder.key(anyString())).thenReturn(mockTypedMessageBuilder);
+            when(mockTypedMessageBuilder.properties((Map<String, String>) any(Map.class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.value((T) any(byte[].class))).thenReturn(mockTypedMessageBuilder);
+            when(mockTypedMessageBuilder.send()).thenReturn(mockMessageId);
             when(mockTypedMessageBuilder.sendAsync()).thenReturn(future);
 
         } catch (PulsarClientException e) {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.processors.pulsar.pubsub.TestConsumePulsar;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
     @Test
     public void nullMessageTest() throws PulsarClientException {
         when(mockClientService.getMockConsumer().receive(0, TimeUnit.SECONDS)).thenReturn(mockMessage).thenReturn(null);
-        when(mockMessage.getData()).thenReturn(null);
+        when(mockMessage.getValue()).thenReturn(null);
         mockClientService.setMockMessage(mockMessage);
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
@@ -72,7 +73,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
     @Test
     public void emptyMessageTest() throws PulsarClientException {
         when(mockClientService.getMockConsumer().receive(0, TimeUnit.SECONDS)).thenReturn(mockMessage).thenReturn(null);
-        when(mockMessage.getData()).thenReturn("".getBytes());
+        when(mockMessage.getValue()).thenReturn("".getBytes());
         mockClientService.setMockMessage(mockMessage);
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
@@ -108,7 +109,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
      */
     @Test
     public void onStoppedTest() throws PulsarClientException {
-        when(mockMessage.getData()).thenReturn("Mocked Message".getBytes());
+        when(mockMessage.getValue()).thenReturn("Mocked Message".getBytes());
         mockClientService.setMockMessage(mockMessage);
 
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
@@ -122,5 +123,10 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
 
         // Verify that the consumer was closed
         verify(mockClientService.getMockConsumer(), times(1)).close();
+    }
+
+    @Test
+    public void mappedAttributesTest() throws PulsarClientException {
+        super.doMappedAttributesTest();
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
@@ -16,8 +16,10 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub.sync;
 
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
 import org.apache.nifi.processors.pulsar.pubsub.TestConsumePulsarRecord;
+import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.Test;
@@ -140,5 +142,10 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
         String flowFileContents = new String(runner.getContentAsByteArray(results.get(0)));
         assertEquals(expected.toString(), flowFileContents);
+    }
+
+    @Test
+    public void mappedAttributesTest() throws PulsarClientException {
+        super.doMappedAttributesTest();
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncPublishPulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncPublishPulsar.java
@@ -37,12 +37,7 @@ public class TestSyncPublishPulsar extends TestPublishPulsar {
 
     @Test
     public void pulsarClientExceptionTest() throws PulsarClientException, UnsupportedEncodingException {
-       when(mockClientService.getMockProducer().send(Matchers.argThat(new ArgumentMatcher<byte[]>() {
-          @Override
-          public boolean matches(byte[] argument) {
-              return true;
-          }
-       }))).thenThrow(PulsarClientException.class);
+       when(mockClientService.getMockTypedMessageBuilder().send()).thenThrow(PulsarClientException.class);
 
        mockClientService.setMockProducer(mockProducer);
 
@@ -107,7 +102,8 @@ public class TestSyncPublishPulsar extends TestPublishPulsar {
        verify(mockClientService.getMockProducerBuilder(), times(1)).topic("my-topic");
 
        // Verify that the send method on the producer was called with the expected content
-       verify(mockClientService.getMockProducer(), times(1)).send(content.getBytes());
+       verify(mockClientService.getMockTypedMessageBuilder(), times(1)).value(content.getBytes());
+       verify(mockClientService.getMockTypedMessageBuilder(), times(1)).send();
     }
 
     @Test
@@ -122,7 +118,8 @@ public class TestSyncPublishPulsar extends TestPublishPulsar {
             runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS);
         }
         // Verify that the send method on the producer was called with the expected content
-        verify(mockClientService.getMockProducer(), times(20)).send(content.getBytes());
+        verify(mockClientService.getMockTypedMessageBuilder(), times(20)).value(content.getBytes());
+        verify(mockClientService.getMockTypedMessageBuilder(), times(20)).send();
     }
 
     @Test
@@ -143,6 +140,21 @@ public class TestSyncPublishPulsar extends TestPublishPulsar {
         runner.enqueue(sb.toString().getBytes("UTF-8"));
         runner.run();
         runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS);
-        verify(mockClientService.getMockProducer(), times(20)).send(content.getBytes());
+        verify(mockClientService.getMockTypedMessageBuilder(), times(20)).value(content.getBytes());
+        verify(mockClientService.getMockTypedMessageBuilder(), times(20)).send();
+    }
+
+    @Test
+    public void mappedPropertiesTest() throws UnsupportedEncodingException, PulsarClientException {
+        super.doMappedPropertiesTest();
+
+        verify(mockClientService.getMockTypedMessageBuilder()).send();
+    }
+
+    @Test
+    public void messageKeyTest() throws UnsupportedEncodingException, PulsarClientException {
+        super.doMessageKeyTest();
+
+        verify(mockClientService.getMockTypedMessageBuilder(), times(2)).send();
     }
 }


### PR DESCRIPTION
# Adds the ability to map Flow File attributes from Pulsar message properties for Consuming processors
   - see MAPPED_FLOWFILE_ATTRIBUTES property description for details
   - consecutive messages with different values for the same mapped properties will be separated into two different flowfiles.
   - can map the value of the Pulsar message key using this mechanism via the special notation ```__KEY__```

# Adds the ability to map Pulsar message properties and key from Flow File attributes for Publishing processors
   - see MAPPED_MESSAGE_PROPERTIES and MESSAGE_KEY property descriptions for details
