### PR TITLE
Test Improvements, avro.schema attribute made conditional if readerSchema is AVRO type and new flow file on schema udpdates

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
@@ -56,6 +57,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaType;
 
 @CapabilityDescription("Consumes messages from Apache Pulsar. "
         + "The complementary NiFi processor for sending messages is PublishPulsarRecord. Please note that, at this time, "
@@ -67,7 +69,7 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
         + "FlowFile. No two Pulsar messages will be placed into the same FlowFile if they have different schemas.")
 @Tags({"Pulsar", "Get", "Record", "csv", "avro", "json", "Ingest", "Ingress", "Topic", "PubSub", "Consume"})
 @WritesAttributes({
-    @WritesAttribute(attribute = "record.count", description = "The number of records received")
+        @WritesAttribute(attribute = "record.count", description = "The number of records received")
 })
 @InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
 @SeeAlso({PublishPulsar.class, ConsumePulsar.class, PublishPulsarRecord.class})
@@ -146,7 +148,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 .evaluateAttributeExpressions().asInteger() : Integer.MAX_VALUE;
 
         final byte[] demarcator = context.getProperty(MESSAGE_DEMARCATOR).isSet() ? context.getProperty(MESSAGE_DEMARCATOR)
-            .evaluateAttributeExpressions().getValue().getBytes() : RECORD_SEPARATOR.getBytes();
+                .evaluateAttributeExpressions().getValue().getBytes() : RECORD_SEPARATOR.getBytes();
 
         try {
             Consumer<GenericRecord> consumer = getConsumer(context, getConsumerId(context, session.get()));
@@ -157,10 +159,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             }
 
             if (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean()) {
-               consumeAsync(consumer, context, session);
-               handleAsync(context, session, consumer, readerFactory, writerFactory, demarcator);
+                consumeAsync(consumer, context, session);
+                handleAsync(context, session, consumer, readerFactory, writerFactory, demarcator);
             } else {
-               consumeMessages(context, session, consumer, getMessages(consumer, maxMessages), readerFactory, writerFactory, demarcator, false);
+                consumeMessages(context, session, consumer, getMessages(consumer, maxMessages), readerFactory, writerFactory, demarcator, false);
             }
         } catch (PulsarClientException e) {
             getLogger().error("Unable to consume from Pulsar Topic ", e);
@@ -172,7 +174,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     /**
      * Retrieve a batch of up to maxMessages for processing.
      *
-     * @param consumer - The Pulsar consumer.
+     * @param consumer    - The Pulsar consumer.
      * @param maxMessages - The maximum number of messages to consume from Pulsar.
      * @return A List of Messages
      * @throws PulsarClientException in the event we cannot communicate with the Pulsar broker.
@@ -183,8 +185,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         AtomicInteger msgCount = new AtomicInteger(0);
 
         while (msgCount.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
-           messages.add(msg);
-           msgCount.incrementAndGet();
+            messages.add(msg);
+            msgCount.incrementAndGet();
         }
 
         return messages;
@@ -195,240 +197,237 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
      * All of the messages passed in shall be routed to either SUCCESS or PARSE_FAILURE, allowing us to acknowledge
      * the receipt of the messages to Pulsar, so they are not re-sent.
      *
-     * @param context - The current ProcessContext
-     * @param session - The current ProcessSession.
-     * @param consumer - The Pulsar consumer.
-     * @param messages - A list of messages.
+     * @param context       - The current ProcessContext
+     * @param session       - The current ProcessSession.
+     * @param consumer      - The Pulsar consumer.
+     * @param messages      - A list of messages.
      * @param readerFactory - The factory used to read the messages.
      * @param writerFactory - The factory used to write the messages.
-     * @param demarcator - The value used to identify unique records in the list
-     * @param async - Whether or not to consume the messages asynchronously.
-     *  
+     * @param demarcator    - The value used to identify unique records in the list
+     * @param async         - Whether or not to consume the messages asynchronously.
      * @throws PulsarClientException if there is an issue communicating with Apache Pulsar.
      */
-    private void consumeMessages(ProcessContext context, ProcessSession session, 
-       final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,
-       final RecordReaderFactory readerFactory, RecordSetWriterFactory writerFactory, 
-       final byte[] demarcator, final boolean async) throws PulsarClientException {
+    private void consumeMessages(ProcessContext context, ProcessSession session,
+                                 final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,
+                                 final RecordReaderFactory readerFactory, RecordSetWriterFactory writerFactory,
+                                 final byte[] demarcator, final boolean async) throws PulsarClientException {
 
-       if (CollectionUtils.isEmpty(messages)) {
-          return;
-       }
+        if (CollectionUtils.isEmpty(messages)) {
+            return;
+        }
 
-       messages.sort(Comparator.comparing(Message::getTopicName));
+        final List<Message<GenericRecord>> groupedMessages = messages
+                .stream()
+                .collect(Collectors.groupingBy(Message::getTopicName))
+                .values()
+                .stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
 
-       final BlockingQueue<Message<GenericRecord>> parseFailures = 
-    	  new LinkedBlockingQueue<Message<GenericRecord>>();
-       
-       RecordSchema schema = null;
-       FlowFile flowFile = null;
-       OutputStream rawOut = null;
-       RecordSetWriter writer = null;
+        final BlockingQueue<Message<GenericRecord>> parseFailures =
+                new LinkedBlockingQueue<Message<GenericRecord>>();
 
-       Map<String, String> lastAttributes = null;
-       Message<GenericRecord> lastMessage = null;
-       Map<String, String> currentAttributes = null;
+        RecordSchema schema = null;
+        FlowFile flowFile = null;
+        OutputStream rawOut = null;
+        RecordSetWriter writer = null;
 
-       // Cumulative acks are NOT permitted on Shared subscriptions
-       final boolean shared = isSharedSubscription(context);
-       
-       try {
-           for (Message<GenericRecord> msg : messages) {
-               currentAttributes = getMappedFlowFileAttributes(context, msg);
-               // Introduce an attribute to distinguish between current and previously captured attributes,
-               // particularly when the message originates from a different topic.
-               currentAttributes.put("topicName", msg.getTopicName());
-               // if the current message's mapped attribute values differ from the previous set's,
-               // write out the active record set and clear various references so that we'll start a new one
-               if (lastAttributes != null && !lastAttributes.equals(currentAttributes)) {
-                   WriteResult result = writer.finishRecordSet();
-                   IOUtils.closeQuietly(writer);
-                   IOUtils.closeQuietly(rawOut);
+        Map<String, String> lastAttributes = null;
+        Message<GenericRecord> lastMessage = null;
+        Map<String, String> currentAttributes = null;
 
-                   if (result != WriteResult.EMPTY) {
-                       flowFile = session.putAllAttributes(flowFile, result.getAttributes());
-                       flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
-                       session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
-                       session.transfer(flowFile, REL_SUCCESS);
-                   } else {
-                       session.rollback();
-                   }
+        // Cumulative acks are NOT permitted on Shared subscriptions
+        final boolean shared = isSharedSubscription(context);
 
-                   handleFailures(session, parseFailures, demarcator);
-                   parseFailures.clear();
-                   
-                   if (!shared) {
-                	 acknowledgeCumulative(consumer, lastMessage, async);
-                   }
+        try {
+            for (Message<GenericRecord> msg : groupedMessages) {
+                currentAttributes = getMappedFlowFileAttributes(context, msg);
+                // Introduce an attribute to distinguish between current and previously captured attributes,
+                // particularly when the message originates from a different topic.
+                currentAttributes.put("topicName", msg.getTopicName());
+                // add the schema to the attributes in-case the schema is updated on the topic
+                if (msg.getReaderSchema().isPresent() && msg.getReaderSchema().get().getSchemaInfo().getType() == SchemaType.AVRO) {
+                    currentAttributes.put("avro.schema", new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()));
+                }
 
-                   lastAttributes = null;
-                   lastMessage = null;
-               }
+                // if the current message's mapped attribute values differ from the previous set's,
+                // write out the active record set and clear various references so that we'll start a new one
+                if (lastAttributes != null && !lastAttributes.equals(currentAttributes)) {
+                    WriteResult result = writer.finishRecordSet();
+                    IOUtils.closeQuietly(writer);
+                    IOUtils.closeQuietly(rawOut);
 
-               // if there's no record set actively being written, begin one
-               byte[] data = msg.getData();
-               if (lastMessage == null) {
-                   flowFile = session.create();
-                   flowFile = session.putAllAttributes(flowFile, currentAttributes);
-                   if (msg.getReaderSchema().isPresent()) {
-                       String msgSchema = new String(msg.getReaderSchema().get().getSchemaInfo().getSchema());
-                       flowFile = session.putAttribute(flowFile, "avro.schema", msgSchema);
-                       schema = new SimpleRecordSchema(
-                               new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()),
-                               "avro",
-                               SchemaIdentifier.EMPTY
-                       );
-                   }else {
-                       schema = getSchema(flowFile, readerFactory, data);
-                   }
-                   rawOut = session.write(flowFile);
-                   writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);
+                    if (result != WriteResult.EMPTY) {
+                        flowFile = session.putAllAttributes(flowFile, result.getAttributes());
+                        flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
+                        session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
+                        session.transfer(flowFile, REL_SUCCESS);
+                    } else {
+                        session.rollback();
+                    }
 
-                   if (schema == null || writer == null) {
-                       parseFailures.add(msg);
-                       session.remove(flowFile);
-                       IOUtils.closeQuietly(rawOut);
-                       getLogger().error("Unable to create a record writer to consume from the Pulsar topic");
-                       continue;
-                   }
+                    handleFailures(session, parseFailures, demarcator);
+                    parseFailures.clear();
 
-                   writer.beginRecordSet();
-               }
+                    if (!shared) {
+                        acknowledgeCumulative(consumer, lastMessage, async);
+                    }
 
-               lastAttributes = currentAttributes;
-               lastMessage = msg;
+                    lastAttributes = null;
+                    lastMessage = null;
+                }
 
-               if (shared) {
-            	 acknowledge(consumer, msg, async);
-               }
-               
-               // write each of the records in the current message to the active record set. These will each
-               // have the same mapped flowfile attribute values, which means that it's ok that they are all placed
-               // in the same output flowfile.
-               
-               final InputStream in = new ByteArrayInputStream(data);
-               try {
-                   RecordReader r = readerFactory.createRecordReader(flowFile, in, getLogger());
-                   for (Record record = r.nextRecord(); record != null; record = r.nextRecord()) {
-                       writer.write(record);
-                   }
-               } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
-                   parseFailures.add(msg);
-               }
-           }
+                // if there's no record set actively being written, begin one
+                byte[] data = msg.getData();
+                if (lastMessage == null) {
+                    flowFile = session.create();
+                    flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                    schema = getSchema(flowFile, readerFactory, data);
+                    rawOut = session.write(flowFile);
+                    writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);
 
-           WriteResult result = writer.finishRecordSet();
-           IOUtils.closeQuietly(writer);
-           IOUtils.closeQuietly(rawOut);
+                    if (schema == null || writer == null) {
+                        parseFailures.add(msg);
+                        session.remove(flowFile);
+                        IOUtils.closeQuietly(rawOut);
+                        getLogger().error("Unable to create a record writer to consume from the Pulsar topic");
+                        continue;
+                    }
 
-           if (result != WriteResult.EMPTY) {
-               flowFile = session.putAllAttributes(flowFile, result.getAttributes());
-               flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
-               session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
-               session.transfer(flowFile, REL_SUCCESS);
-           } else {
-               // We were able to parse the records, but unable to write them to the FlowFile
-               session.rollback();
-           }
-       } catch (IOException e) {
-           getLogger().error("Unable to consume from Pulsar topic ", e);
-       }
+                    writer.beginRecordSet();
+                }
 
