### PR TITLE
Allow empty demarcator; insert demarcators only between messages

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -202,12 +202,12 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .name("MESSAGE_DEMARCATOR")
             .displayName("Message Demarcator")
             .required(true)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(Validator.VALID)
             .defaultValue("\n")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .description("Specifies the string (interpreted as UTF-8) to use for demarcating multiple messages consumed from Pulsar within "
                 + "a single FlowFile. If not specified, the content of the FlowFile will consist of all of the messages consumed from Pulsar "
-                + "concatenated together. If specified, the contents of the individual Pulsar messages will be separate by this delimiter. "
+                + "concatenated together. If specified, the contents of the individual Pulsar messages will be separated by this delimiter. "
                 + "To enter special character such as 'new line' use CTRL+Enter or Shift+Enter, depending on your OS.")
             .build();
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -151,8 +151,12 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         }
                         
                         try {
+                        	//only write demarcators between messages
+                        	if (msgCount.get() > 0) {
+                        		out.write(demarcatorBytes);
+                        	}
+                        	
                             out.write(msg.getValue());
-                            out.write(demarcatorBytes);
                             msgCount.getAndIncrement();
                         } catch (final IOException ioEx) {
                             session.rollback();
@@ -251,8 +255,13 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     if (msgValue == null || msgValue.length < 1) {
                         continue;
                     }
+                    
+                    // only write demarcators between messages
+                    if (msgCount.get() > 0) {
+                    	out.write(demarcatorBytes);
+                    }
+                    
                     out.write(msgValue);
-                    out.write(demarcatorBytes);
                     msgCount.getAndIncrement();
                 } catch (final IOException ioEx) {
                     getLogger().error("Unable to create flow file ", ioEx);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -163,11 +163,15 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         flowFiles.get(0).assertAttributeEquals(ConsumePulsar.MSG_COUNT, batchSize + "");
 
         StringBuffer sb = new StringBuffer();
-        for (int idx = 0; idx < batchSize; idx++) {
+        
+        // expect demarcators to occur between messages
+        for (int idx = 0; idx < batchSize - 1; idx++) {
             sb.append(msg);
-            sb.append("\n");
+            sb.append('\n');
         }
 
+        sb.append(msg);
+        
         flowFiles.get(0).assertContentEquals(sb.toString());
 
         boolean shared = isSharedSubType(subType);
@@ -212,7 +216,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         assertEquals(iterations, flowFiles.size());
 
         for (MockFlowFile ff : flowFiles) {
-            ff.assertContentEquals(msg + ConsumePulsar.MESSAGE_DEMARCATOR.getDefaultValue());
+            ff.assertContentEquals(msg);        
         }
 
         verify(mockClientService.getMockConsumer(), times(iterations * 2)).receive(0, TimeUnit.SECONDS);
@@ -258,12 +262,12 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         // first flow file should have A, second should have B
         flowFiles.get(0).assertAttributeNotExists("prop");
         flowFiles.get(0).assertAttributeNotExists("key");
-        flowFiles.get(0).assertContentEquals("A===B===");
+        flowFiles.get(0).assertContentEquals("A===B");
         flowFiles.get(1).assertAttributeEquals("prop", "val");
         flowFiles.get(1).assertAttributeNotExists("key");
-        flowFiles.get(1).assertContentEquals("C===");
+        flowFiles.get(1).assertContentEquals("C");
         flowFiles.get(2).assertAttributeEquals("prop", "val");
         flowFiles.get(2).assertAttributeEquals("key", "K");
-        flowFiles.get(2).assertContentEquals("D===");
+        flowFiles.get(2).assertContentEquals("D");
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -140,6 +140,11 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
     	doMultipleMultiRecordsTest("Shared");
     }
     
+    @Test
+    public void parseFailuresTest() throws Exception {
+    	doFailedParseHandlingTest("message", "topic", "sub", true);
+    }
+    
     private void doMultipleMultiRecordsTest(String subType) throws PulsarClientException {
        StringBuffer input = new StringBuffer(1024);
        StringBuffer expected = new StringBuffer(1024);
@@ -158,7 +163,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
     @Test
     public void mappedAttributesTest() throws PulsarClientException {
-        runner.setProperty(ConsumePulsar.ASYNC_ENABLED, Boolean.toString(true));
+        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
 
         super.doMappedAttributesTest();
     }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockRecordParser.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockRecordParser.java
@@ -45,7 +45,7 @@ public class MockRecordParser extends AbstractControllerService implements Recor
     private final int failAfterN;
 
     public MockRecordParser() {
-        this(-1);
+        this(Integer.MAX_VALUE);
     }
 
     public MockRecordParser(final int failAfterN) {
@@ -74,7 +74,7 @@ public class MockRecordParser extends AbstractControllerService implements Recor
 
             @Override
             public Record nextRecord(boolean coerceTypes, boolean dropUnknown) throws IOException, MalformedRecordException, SchemaValidationException {
-                if (failAfterN >= recordCount) {
+                if (failAfterN <= recordCount) {
                     throw new MalformedRecordException("Intentional Unit Test Exception because " + recordCount + " records have been read");
                 }
                 final String line = reader.readLine();

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
@@ -138,6 +138,11 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
     	doMultipleMultiRecordsTest("Shared");
     }
     
+    @Test
+    public void parseFailuresTest() throws Exception {
+    	doFailedParseHandlingTest("message", "topic", "sub", false);
+    }
+    
     private void doMultipleMultiRecordsTest(String subType) throws PulsarClientException {
         StringBuffer input = new StringBuffer(1024);
         StringBuffer expected = new StringBuffer(1024);


### PR DESCRIPTION
Alters demarcator support in ConsumePulsar and ConsumePulsarRecord as follows:

- An empty demarcator value is now valid (property validation previously required a non-empty value).
- Demarcators will now be inserted only between two consecutive messages in the same batch. Previously, a demarcator was always appended to each batched message regardless of whether another message followed it, which resulted in each batch having a dangling demarcator.