### PR TITLE
Bugfix/message loop consumer receive

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -384,10 +384,11 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                 Message<GenericRecord> msg = null;
                 AtomicInteger msgCount = new AtomicInteger(0);
 
-                while (((msg = consumer.receive(0, TimeUnit.SECONDS)) != null) && msgCount.get() < maxMessages) {
+                while (msgCount.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
                     messages.add(msg);
                     msgCount.incrementAndGet();
                 }
+
                 return messages;
             });
         } catch (final RejectedExecutionException ex) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -146,7 +146,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         	getAckService().submit(new Callable<Object>() {
                         		@Override
                         		public Object call() throws Exception {
-                        			return consumer.acknowledgeAsync(msg);
+                        			return consumer.acknowledgeAsync(msg).get();
                         		}
                         	});
                         }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -214,7 +214,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             Map<String, String> lastAttributes = null;
             Map<String, String> currentAttributes = null;
 
-            while (((msg = consumer.receive(0, TimeUnit.SECONDS)) != null) && loopCounter.get() < maxMessages) {
+            while (loopCounter.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
 
                 if (lastMsg != null && !lastAttributes.equals(currentAttributes)) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -193,10 +193,11 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         Message<GenericRecord> msg = null;
         AtomicInteger msgCount = new AtomicInteger(0);
 
-        while (((msg = consumer.receive(0, TimeUnit.SECONDS)) != null) && msgCount.get() < maxMessages) {
+        while (msgCount.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
            messages.add(msg);
            msgCount.incrementAndGet();
         }
+
         return messages;
     }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -342,7 +342,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     		getAckService().submit(new Callable<Object>() {
     			@Override
     			public Object call() throws Exception {
-    				return consumer.acknowledgeAsync(msg);
+    				return consumer.acknowledgeAsync(msg).get();
     			}
     		});
     	}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -149,7 +149,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         boolean shared = isSharedSubType(subType);
         
         // Verify that every message was acknowledged
-        verify(mockClientService.getMockConsumer(), times(batchSize + 1)).receive(0, TimeUnit.SECONDS);
+        verify(mockClientService.getMockConsumer(), times(batchSize)).receive(0, TimeUnit.SECONDS);
         
         if (shared) {
         	if (async) {
@@ -191,7 +191,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
             ff.assertContentEquals(msg);        
         }
 
-        verify(mockClientService.getMockConsumer(), times(iterations * 2)).receive(0, TimeUnit.SECONDS);
+        verify(mockClientService.getMockConsumer(), times(iterations)).receive(0, TimeUnit.SECONDS);
 
         boolean shared = isSharedSubType(subType);
         

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -164,7 +164,7 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
         assertEquals(iterations, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), times(iterations * (batchSize+1))).receive(0, TimeUnit.SECONDS);
+        verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).receive(0, TimeUnit.SECONDS);
 
         boolean shared = isSharedSubType(subType);
         


### PR DESCRIPTION
Includes two bug fixes, one major and one minor:
- In loop conditions of the message receive loops in ConsumePulsar, ConsumePulsarRecord, and AbstractPulsarConsumerProcessor, moved the consumer.receive() call to occur AFTER the comparison of the current batch size against the maximum batch size. The previous approach (consumer.receive() BEFORE the batch size check) was causing an extra message to be received and go unhandled whenever messages were still available and the batch size limit was reached. This resulted in unnecessary message timeouts/redeliveries, and became especially problematic when the individual message was part of a large internal batch, which tended to happen in high volume or "bursty" dataflows.
- Tweaked the acknowledgeAsync() executor service task in ConsumePulsar and ConsumePulsarRecord to make a call to Future.get() for consistency with the acknowledgeCumulativeAsync() executor service tasks. 