-       handleFailures(session, parseFailures, demarcator);
-       
-       if (!shared) {
-    	  acknowledgeCumulative(consumer, messages.get(messages.size() - 1), async);
-       }
+                lastAttributes = currentAttributes;
+                lastMessage = msg;
+
+                if (shared) {
+                    acknowledge(consumer, msg, async);
+                }
+
+                // write each of the records in the current message to the active record set. These will each
+                // have the same mapped flowfile attribute values, which means that it's ok that they are all placed
+                // in the same output flowfile.
+
+                final InputStream in = new ByteArrayInputStream(data);
+                try {
+                    RecordReader r = readerFactory.createRecordReader(flowFile, in, getLogger());
+                    for (Record record = r.nextRecord(); record != null; record = r.nextRecord()) {
+                        writer.write(record);
+                    }
+                } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
+                    parseFailures.add(msg);
+                }
+            }
+
+            WriteResult result = writer.finishRecordSet();
+            IOUtils.closeQuietly(writer);
+            IOUtils.closeQuietly(rawOut);
+
+            if (result != WriteResult.EMPTY) {
+                flowFile = session.putAllAttributes(flowFile, result.getAttributes());
+                flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
+                session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
+                session.transfer(flowFile, REL_SUCCESS);
+            } else {
+                // We were able to parse the records, but unable to write them to the FlowFile
+                session.rollback();
+            }
+        } catch (IOException e) {
+            getLogger().error("Unable to consume from Pulsar topic ", e);
+        }
+
+        handleFailures(session, parseFailures, demarcator);
+
+        if (!shared) {
+            acknowledgeCumulative(consumer, messages.get(messages.size() - 1), async);
+        }
     }
 
     private void acknowledge(final Consumer<GenericRecord> consumer, final Message<GenericRecord> msg, final boolean async) throws PulsarClientException {
-    	if (async) {
-    		getAckService().submit(new Callable<Object>() {
-    			@Override
-    			public Object call() throws Exception {
-    				return consumer.acknowledgeAsync(msg).get();
-    			}
-    		});
-    	}
-    	else {
-    		consumer.acknowledge(msg);;
-    	}
+        if (async) {
+            getAckService().submit(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return consumer.acknowledgeAsync(msg).get();
+                }
+            });
+        } else {
+            consumer.acknowledge(msg);
+        }
     }
