### PR TITLE
Added logic to reuse Publisher leases if possible

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -238,4 +238,12 @@ public class PublisherLease implements Closeable {
             logger.error("Unable to close producer", pcEx);
         }
     }
+
+    /**
+     * Get the topic name for this producer lease
+     * @return the topic name that this producer is publishing to
+     */
+    public String getTopicName() {
+        return producer != null ? producer.getTopic() : null;
+    }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.utils.PublisherLease;
+import org.apache.nifi.processors.pulsar.utils.PublisherPool;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    @Mock
+    private PublisherPool mockPublisherPool;
+
+    @Mock
+    private PublisherLease mockLease1;
+
+    @Mock
+    private PublisherLease mockLease2;
+
+    private PublishPulsar processor;
+
+    @Before
+    public void setUp() throws InitializationException, Exception {
+        MockitoAnnotations.openMocks(this);
+        
+        processor = new PublishPulsar();
+        runner = TestRunners.newTestRunner(processor);
+        addPulsarClientService();
+        
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "test-topic");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        
+        // Use reflection to inject the mock PublisherPool
+        injectMockPublisherPool();
+    }
+    
+    private void injectMockPublisherPool() throws Exception {
+        // Get the private publisherPool field from AbstractPulsarProducerProcessor
+        Field publisherPoolField = AbstractPulsarProducerProcessor.class.getDeclaredField("publisherPool");
+        publisherPoolField.setAccessible(true);
+        publisherPoolField.set(processor, mockPublisherPool);
+    }
+    
+    private PublisherLease getCurrentLease() throws Exception {
+        Field currentLeaseField = PublishPulsar.class.getDeclaredField("currentLease");
+        currentLeaseField.setAccessible(true);
+        return (PublisherLease) currentLeaseField.get(processor);
+    }
+    
+    private PublisherLease callObtainPublisherLease(String topicName) throws Exception {
+        Method obtainPublisherLeaseMethod = PublishPulsar.class.getDeclaredMethod("obtainPublisherLease", String.class);
+        obtainPublisherLeaseMethod.setAccessible(true);
+        return (PublisherLease) obtainPublisherLeaseMethod.invoke(processor, topicName);
+    }
+
+    @Test
+    public void testLeaseReuseForSameTopic() throws Exception {
+        // Setup mock lease to return consistent topic name
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn("topic1");
+        
+        // First call should create new lease
+        PublisherLease lease1 = callObtainPublisherLease("topic1");
+        assertSame("First call should return the mock lease", mockLease1, lease1);
+        assertSame("Current lease should be set", mockLease1, getCurrentLease());
+        
+        // Second call with same topic should reuse existing lease
+        PublisherLease lease2 = callObtainPublisherLease("topic1");
+        assertSame("Second call should return the same lease", mockLease1, lease2);
+        assertSame("Current lease should still be the same", mockLease1, getCurrentLease());
+        
+        // Verify pool was only called once
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic1");
+        verify(mockLease1, never()).close();
+    }
+
+    @Test
+    public void testLeaseRecreationForDifferentTopic() throws Exception {
+        // Setup mock leases for different topics
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockPublisherPool.obtainPublisher("topic2")).thenReturn(mockLease2);
+        when(mockLease1.getTopicName()).thenReturn("topic1");
+        when(mockLease2.getTopicName()).thenReturn("topic2");
+        
+        // First call creates lease for topic1
+        PublisherLease lease1 = callObtainPublisherLease("topic1");
+        assertSame("First lease should be mockLease1", mockLease1, lease1);
+        
+        // Second call with different topic should close old lease and create new one
+        PublisherLease lease2 = callObtainPublisherLease("topic2");
+        assertSame("Second lease should be mockLease2", mockLease2, lease2);
+        assertSame("Current lease should be updated", mockLease2, getCurrentLease());
+        
+        // Verify old lease was closed and new lease was created
+        verify(mockLease1, times(1)).close();
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic1");
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic2");
+    }
+
+    @Test
+    public void testNullTopicNameHandling() throws Exception {
+        // Setup mock lease that returns null topic name
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn(null);
+        
+        // First call with real topic
+        PublisherLease lease1 = callObtainPublisherLease("topic1");
+        assertSame("First lease should be mockLease1", mockLease1, lease1);
+        
+        // Second call with same topic should not reuse because lease returns null topic
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease2);
+        PublisherLease lease2 = callObtainPublisherLease("topic1");
+        assertSame("Second lease should be mockLease2", mockLease2, lease2);
+        
+        // Verify old lease was closed because topic comparison failed
+        verify(mockLease1, times(1)).close();
+        verify(mockPublisherPool, times(2)).obtainPublisher("topic1");
+    }
+
+    @Test
+    public void testRequestedTopicNameNullHandling() throws Exception {
+        // Setup mock lease
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn("topic1");
+        
+        // First call with real topic
+        PublisherLease lease1 = callObtainPublisherLease("topic1");
+        assertSame("First lease should be mockLease1", mockLease1, lease1);
+        
+        // Second call with null topic should not reuse lease
+        when(mockPublisherPool.obtainPublisher(null)).thenReturn(mockLease2);
+        PublisherLease lease2 = callObtainPublisherLease(null);
+        assertSame("Second lease should be mockLease2", mockLease2, lease2);
+        
+        // Verify old lease was closed
+        verify(mockLease1, times(1)).close();
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic1");
+        verify(mockPublisherPool, times(1)).obtainPublisher(null);
+    }
+
+    @Test
+    public void testBothTopicNamesNullHandling() throws Exception {
+        // Setup mock lease that returns null topic name
+        when(mockPublisherPool.obtainPublisher(null)).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn(null);
+        
+        // First call with null topic
+        PublisherLease lease1 = callObtainPublisherLease(null);
+        assertSame("First lease should be mockLease1", mockLease1, lease1);
+        
+        // Second call with null topic should not reuse because both are null
+        when(mockPublisherPool.obtainPublisher(null)).thenReturn(mockLease2);
+        PublisherLease lease2 = callObtainPublisherLease(null);
+        assertSame("Second lease should be mockLease2", mockLease2, lease2);
+        
+        // Verify old lease was closed
+        verify(mockLease1, times(1)).close();
+        verify(mockPublisherPool, times(2)).obtainPublisher(null);
+    }
+
+    @Test
+    public void testPublisherPoolReturnsNull() throws Exception {
+        // Setup mock pool to return null
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(null);
+        
+        // Call should return null and not crash
+        PublisherLease lease = callObtainPublisherLease("topic1");
+        assertNull("Lease should be null when pool returns null", lease);
+        assertNull("Current lease should remain null", getCurrentLease());
+        
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic1");
+    }
+
+    @Test
+    public void testOnUnscheduledCleansUpLease() throws Exception {
+        // Setup mock lease
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn("topic1");
+        
+        // Create a lease
+        callObtainPublisherLease("topic1");
+        assertSame("Current lease should be set", mockLease1, getCurrentLease());
+        
+        // Call onUnscheduled
+        processor.onUnscheduled();
+        
+        // Verify lease was closed and cleared
+        verify(mockLease1, times(1)).close();
+        assertNull("Current lease should be null after onUnscheduled", getCurrentLease());
+    }
+
+    @Test
+    public void testOnUnscheduledWithNullTopicName() throws Exception {
+        // Setup mock lease that returns null topic name
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn(null);
+        
+        // Create a lease
+        callObtainPublisherLease("topic1");
+        assertSame("Current lease should be set", mockLease1, getCurrentLease());
+        
+        // Call onUnscheduled - should not crash despite null topic name
+        processor.onUnscheduled();
+        
+        // Verify lease was closed and cleared
+        verify(mockLease1, times(1)).close();
+        assertNull("Current lease should be null after onUnscheduled", getCurrentLease());
+    }
+
+    @Test
+    public void testOnUnscheduledWithNoCurrentLease() throws Exception {
+        // Ensure no current lease
+        assertNull("Current lease should be null initially", getCurrentLease());
+        
+        // Call onUnscheduled - should not crash
+        processor.onUnscheduled();
+        
+        // Should still be null and no interactions with mocks
+        assertNull("Current lease should still be null", getCurrentLease());
+        verifyNoInteractions(mockLease1, mockLease2);
+    }
+
+    @Test
+    public void testIntegrationWithFlowFileProcessing() throws Exception {
+        // Setup mock lease
+        when(mockPublisherPool.obtainPublisher("test-topic")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn("test-topic");
+        
+        // Add a FlowFile
+        runner.enqueue("test content".getBytes());
+        
+        // Run the processor
+        runner.run(1);
+        
+        // Verify the lease was obtained and used
+        verify(mockPublisherPool, times(1)).obtainPublisher("test-topic");
+        verify(mockLease1, times(1)).publish(any(), any(), any(), any(), any(), anyBoolean());
+        
+        // Verify FlowFile was transferred successfully
+        runner.assertAllFlowFilesTransferred(AbstractPulsarProducerProcessor.REL_SUCCESS, 1);
+        List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(AbstractPulsarProducerProcessor.REL_SUCCESS);
+        assertEquals("Should have one success FlowFile", 1, successFlowFiles.size());
+    }
+
+    @Test
+    public void testIntegrationWithMultipleFlowFilesSameTopic() throws Exception {
+        // Setup mock lease
+        when(mockPublisherPool.obtainPublisher("test-topic")).thenReturn(mockLease1);
+        when(mockLease1.getTopicName()).thenReturn("test-topic");
+        
+        // Add multiple FlowFiles
+        runner.enqueue("content1".getBytes());
+        runner.enqueue("content2".getBytes());
+        runner.enqueue("content3".getBytes());
+        
+        // Run the processor
+        runner.run(1);
+        
+        // Verify the lease was obtained only once and reused
+        verify(mockPublisherPool, times(1)).obtainPublisher("test-topic");
+        verify(mockLease1, times(3)).publish(any(), any(), any(), any(), any(), anyBoolean());
+        verify(mockLease1, never()).close(); // Should not be closed during processing
+        
+        // Verify all FlowFiles were transferred successfully
+        runner.assertAllFlowFilesTransferred(AbstractPulsarProducerProcessor.REL_SUCCESS, 3);
+    }
+
+    @Test
+    public void testIntegrationWithMultipleFlowFilesDifferentTopics() throws Exception {
+        // Use expression language to vary topic names
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "${topic.name}");
+        
+        // Setup mock leases
+        when(mockPublisherPool.obtainPublisher("topic1")).thenReturn(mockLease1);
+        when(mockPublisherPool.obtainPublisher("topic2")).thenReturn(mockLease2);
+        when(mockLease1.getTopicName()).thenReturn("topic1");
+        when(mockLease2.getTopicName()).thenReturn("topic2");
+        
+        // Add FlowFiles with different topic attributes
+        runner.enqueue("content1".getBytes(), java.util.Collections.singletonMap("topic.name", "topic1"));
+        runner.enqueue("content2".getBytes(), java.util.Collections.singletonMap("topic.name", "topic2"));
+        runner.enqueue("content3".getBytes(), java.util.Collections.singletonMap("topic.name", "topic1"));
+        
+        // Run the processor
+        runner.run(1);
+        
+        // Verify leases were obtained for both topics
+        verify(mockPublisherPool, times(2)).obtainPublisher("topic1"); // Called twice due to topic switch
+        verify(mockPublisherPool, times(1)).obtainPublisher("topic2");
+        
+        // Verify lease closure when switching topics
+        verify(mockLease1, times(1)).close(); // Closed when switching to topic2
+        verify(mockLease2, times(1)).close(); // Closed when switching back to topic1
+        
+        // Verify all FlowFiles were processed
+        runner.assertAllFlowFilesTransferred(AbstractPulsarProducerProcessor.REL_SUCCESS, 3);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherLeaseTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherLeaseTest.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.RecordSet;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class PublisherLeaseTest {
+
+    @Mock
+    private Producer producer;
+
+    @Mock
+    private ComponentLog logger;
+
+    @Mock
+    private FlowFile flowFile;
+
+    @Mock
+    private TypedMessageBuilder typedMessageBuilder;
+
+    @Mock
+    private MessageId messageId;
+
+    @Mock
+    private RecordSet recordSet;
+
+    @Mock
+    private RecordSetWriterFactory writerFactory;
+
+    @Mock
+    private RecordSchema schema;
+
+    @Mock
+    private Record record;
+
+    private PublisherLease publisherLease;
+    private Map<String, String> messageProperties;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        publisherLease = new PublisherLease(producer, logger);
+        messageProperties = new HashMap<>();
+        messageProperties.put("key1", "value1");
+        messageProperties.put("key2", "value2");
+    }
+
+    @Test
+    public void testConstructor() {
+        PublisherLease lease = new PublisherLease(producer, logger);
+        assertNotNull("PublisherLease should be created", lease);
+    }
+
+    @Test
+    public void testGetTopicNameWithValidProducer() {
+        String expectedTopic = "test-topic";
+        when(producer.getTopic()).thenReturn(expectedTopic);
+
+        String actualTopic = publisherLease.getTopicName();
+
+        assertEquals("Topic name should match producer's topic", expectedTopic, actualTopic);
+        verify(producer, times(1)).getTopic();
+    }
+
+    @Test
+    public void testGetTopicNameWithNullProducer() {
+        PublisherLease leaseWithNullProducer = new PublisherLease(null, logger);
+
+        String actualTopic = leaseWithNullProducer.getTopicName();
+
+        assertNull("Topic name should be null when producer is null", actualTopic);
+    }
+
+    @Test
+    public void testGetTopicNameWhenProducerReturnsNull() {
+        when(producer.getTopic()).thenReturn(null);
+
+        String actualTopic = publisherLease.getTopicName();
+
+        assertNull("Topic name should be null when producer returns null", actualTopic);
+        verify(producer, times(1)).getTopic();
+    }
+
+    @Test
+    public void testPublishWithoutDemarcator() throws IOException, PulsarClientException {
+        // Setup FlowFile
+        byte[] content = "test content".getBytes();
+        when(flowFile.getSize()).thenReturn((long) content.length);
+        InputStream inputStream = new ByteArrayInputStream(content);
+
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.key(anyString())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call publish method
+        publisherLease.publish(flowFile, inputStream, "test-key", messageProperties, null, false);
+
+        // Verify interactions
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value(content);
+        verify(typedMessageBuilder, times(1)).key("test-key");
+        verify(typedMessageBuilder, times(1)).send();
+    }
+
+    @Test
+    public void testPublishWithoutDemarcatorAsync() throws IOException, PulsarClientException {
+        // Setup FlowFile
+        byte[] content = "test content".getBytes();
+        when(flowFile.getSize()).thenReturn((long) content.length);
+        InputStream inputStream = new ByteArrayInputStream(content);
+
+        // Setup TypedMessageBuilder chain for async
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.key(anyString())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.sendAsync()).thenReturn(CompletableFuture.completedFuture(messageId));
+
+        // Call publish method with async=true
+        publisherLease.publish(flowFile, inputStream, "test-key", messageProperties, null, true);
+
+        // Verify interactions
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value(content);
+        verify(typedMessageBuilder, times(1)).key("test-key");
+        verify(typedMessageBuilder, times(1)).sendAsync();
+        verify(typedMessageBuilder, never()).send(); // Should not call sync send
+    }
+
+    @Test
+    public void testPublishWithNullMessageKey() throws IOException, PulsarClientException {
+        // Setup FlowFile
+        byte[] content = "test content".getBytes();
+        when(flowFile.getSize()).thenReturn((long) content.length);
+        InputStream inputStream = new ByteArrayInputStream(content);
+
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call publish method with null key
+        publisherLease.publish(flowFile, inputStream, null, messageProperties, null, false);
+
+        // Verify interactions
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value(content);
+        verify(typedMessageBuilder, never()).key(anyString()); // Should not set key when null
+        verify(typedMessageBuilder, times(1)).send();
+    }
+
+    @Test
+    public void testPublishWithDemarcator() throws IOException, PulsarClientException {
+        // Setup FlowFile with content that will be split by demarcator
+        String content = "message1\nmessage2\nmessage3";
+        when(flowFile.getSize()).thenReturn((long) content.length());
+        InputStream inputStream = new ByteArrayInputStream(content.getBytes());
+        byte[] demarcator = "\n".getBytes();
+
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.key(anyString())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call publish method
+        publisherLease.publish(flowFile, inputStream, "test-key", messageProperties, demarcator, false);
+
+        // Verify interactions - should be called 3 times for 3 messages
+        verify(producer, times(3)).newMessage();
+        verify(typedMessageBuilder, times(3)).properties(messageProperties);
+        verify(typedMessageBuilder, times(3)).value(any(byte[].class));
+        verify(typedMessageBuilder, times(3)).key("test-key");
+        verify(typedMessageBuilder, times(3)).send();
+    }
+
+    @Test
+    public void testPublishWithEmptyMessageProperties() throws IOException, PulsarClientException {
+        // Setup FlowFile
+        byte[] content = "test content".getBytes();
+        when(flowFile.getSize()).thenReturn((long) content.length);
+        InputStream inputStream = new ByteArrayInputStream(content);
+        Map<String, String> emptyProperties = new HashMap<>();
+
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call publish method
+        publisherLease.publish(flowFile, inputStream, null, emptyProperties, null, false);
+
+        // Verify interactions
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(emptyProperties);
+        verify(typedMessageBuilder, times(1)).value(content);
+        verify(typedMessageBuilder, times(1)).send();
+    }
+
+    @Test
+    public void testComplete() {
+        // Initially, complete should return 0
+        assertEquals("Initial message count should be 0", 0, publisherLease.complete());
+
+        // The complete() method returns the count of messages sent, but since we can't easily
+        // mock the internal messagesSent counter increment (it's done inside publish methods),
+        // we can only test the initial state
+    }
+
+    @Test
+    public void testClose() throws PulsarClientException {
+        // Call close method
+        publisherLease.close();
+
+        // Verify producer was flushed and closed
+        verify(producer, times(1)).flush();
+        verify(producer, times(1)).close();
+    }
+
+    @Test
+    public void testCloseWithPulsarClientException() throws PulsarClientException {
+        // Setup producer to throw exception on flush
+        doThrow(new PulsarClientException("Test exception")).when(producer).flush();
+
+        // Call close method - should not throw exception
+        publisherLease.close();
+
+        // Verify error was logged
+        verify(logger, times(1)).error(eq("Unable to close producer"), any(PulsarClientException.class));
+        verify(producer, times(1)).flush();
+        verify(producer, times(1)).close(); // Should still try to close
+    }
+
+    @Test
+    public void testCloseWithExceptionOnClose() throws PulsarClientException {
+        // Setup producer to throw exception on close
+        doThrow(new PulsarClientException("Test exception")).when(producer).close();
+
+        // Call close method - should not throw exception
+        publisherLease.close();
+
+        // Verify error was logged
+        verify(logger, times(1)).error(eq("Unable to close producer"), any(PulsarClientException.class));
+        verify(producer, times(1)).flush();
+        verify(producer, times(1)).close();
+    }
+
+    @Test
+    public void testSendAsyncMethod() throws PulsarClientException {
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.key(anyString())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.sendAsync()).thenReturn(CompletableFuture.completedFuture(messageId));
+
+        // Call protected sendAsync method via reflection or create subclass for testing
+        CompletableFuture<MessageId> result = publisherLease.sendAsync(producer, "test-key", messageProperties, "test-content".getBytes());
+
+        // Verify result
+        assertNotNull("Result should not be null", result);
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value("test-content".getBytes());
+        verify(typedMessageBuilder, times(1)).key("test-key");
+        verify(typedMessageBuilder, times(1)).sendAsync();
+    }
+
+    @Test
+    public void testSendAsyncMethodWithNullKey() throws PulsarClientException {
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.sendAsync()).thenReturn(CompletableFuture.completedFuture(messageId));
+
+        // Call protected sendAsync method with null key
+        CompletableFuture<MessageId> result = publisherLease.sendAsync(producer, null, messageProperties, "test-content".getBytes());
+
+        // Verify result and interactions
+        assertNotNull("Result should not be null", result);
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value("test-content".getBytes());
+        verify(typedMessageBuilder, never()).key(anyString()); // Should not set key when null
+        verify(typedMessageBuilder, times(1)).sendAsync();
+    }
+
+    @Test
+    public void testSendSyncMethod() throws PulsarClientException {
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.key(anyString())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call protected send method
+        CompletableFuture<MessageId> result = publisherLease.send(producer, "test-key", messageProperties, "test-content".getBytes());
+
+        // Verify result
+        assertNotNull("Result should not be null", result);
+        assertFalse("Result should not be cancelled", result.isCancelled());
+        
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value("test-content".getBytes());
+        verify(typedMessageBuilder, times(1)).key("test-key");
+        verify(typedMessageBuilder, times(1)).send();
+    }
+
+    @Test
+    public void testSendSyncMethodWithNullKey() throws PulsarClientException {
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call protected send method with null key
+        CompletableFuture<MessageId> result = publisherLease.send(producer, null, messageProperties, "test-content".getBytes());
+
+        // Verify result and interactions
+        assertNotNull("Result should not be null", result);
+        verify(producer, times(1)).newMessage();
+        verify(typedMessageBuilder, times(1)).properties(messageProperties);
+        verify(typedMessageBuilder, times(1)).value("test-content".getBytes());
+        verify(typedMessageBuilder, never()).key(anyString()); // Should not set key when null
+        verify(typedMessageBuilder, times(1)).send();
+    }
+
+    @Test
+    public void testMultiplePublishCallsIncrementsMessageCount() throws IOException, PulsarClientException {
+        // Setup FlowFile
+        byte[] content = "test content".getBytes();
+        when(flowFile.getSize()).thenReturn((long) content.length);
+        
+        // Setup TypedMessageBuilder chain
+        when(producer.newMessage()).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.properties(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
+        when(typedMessageBuilder.send()).thenReturn(messageId);
+
+        // Call publish multiple times
+        InputStream inputStream1 = new ByteArrayInputStream(content);
+        publisherLease.publish(flowFile, inputStream1, null, messageProperties, null, false);
+        
+        InputStream inputStream2 = new ByteArrayInputStream(content);
+        publisherLease.publish(flowFile, inputStream2, null, messageProperties, null, false);
+
+        // Verify producer was called twice
+        verify(producer, times(2)).newMessage();
+        verify(typedMessageBuilder, times(2)).send();
+    }
+
+    @Test
+    public void testPublishWithIOException() throws IOException {
+        // Create an InputStream that will throw IOException
+        InputStream faultyInputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("Test IO Exception");
+            }
+        };
+
+        when(flowFile.getSize()).thenReturn(10L);
+
+        // Call publish method - should propagate IOException
+        try {
+            publisherLease.publish(flowFile, faultyInputStream, null, messageProperties, null, false);
+            fail("Should have thrown IOException");
+        } catch (IOException e) {
+            assertEquals("Exception message should match", "Test IO Exception", e.getMessage());
+        }
+
+        // Verify producer was not called since reading failed
+        verify(producer, never()).newMessage();
+    }
+}


### PR DESCRIPTION
Rather that store the Pulsar publisher in a cache, a better approach would be to reuse the existing PublisherLease object if possible. This simplifies the design while avoiding the creation of a new Pulsar Publisher for every FlowFile.

Addresses this [issue](https://github.com/david-streamlio/pulsar-nifi-bundle/issues/89)