### PR TITLE
Fixed jackson-core artifact version

### DIFF
--- a/nifi-pulsar-client-service-api/pom.xml
+++ b/nifi-pulsar-client-service-api/pom.xml
@@ -26,25 +26,36 @@
     <packaging>jar</packaging>
 
     <dependencies>
+    
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client-original</artifactId>
             <version>${pulsar.version}</version>
 		</dependency>
+		
         <dependency>
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client-auth-athenz</artifactId>
             <version>${pulsar.version}</version>
         </dependency>
+        
+        <dependency>
+        	<groupId>com.fasterxml.jackson.core</groupId>
+  		    <artifactId>jackson-core</artifactId>
+  		    <version>${jackson-core.version}</version>
+        </dependency>
+        
         <dependency>
         	<groupId>org.apache.commons</groupId>
         	<artifactId>commons-collections4</artifactId>
-        	<version>4.2</version>
+        	<version>${commons-collections4.version}</version>
         </dependency>
+        
     </dependencies>
 </project>

--- a/nifi-pulsar-processors/pom.xml
+++ b/nifi-pulsar-processors/pom.xml
@@ -80,19 +80,19 @@
         <dependency>
         	<groupId>org.apache.commons</groupId>
         	<artifactId>commons-lang3</artifactId>
-        	<version>3.8.1</version>
+        	<version>${commons-lang3.version}</version>
         </dependency>
         
         <dependency>
            <groupId>org.apache.directory.studio</groupId>
            <artifactId>org.apache.commons.io</artifactId>
-           <version>2.4</version>
+           <version>${commons.io.version}</version>
         </dependency>
         
         <dependency>
         	<groupId>com.fasterxml.jackson.core</groupId>
-  			<artifactId>jackson-core</artifactId>
-  			<version>2.12.2</version>
+  		    <artifactId>jackson-core</artifactId>
+  		    <version>${jackson-core.version}</version>
         </dependency>
         
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,13 @@
     </parent>
     
     <properties>
+    	<commons-collections4.version>4.2</commons-collections4.version>
+    	<commons-lang3.version>3.8.1</commons-lang3.version>
+    	<commons.io.version>2.4</commons.io.version>
+    	<jackson-core.version>2.12.3</jackson-core.version>
     	<pulsar.version>2.8.0</pulsar.version>
     	<nifi.version>1.11.3</nifi.version>
-    	<jdk.release>8</jdk.release>
+    	<jdk.release>11</jdk.release>
     </properties>
 
     <artifactId>nifi-pulsar-bundle</artifactId>


### PR DESCRIPTION
Updated to 2.12.3, removed "backdoor" version from pulsar-commons dependency