-    
+
     private void acknowledgeCumulative(final Consumer<GenericRecord> consumer, final Message<GenericRecord> msg, final boolean async) throws PulsarClientException {
-    	if (async) {
-    		getAckService().submit(new Callable<Object>() {
-    			@Override
-    			public Object call() throws Exception {
-    				return consumer.acknowledgeCumulativeAsync(msg).get();
-    			}
-    		});
-    	}
-    	else {
-    		consumer.acknowledgeCumulative(msg);
-    	}
+        if (async) {
+            getAckService().submit(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return consumer.acknowledgeCumulativeAsync(msg).get();
+                }
+            });
+        } else {
+            consumer.acknowledgeCumulative(msg);
+        }
     }
-    
-    private void handleFailures(ProcessSession session, 
-    	BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) {
+
+    private void handleFailures(ProcessSession session,
+                                BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) {
 
         if (CollectionUtils.isEmpty(parseFailures)) {
-           return;
+            return;
         }
 
         FlowFile flowFile = session.create();
         OutputStream rawOut = session.write(flowFile);
 
         try {
-           Iterator<Message<GenericRecord>> failureIterator = parseFailures.iterator();
-           
-           for (int idx = 0; failureIterator.hasNext(); idx++) {
-        	  Message<GenericRecord> msg = failureIterator.next();
+            Iterator<Message<GenericRecord>> failureIterator = parseFailures.iterator();
 
-              if (msg != null && msg.getData() != null) {
-            	 if (idx > 0) {
-            		 rawOut.write(demarcator);
-            	 }
-            	 
-                 rawOut.write(msg.getData());
-              }
-           }
-           IOUtils.closeQuietly(rawOut);
-           session.transfer(flowFile, REL_PARSE_FAILURE);
+            for (int idx = 0; failureIterator.hasNext(); idx++) {
+                Message<GenericRecord> msg = failureIterator.next();
+
+                if (msg != null && msg.getData() != null) {
+                    if (idx > 0) {
+                        rawOut.write(demarcator);
+                    }
+
+                    rawOut.write(msg.getData());
+                }
+            }
+            IOUtils.closeQuietly(rawOut);
+            session.transfer(flowFile, REL_PARSE_FAILURE);
         } catch (IOException e) {
-           getLogger().error("Unable to route failures", e);
+            getLogger().error("Unable to route failures", e);
         }
     }
 
     /**
      * Pull messages off of the CompletableFuture's held in the consumerService and process them in a batch.
-     * 
-     * @param context - The current ProcessContext
-     * @param session - The current ProcessSession.
-     * @param consumer - The Pulsar consumer.
+     *
+     * @param context       - The current ProcessContext
+     * @param session       - The current ProcessSession.
+     * @param consumer      - The Pulsar consumer.
      * @param readerFactory - The factory used to read the messages.
      * @param writerFactory - The factory used to write the messages.
-     * @param demarcator - The bytes used to demarcate the individual messages.
-     * 
-     * @throws PulsarClientException if there is an issue connecting to the Pulsar cluster. 
+     * @param demarcator    - The bytes used to demarcate the individual messages.
+     * @throws PulsarClientException if there is an issue connecting to the Pulsar cluster.
      */
     protected void handleAsync(ProcessContext context, ProcessSession session, final Consumer<GenericRecord> consumer,
-         final RecordReaderFactory readerFactory, RecordSetWriterFactory writerFactory, byte[] demarcator) throws PulsarClientException {
+                               final RecordReaderFactory readerFactory, RecordSetWriterFactory writerFactory, byte[] demarcator) throws PulsarClientException {
 
         final Integer queryTimeout = context.getProperty(MAX_WAIT_TIME).evaluateAttributeExpressions().asTimePeriod(TimeUnit.SECONDS).intValue();
 
         try {
-             Future<List<Message<GenericRecord>>> done = null;
-             do {
-                 done = getConsumerService().poll(queryTimeout, TimeUnit.SECONDS);
+            Future<List<Message<GenericRecord>>> done = null;
+            do {
+                done = getConsumerService().poll(queryTimeout, TimeUnit.SECONDS);
 
-                 if (done != null) {
+                if (done != null) {
                     List<Message<GenericRecord>> messages = done.get();
                     if (CollectionUtils.isNotEmpty(messages)) {
-                      consumeMessages(context, session, consumer, messages, readerFactory, writerFactory, demarcator, true);
+                        consumeMessages(context, session, consumer, messages, readerFactory, writerFactory, demarcator, true);
                     }
-                 }
-             } while (done != null);
+                }
+            } while (done != null);
 
         } catch (InterruptedException | ExecutionException e) {
             getLogger().error("Trouble consuming messages ", e);
@@ -443,22 +442,22 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             in = new ByteArrayInputStream(msgValue);
             schema = readerFactory.createRecordReader(flowFile, in, getLogger()).getSchema();
         } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
-           getLogger().error("Unable to determine the schema", e);
-           return null;
+            getLogger().error("Unable to determine the schema", e);
+            return null;
         } finally {
-           IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(in);
         }
 
         return schema;
     }
 
