### PR TITLE
avro.schema added to the flow file so AvroReader can read the autoconsumed reader schema

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -277,6 +277,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                if (lastMessage == null) {
                    flowFile = session.create();
                    flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                   if (msg.getReaderSchema().isPresent()) {
+                       String msgSchema = new String(msg.getReaderSchema().get().getSchemaInfo().getSchema());
+                       flowFile = session.putAttribute(flowFile, "avro.schema", msgSchema);
+                   }
                    schema = getSchema(flowFile, readerFactory, data);
                    rawOut = session.write(flowFile);
                    writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);


### PR DESCRIPTION
Since there is no external schema registry available, when reading an AvroRecord using an AvroReader controller in NiFi, the only option is to employ the Explicit schema strategy, wherein you must specify the schema in a text field. However, this approach is not suitable for scenarios involving multiple topics, as it restricts you to using only one schema and cannot handle input from topics with varying schema types.

To address this limitation, we can enhance the process by adding an additional attribute called avro.schema to the flow file. Since Pulsar consumption is already utilizing the AUTO_CONSUME() function, the reader schema is automatically populated on the Message<GenericRecord>. By introducing this attribute, we can opt for the 'Schema Text Property' strategy in the AvroReader, which conveniently has ${avro.schema} configured as a default property on the reader.
[https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-record-serialization-services-nar/1.23.2/org.apache.nifi.avro.AvroReader/index.html](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-record-serialization-services-nar/1.23.2/org.apache.nifi.avro.AvroReader/index.html)

This enhancement allows us to rely on the AUTO_CONSUMED schemas instead of manually specifying schemas. We can effortlessly extract these schemas from the flow file and pass them along to AVROSetWriter or ParquetWriter for further processing, eliminating the need for intricate schema management.

attn: @z-kovacs 