### PR TITLE
MultiTopic consumption with AUTO_CONSUME schema

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -21,14 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -55,14 +48,10 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
-import org.apache.nifi.serialization.MalformedRecordException;
-import org.apache.nifi.serialization.RecordReader;
-import org.apache.nifi.serialization.RecordReaderFactory;
-import org.apache.nifi.serialization.RecordSetWriter;
-import org.apache.nifi.serialization.RecordSetWriterFactory;
-import org.apache.nifi.serialization.WriteResult;
+import org.apache.nifi.serialization.*;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.SchemaIdentifier;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -226,6 +215,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
           return;
        }
 
+       messages.sort(Comparator.comparing(Message::getTopicName));
+
        final BlockingQueue<Message<GenericRecord>> parseFailures = 
     	  new LinkedBlockingQueue<Message<GenericRecord>>();
        
@@ -244,7 +235,9 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
        try {
            for (Message<GenericRecord> msg : messages) {
                currentAttributes = getMappedFlowFileAttributes(context, msg);
-               
+               // Introduce an attribute to distinguish between current and previously captured attributes,
+               // particularly when the message originates from a different topic.
+               currentAttributes.put("topicName", msg.getTopicName());
                // if the current message's mapped attribute values differ from the previous set's,
                // write out the active record set and clear various references so that we'll start a new one
                if (lastAttributes != null && !lastAttributes.equals(currentAttributes)) {
@@ -280,8 +273,14 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                    if (msg.getReaderSchema().isPresent()) {
                        String msgSchema = new String(msg.getReaderSchema().get().getSchemaInfo().getSchema());
                        flowFile = session.putAttribute(flowFile, "avro.schema", msgSchema);
+                       schema = new SimpleRecordSchema(
+                               new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()),
+                               "avro",
+                               SchemaIdentifier.EMPTY
+                       );
+                   }else {
+                       schema = getSchema(flowFile, readerFactory, data);
                    }
-                   schema = getSchema(flowFile, readerFactory, data);
                    rawOut = session.write(flowFile);
                    writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -277,6 +277,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                if (lastMessage == null) {
                    flowFile = session.create();
                    flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                   if (msg.getReaderSchema().isPresent()) {
+                       String msgSchema = new String(msg.getReaderSchema().get().getSchemaInfo().getSchema());
+                       flowFile = session.putAttribute(flowFile, "avro.schema", msgSchema);
+                   }
                    schema = getSchema(flowFile, readerFactory, data);
                    rawOut = session.write(flowFile);
                    writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -115,7 +115,9 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
     	}
     	
     	when(mockMessage.getData()).thenReturn(msg.getBytes());
-    	mockClientService.setMockMessage(mockMessage);
+        when(mockMessage.getTopicName()).thenReturn("foo");
+
+        mockClientService.setMockMessage(mockMessage);
     	
     	runner.run();
     	runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
@@ -144,6 +146,7 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
     
     protected List<MockFlowFile> sendMessages(String msg, String topic, String sub, boolean async, int iterations, int batchSize, String subType) throws PulsarClientException {
         when(mockMessage.getData()).thenReturn(msg.getBytes());
+        when(mockMessage.getTopicName()).thenReturn(topic);
         mockClientService.setMockMessage(mockMessage);
 
         runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(async));
@@ -201,6 +204,8 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
           .thenReturn(null)
           .thenReturn(null)
           .thenReturn("K");
+
+        when(mockMessage.getTopicName()).thenReturn("foo");
         
         mockClientService.setMockMessage(mockMessage);
 


### PR DESCRIPTION

Since there is no external schema registry available, when reading an AvroRecord using an AvroReader controller in NiFi, the only option is to employ the Explicit schema strategy, wherein you must specify the schema in a text field. However, this approach is not suitable for scenarios involving multiple topics, as it restricts you to using only one schema and cannot handle input from topics with varying schema types.

To address this limitation, we can enhance the process by adding an additional attribute called avro.schema to the flow file. Since Pulsar consumption is already utilizing the AUTO_CONSUME() function, the reader schema is automatically populated on the Message. By introducing this attribute, we can opt for the 'Schema Text Property' strategy in the AvroReader, which conveniently has ${avro.schema} configured as a default property on the reader.
https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-record-serialization-services-nar/1.23.2/org.apache.nifi.avro.AvroReader/index.html

This enhancement allows us to rely on the AUTO_CONSUMED schemas instead of manually specifying schemas. We can effortlessly extract these schemas from the flow file and pass them along to AVROSetWriter or ParquetWriter for further processing, eliminating the need for intricate schema management.


Furthermore, when the ConsumePulsarRecord function processes a batch of messages, it does so without any specific order. This unsorted processing can result in the generation of a large number of flow files each time messages are intermingled. On the other hand, sorting the batch leads to a significantly improved distribution of messages within the AvroSet.