-    private RecordSetWriter getRecordWriter(RecordSetWriterFactory writerFactory, 
-    	RecordSchema srcSchema, OutputStream out, FlowFile flowFile) {
+    private RecordSetWriter getRecordWriter(RecordSetWriterFactory writerFactory,
+                                            RecordSchema srcSchema, OutputStream out, FlowFile flowFile) {
         try {
             RecordSchema writeSchema = writerFactory.getSchema(Collections.emptyMap(), srcSchema);
             return writerFactory.createWriter(getLogger(), writeSchema, out, flowFile);
         } catch (SchemaNotFoundException | IOException e) {
-           return null;
+            return null;
         }
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -48,6 +48,7 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
     protected static String BAD_MSG = "Malformed message";
     protected static String MOCKED_MSG = "Mocked Message, 1";
     protected static String DEFAULT_TOPIC = "foo";
+    protected static String DEFAULT_TOPIC_2 = "bar";
     protected static String DEFAULT_SUB = "bar";
 
     @Mock

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -16,25 +16,35 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub.async;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
 import org.apache.nifi.processors.pulsar.pubsub.TestConsumePulsarRecord;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
     @Test
     public void emptyMessageTest() throws PulsarClientException {
         when(mockMessage.getData()).thenReturn("".getBytes());
+        when(mockMessage.getTopicName()).thenReturn(DEFAULT_TOPIC);
+
         mockClientService.setMockMessage(mockMessage);
 
         runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
@@ -50,18 +60,19 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
 
     @Test
     public void singleMalformedMessageTest() throws PulsarClientException {
-       when(mockMessage.getData()).thenReturn(BAD_MSG.getBytes());
-       mockClientService.setMockMessage(mockMessage);
+        when(mockMessage.getData()).thenReturn(BAD_MSG.getBytes());
+        when(mockMessage.getTopicName()).thenReturn(DEFAULT_TOPIC);
+        mockClientService.setMockMessage(mockMessage);
 
-       runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
-       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
-       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
-       runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
-       runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
-       runner.run();
-       runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
+        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
+        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-       verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
     }
 
     /*
@@ -81,8 +92,8 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         StringBuffer expected = new StringBuffer(1024);
 
         for (int idx = 0; idx < 50; idx++) {
-           input.append("Justin Thyme, " + idx).append("\n");
-           expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
+            input.append("Justin Thyme, " + idx).append("\n");
+            expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
         }
 
         List<MockFlowFile> results = this.sendMessages(input.toString(), false, 1);
@@ -92,35 +103,103 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
     }
 
     /*
+     * Send multiple messages on different topics,
+     * check if it creates two flow files by retaining the order of messages
+     */
+    @Test
+    public void multipleGoodMessagesOnTwoTopicsCreatesMultipleRecordsTest() throws IOException {
+
+        List<Message<GenericRecord>> mockMessages = new ArrayList<>();
+        mockMessages.add(createTestMessage("A,9".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC, "", SchemaType.JSON));
+        mockMessages.add(createTestMessage("Z,10".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC_2, "", SchemaType.JSON));
+        mockMessages.add(createTestMessage("G,1".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC, "", SchemaType.JSON));
+        mockMessages.add(createTestMessage("F,7".getBytes(), "K", singletonMap("prop", "val"), DEFAULT_TOPIC_2, "", SchemaType.JSON));
+
+        mockClientService.setMockMessages(mockMessages);
+
+        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(false));
+        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC + "," + DEFAULT_TOPIC_2);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 4 + "");
+        runner.run(1, true);
+
+        List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+        successFlowFiles.get(0).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
+        successFlowFiles.get(0).assertAttributeNotExists("avro.schema");
+        successFlowFiles.get(1).assertContentEquals("\"A\",\"9\"\n\"G\",\"1\"\n".getBytes());
+        successFlowFiles.get(1).assertAttributeNotExists("avro.schema");
+        assertEquals(2, successFlowFiles.size());
+    }
+
+    /*
+     * Send multiple messages on different topics while updating schema for one topic,
+     * check if it creates two three files by retaining the order of messages
+     */
+    @Test
+    public void multipleGoodMessagesWithSchemaUpdateOnTwoTopicsTest() throws IOException {
+        String schema1 = "{\"type\": \"record\",\"name\": \"ExampleRecord\",\"fields\": [{\"name\": \"field1\", \"type\": \"int\"}]}\r\n";
+        String schema1_updated = "{\"type\": \"record\",\"name\": \"ExampleRecord\",\"fields\": [{\"name\": \"field1\", \"type\": \"int\"},{\"name\": \"field2\", \"type\": [\"null\", \"string\"], \"default\": null}]}\r\n";
+
+        List<Message<GenericRecord>> mockMessages = new ArrayList<>();
+        mockMessages.add(createTestMessage("A,9".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC, schema1, SchemaType.AVRO));
+        mockMessages.add(createTestMessage("Z,10".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC_2, schema1, SchemaType.AVRO));
+        mockMessages.add(createTestMessage("G,1".getBytes(), null, singletonMap("prop", "val"), DEFAULT_TOPIC, schema1_updated, SchemaType.AVRO));
+        mockMessages.add(createTestMessage("F,7".getBytes(), "K", singletonMap("prop", "val"), DEFAULT_TOPIC_2, schema1, SchemaType.AVRO));
+
+        mockClientService.setMockMessages(mockMessages);
+
+        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(false));
+        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC + "," + DEFAULT_TOPIC_2);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 4 + "");
+        runner.run(1, true);
+
+        List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+        successFlowFiles.get(0).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
+        successFlowFiles.get(0).assertAttributeExists("avro.schema");
+        successFlowFiles.get(0).assertAttributeEquals("avro.schema", schema1);
+        successFlowFiles.get(1).assertContentEquals("\"A\",\"9\"\n".getBytes());
+        successFlowFiles.get(1).assertAttributeExists("avro.schema");
+        successFlowFiles.get(1).assertAttributeEquals("avro.schema", schema1);
+        successFlowFiles.get(2).assertContentEquals("\"G\",\"1\"\n".getBytes());
+        successFlowFiles.get(2).assertAttributeExists("avro.schema");
+        successFlowFiles.get(2).assertAttributeEquals("avro.schema", schema1_updated);
+        assertEquals(3, successFlowFiles.size());
+    }
+
+    /*
      * Send a single message with multiple records,
      * some of them good and some malformed
      */
     @Test
     public void singleMessageWithGoodAndBadRecordsTest() throws PulsarClientException {
-       StringBuffer input = new StringBuffer(1024);
-       StringBuffer expected = new StringBuffer(1024);
+        StringBuffer input = new StringBuffer(1024);
+        StringBuffer expected = new StringBuffer(1024);
 
-       for (int idx = 0; idx < 10; idx++) {
-          if (idx % 2 == 0) {
-             input.append("Justin Thyme, " + idx).append("\n");
-             expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
-          } else {
-             input.append(BAD_MSG).append("\n");
-          }
+        for (int idx = 0; idx < 10; idx++) {
+            if (idx % 2 == 0) {
+                input.append("Justin Thyme, " + idx).append("\n");
+                expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
+            } else {
+                input.append(BAD_MSG).append("\n");
+            }
         }
 
-       when(mockMessage.getData()).thenReturn(input.toString().getBytes());
-       mockClientService.setMockMessage(mockMessage);
+        when(mockMessage.getData()).thenReturn(input.toString().getBytes());
+        when(mockMessage.getTopicName()).thenReturn(DEFAULT_TOPIC);
+        mockClientService.setMockMessage(mockMessage);
 
-       runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(false));
-       runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
-       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
-       runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
-       runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
-       runner.run(1, true);
+        runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(false));
+        runner.setProperty(ConsumePulsarRecord.TOPICS, DEFAULT_TOPIC);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_NAME, DEFAULT_SUB);
+        runner.setProperty(ConsumePulsarRecord.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 1 + "");
+        runner.run(1, true);
 
