### PR TITLE
Support for KeyShared subscriptions and fixes acknowledgement handling for shared subscriptions

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -61,6 +61,8 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
     protected static final String PULSAR_MESSAGE_KEY = "__KEY__";
 
     protected static final AllowableValue EXCLUSIVE = new AllowableValue("Exclusive", "Exclusive", "There can be only 1 consumer on the same topic with the same subscription name");
+    protected static final AllowableValue KEY_SHARED = new AllowableValue("Key_Shared", "Key_Shared", "Multiple consumers will be able to use the same subscription name and messages "
+    		+ "but only 1 consumer will receive the messages for a given message key.");
     protected static final AllowableValue SHARED = new AllowableValue("Shared", "Shared", "Multiple consumer will be able to use the same subscription name and the messages");
     protected static final AllowableValue FAILOVER = new AllowableValue("Failover", "Failover", "Multiple consumer will be able to use the same subscription name but only 1 consumer "
             + "will receive the messages. If that consumer disconnects, one of the other connected consumers will start receiving messages.");
@@ -192,7 +194,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .displayName("Subscription Type")
             .description("Select the subscription type to be used when subscribing to the topic.")
             .required(true)
-            .allowableValues(EXCLUSIVE, SHARED, FAILOVER)
+            .allowableValues(EXCLUSIVE, SHARED, KEY_SHARED, FAILOVER)
             .defaultValue(SHARED.getValue())
             .build();
 
@@ -486,5 +488,11 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         String mappings = context.getProperty(MAPPED_FLOWFILE_ATTRIBUTES).getValue();
 
         return PropertyMappingUtils.getMappedValues(mappings, (p) -> PULSAR_MESSAGE_KEY.equals(p) ? message.getKey() : message.getProperty(p));
+    }
+    
+    protected boolean isSharedSubscription(ProcessContext context) {
+    	final String subscriptionType = context.getProperty(SUBSCRIPTION_TYPE).getValue();
+    	
+    	return subscriptionType.equalsIgnoreCase(SHARED.getValue()) || subscriptionType.equalsIgnoreCase(KEY_SHARED.getValue());
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarProcessorTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarProcessorTest.java
@@ -27,6 +27,10 @@ public abstract class AbstractPulsarProcessorTest<T> {
 
     protected MockPulsarClientService<T> mockClientService;
 
+    protected boolean isSharedSubType(String subType) {
+    	return subType.equalsIgnoreCase("Shared") || subType.equalsIgnoreCase("Key_Shared");
+    }
+    
     protected void addPulsarClientService() throws InitializationException {
         mockClientService = new MockPulsarClientService<T>();
         runner.addControllerService("Pulsar Client Service", mockClientService);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
@@ -38,6 +38,8 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         runner.setProperty(ConsumePulsar.TOPICS, "foo");
         runner.setProperty(ConsumePulsar.SUBSCRIPTION_NAME, "bar");
         runner.setProperty(ConsumePulsar.ASYNC_ENABLED, Boolean.toString(true));
+        runner.setProperty(ConsumePulsar.SUBSCRIPTION_TYPE, "Exclusive");
+        
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
@@ -45,7 +47,7 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), times(0)).acknowledge(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(0)).acknowledgeCumulativeAsync(mockMessage);
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -40,12 +40,13 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
         runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
         runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
         runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
         runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
     }
 
     @Test
@@ -55,12 +56,13 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
        runner.run();
        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-       verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+       verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
     }
 
     /*
@@ -114,6 +116,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(false));
        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
        runner.run(1, true);
 
@@ -129,6 +132,15 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
      */
     @Test
     public void multipleMultiRecordsTest() throws PulsarClientException {
+    	doMultipleMultiRecordsTest("Exclusive");
+    }
+    
+    @Test
+    public void multipleMultiRecordsSharedSubTest() throws PulsarClientException {
+    	doMultipleMultiRecordsTest("Shared");
+    }
+    
+    private void doMultipleMultiRecordsTest(String subType) throws PulsarClientException {
        StringBuffer input = new StringBuffer(1024);
        StringBuffer expected = new StringBuffer(1024);
 
@@ -137,7 +149,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
           expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
        }
 
-       List<MockFlowFile> results = this.sendMessages(input.toString(), false, 50, 100);
+       List<MockFlowFile> results = this.sendMessages(input.toString(), false, 50, 100, subType);
        assertEquals(50, results.size());
 
        String flowFileContents = new String(runner.getContentAsByteArray(results.get(0)));


### PR DESCRIPTION
Adds "Key_Shared" as an available subscription type to ConsumePulsar and ConsumePulsarRecord.

Also fixes some issues with the use of acknowledgeCumulative* regardless of subscription type, and use of acknowledge*Async when the async flag is enabled.

