### PR TITLE
Changed default value of MAX_ASYNC_REQUESTS from 50 to 2

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -156,7 +156,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "Each asynchronous call requires memory, so avoid setting this value to high.")
             .required(false)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .defaultValue("50")
+            .defaultValue("2")
             .build();
 
     public static final PropertyDescriptor ACK_TIMEOUT = new PropertyDescriptor.Builder()

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -114,7 +114,7 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
                     + "Each asynchronous call requires memory, so avoid setting this value to high.")
             .required(false)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .defaultValue("50")
+            .defaultValue("2")
             .build();
 
     public static final PropertyDescriptor BATCHING_ENABLED = new PropertyDescriptor.Builder()

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <mockito-core.version>3.12.4</mockito-core.version>
         <nifi.version>1.20.0</nifi.version>
         <protobuf3.version>3.20.1</protobuf3.version>
-        <pulsar.version>2.10.3</pulsar.version>
+        <pulsar.version>2.11.0</pulsar.version>
         <slf4j-simple.version>2.0.6</slf4j-simple.version>
 
         <java.version>11</java.version>


### PR DESCRIPTION
To reduce memory usage in both the producer and consumer processors, I reduced the default value of the MAX_ASYNC_REQUESTS property from 50 to 2.