-       List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
-       assertEquals(1, successFlowFiles.size());
+        List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+        assertEquals(1, successFlowFiles.size());
 
         List<MockFlowFile> failureFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_PARSE_FAILURE);
         assertEquals(1, failureFlowFiles.size());
@@ -131,33 +210,33 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
      */
     @Test
     public void multipleMultiRecordsTest() throws PulsarClientException {
-    	doMultipleMultiRecordsTest("Exclusive");
+        doMultipleMultiRecordsTest("Exclusive");
     }
-    
+
     @Test
     public void multipleMultiRecordsSharedSubTest() throws PulsarClientException {
-    	doMultipleMultiRecordsTest("Shared");
+        doMultipleMultiRecordsTest("Shared");
     }
-    
+
     @Test
     public void parseFailuresTest() throws Exception {
-    	doFailedParseHandlingTest("message", "topic", "sub", true);
+        doFailedParseHandlingTest("message", "topic", "sub", true);
     }
-    
+
     private void doMultipleMultiRecordsTest(String subType) throws PulsarClientException {
-       StringBuffer input = new StringBuffer(1024);
-       StringBuffer expected = new StringBuffer(1024);
+        StringBuffer input = new StringBuffer(1024);
+        StringBuffer expected = new StringBuffer(1024);
 
-       for (int idx = 0; idx < 50; idx++) {
-          input.append("Justin Thyme, " + idx).append("\n");
-          expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
-       }
+        for (int idx = 0; idx < 50; idx++) {
+            input.append("Justin Thyme, " + idx).append("\n");
+            expected.append("\"Justin Thyme\",\"" + idx + "\"").append("\n");
+        }
 
-       List<MockFlowFile> results = this.sendMessages(input.toString(), false, 50, 100, subType);
-       assertEquals(50, results.size());
+        List<MockFlowFile> results = this.sendMessages(input.toString(), false, 50, 100, subType);
+        assertEquals(50, results.size());
 
-       String flowFileContents = new String(runner.getContentAsByteArray(results.get(0)));
-       assertTrue(flowFileContents.startsWith(expected.toString(), 0));
+        String flowFileContents = new String(runner.getContentAsByteArray(results.get(0)));
+        assertTrue(flowFileContents.startsWith(expected.toString(), 0));
     }
 
     @Test
