### PR TITLE
Changed property name from enableBatching to batchingEnabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To build the NAR files using Maven, just run the following commands. The first o
 version 21, which is necessary since NiFi 2.0 uses this version.
 
 ```
-export JAVA_HOME=<JDK 21 HOME>
+export JAVA_HOME=`/usr/libexec/java_home -v 21`
 mvn clean package -Denforcer.skip
 ```
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -302,13 +302,13 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         config.put("compressionType", CompressionType.valueOf(ctx.getProperty(COMPRESSION_TYPE).getValue()));
 
         if (ctx.getProperty(BATCHING_ENABLED).asBoolean()) {
-            config.put("enableBatching", Boolean.TRUE);
+            config.put("batchingEnabled", Boolean.TRUE);
             config.put("batchingMaxBytes", ctx.getProperty(BATCHING_MAX_BYTES).asDataSize(DataUnit.B).intValue());
             config.put("batchingMaxMessages", ctx.getProperty(BATCHING_MAX_MESSAGES).evaluateAttributeExpressions().asInteger());
             config.put("batchingMaxPublishDelay", ctx.getProperty(BATCH_INTERVAL).evaluateAttributeExpressions()
                     .asTimePeriod(TimeUnit.MILLISECONDS).intValue());
         } else {
-            config.put("enableBatching", Boolean.FALSE);
+            config.put("batchingEnabled", Boolean.FALSE);
         }
 
         return config;


### PR DESCRIPTION
The dynamic property name changed in the Pulsar 3.x client. These are the 26 known properties: 

"compressionType", 
"autoUpdatePartitions", 
"messageRoutingMode", 
"lazyStartPartitionedProducers", 
"maxPendingMessagesAcrossPartitions", 
"batchingMaxMessages", 
"chunkingEnabled", 
"batchingMaxBytes", 
"batchingPartitionSwitchFrequencyByPublishDelay", 
"properties", 
"blockIfQueueFull", 
"encryptionKeys", 
"hashingScheme", 
"topicName", 
"producerName", 
"sendTimeoutMs", 
"initialSequenceId", 
"accessMode", 
"initialSubscriptionName", 
"chunkMaxMessageSize", 
"**batchingEnabled",** 
"multiSchema", 
"maxPendingMessages", 
"cryptoFailureAction", 
"batchingMaxPublishDelayMicros", 
"autoUpdatePartitionsIntervalSeconds"