### PR TITLE
Add gpg plugins to satisfy sonatype uploading rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,27 @@
 	    <autoReleaseAfterClose>true</autoReleaseAfterClose>
 	  </configuration>
 	</plugin>
-      
+	      
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <!-- Prevent `gpg` from using pinentry programs -->
+            <gpgArguments>
+              <arg>--pinentry-mode</arg>
+              <arg>loopback</arg>
+            </gpgArguments>
+          </configuration>
+        </plugin>
+	      
       </plugins>
     </build>
     


### PR DESCRIPTION
# Motivation
If we forget to add the gpg plugin, nexus-staging-maven-plugin will complain that:
```
... ...
* Missing Signature: '/io/streamnative/connectors/nifi-pulsar-nar/1.14.0-rc-3/nifi-pulsar-nar-1.14.0-rc-3.pom.asc' does not exist for 'nifi-pulsar-nar-1.14.0-rc-3.pom'.
... ...
```