@@ -165,5 +244,28 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.setProperty(ConsumePulsarRecord.ASYNC_ENABLED, Boolean.toString(true));
 
         super.doMappedAttributesTest();
+    }
+
+    private static Message<GenericRecord> createTestMessage(byte[] data,
+                                                            String key,
+                                                            Map<String, String> properties,
+                                                            String topicName,
+                                                            String schemaString,
+                                                            SchemaType schemaType
+    ) {
+        Message mockA = mock(Message.class);
+        Schema<Object> schema = mock(Schema.class);
+        SchemaInfo schemaInfo = mock(SchemaInfo.class);
+        when(mockA.getReaderSchema()).thenReturn(Optional.of(schema));
+        when(schema.getSchemaInfo()).thenReturn(schemaInfo);
+        when(schemaInfo.getType()).thenReturn(schemaType);
+        when(schemaInfo.getSchema()).thenReturn(schemaString.getBytes());
+        when(mockA.getData()).thenReturn(data);
+        properties.entrySet().forEach(e ->
+                when(mockA.getProperty(e.getKey())).thenReturn(e.getValue())
+        );
+        when(mockA.getTopicName()).thenReturn(topicName);
+        when(mockA.getKey()).thenReturn(key);
+        return mockA;
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -19,9 +19,10 @@ package org.apache.nifi.processors.pulsar.pubsub.mocks;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.pulsar.PulsarClientService;
@@ -47,6 +48,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -59,11 +61,11 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
 
     @Mock
     PulsarClient mockClient = mock(PulsarClient.class);
-    
+
     @Mock
     PulsarAdmin mockAdmin = mock(PulsarAdmin.class);
 
-	@Mock
+    @Mock
     ProducerBuilder<T> mockProducerBuilder = mock(ProducerBuilder.class);
 
     @Mock
@@ -79,8 +81,8 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
     TypedMessageBuilder<T> mockTypedMessageBuilder = mock(TypedMessageBuilder.class);
 
     @Mock
-    protected Message<GenericRecord> mockMessage;
-    
+    protected Message<GenericRecord>[] mockMessages = new Message[0];
+
     @Mock
     SchemaInfo mockSchema = mock(SchemaInfo.class);
 
@@ -109,6 +111,7 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
 
         when(mockConsumerBuilder.topic(any(String[].class))).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.topic(anyString())).thenReturn(mockConsumerBuilder);
+        when(mockConsumerBuilder.topic(any())).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.subscriptionName(anyString())).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.ackTimeout(anyLong(), any(TimeUnit.class))).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.consumerName(anyString())).thenReturn(mockConsumerBuilder);
@@ -126,35 +129,74 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
         try {
             when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
             when(mockConsumer.isConnected()).thenReturn(true);
-            when(mockConsumer.receive()).thenReturn(mockMessage);
-            doAnswer(new Answer<Message<GenericRecord>>() {
-               public Message<GenericRecord> answer(InvocationOnMock invocation) {
-                       return mockMessage;
-               }
-             }).when(mockConsumer).receive(0, TimeUnit.SECONDS);
+
+            if (mockMessages.length >1 ) {
+                setMockMessages(Arrays.asList(mockMessages));
+            } else if (mockMessages.length==1){
+                setMockMessage(mockMessages[0]);
+            }else{
+                setMockMessage(null);
+            }
+
 
             when(mockProducerBuilder.create()).thenReturn(mockProducer);
             defineDefaultProducerBehavior();
         } catch (PulsarClientException e) {
-           e.printStackTrace();
+            e.printStackTrace();
         }
     }
 
+    /**
+     * sets a message and this message will be returned infinite amount of times by the consumer
+     */
     public void setMockMessage(Message<GenericRecord> mockMessage2) {
-        this.mockMessage = mockMessage2;
+        this.mockMessages = new Message[]{mockMessage2};
 
         // Configure the consumer behavior
         try {
-          when(mockConsumer.receive()).thenReturn(mockMessage);
+            when(mockConsumer.receive()).thenReturn(mockMessage2);
         } catch (PulsarClientException e) {
-          e.printStackTrace();
+            e.printStackTrace();
         }
 
         CompletableFuture<Message<GenericRecord>> future = CompletableFuture.supplyAsync(() -> {
-           return mockMessage;
+            return mockMessage2;
         });
 
         when(mockConsumer.receiveAsync()).thenReturn(future);
+
+        try {
+            doAnswer(new Answer<Message<GenericRecord>>() {
+                public Message<GenericRecord> answer(InvocationOnMock invocation) {
+                    return mockMessage2;
+                }
+            }).when(mockConsumer).receive(0, TimeUnit.SECONDS);
+        } catch (PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setMockMessages(List<Message<GenericRecord>> mockMessages2) {
+        this.mockMessages = mockMessages2.toArray(new Message[]{});
+
+        // Configure the consumer behavior
+        try {
+            when(mockConsumer.receive()).thenReturn(mockMessages[0], Arrays.copyOfRange(mockMessages, 1, mockMessages.length));
+        } catch (PulsarClientException e) {
+            e.printStackTrace();
+        }
+
+        List<CompletableFuture<Message<GenericRecord>>> future = Arrays.stream(mockMessages)
+                .map(mockMessage -> CompletableFuture.supplyAsync(() -> mockMessage))
+                .collect(Collectors.toList());
+
+        when(mockConsumer.receiveAsync()).thenReturn(future.get(0), (CompletableFuture<Message<GenericRecord>>[]) future.subList(1, future.size()).toArray(new CompletableFuture<?>[]{}));
+
+        try {
+            when(mockConsumer.receive(0, TimeUnit.SECONDS)).thenReturn(mockMessages[0], Arrays.copyOfRange(mockMessages, 1, mockMessages.length));
+        } catch (PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Producer<T> getMockProducer() {
@@ -162,8 +204,8 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
     }
 
     public void setMockProducer(Producer<T> mockProducer) {
-       this.mockProducer = mockProducer;
-       defineDefaultProducerBehavior();
+        this.mockProducer = mockProducer;
+        defineDefaultProducerBehavior();
     }
 
     private void defineDefaultProducerBehavior() {
@@ -200,29 +242,29 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
     }
 
     public Consumer<GenericRecord> getMockConsumer() {
-      return mockConsumer;
+        return mockConsumer;
     }
 
     public ProducerBuilder<T> getMockProducerBuilder() {
-      return mockProducerBuilder;
+        return mockProducerBuilder;
     }
 
     public ConsumerBuilder<GenericRecord> getMockConsumerBuilder() {
-      return mockConsumerBuilder;
+        return mockConsumerBuilder;
     }
 
     public TypedMessageBuilder<T> getMockTypedMessageBuilder() {
-      return mockTypedMessageBuilder;
+        return mockTypedMessageBuilder;
     }
 
     @Override
     public PulsarClient getPulsarClient() {
-      return mockClient;
+        return mockClient;
     }
 
     @Override
     public String getPulsarBrokerRootURL() {
-       return "pulsar://mocked:6650";
+        return "pulsar://mocked:6650";
     }
 
 }


### PR DESCRIPTION
It seems we overlooked the verification of whether the schema was actually an Avro schema. Furthermore, we've come to realize that when there's a schema update on a topic, it necessitates the creation of a new flow file. This is because we cannot mix multiple schemas within a single Parquet or Avro file.

To address these concerns, we have prepared a new pull request. This update ensures that the avro.schema attribute is only set when the record schema is of Avro types. Additionally, we have refactored the code and added multiple tests to validate the correct handling of these scenarios.

Furthermore, we have conducted manual testing of both JSON and Avro flows in NiFi with these changes to ensure they work effectively in real-world scenarios.

We appreciate your assistance in reviewing and addressing these issues.