### PR TITLE
ci: add CI/release workflows and fork-PR hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. Inbound PRs (including from forks)
+# require review from a code owner before merge once branch protection is enabled.
+* @david-streamlio

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Keep Maven dependencies (Pulsar, NiFi, Jackson, etc.) patched.
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  # Keep the GitHub Actions used in the workflows above up to date and pinned.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR change and why? Link any related issue: Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] Build / CI
+
+## Checklist
+
+- [ ] `mvn clean package` succeeds locally with Java 21
+- [ ] Added or updated tests where it makes sense
+- [ ] No secrets, credentials, or generated artifacts committed
+- [ ] PR targets the `main` branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+# Build and run unit tests on every push to main and on every pull request
+# (including PRs from forks). Fork PRs run with the default read-only GITHUB_TOKEN
+# and have no access to repository secrets, so this workflow is safe for untrusted
+# contributors. Do NOT switch this to `pull_request_target` — that would expose
+# secrets and a write-capable token to fork code.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Least-privilege token: read-only is all CI needs.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Test (Java 21)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Skip GPG signing (no keys in CI) and the docker-image module (Docker build
+      # is exercised by the release workflow, not on every PR). Tests still run via
+      # the `package` phase.
+      - name: Build and test
+        run: mvn -B -ntp clean package -Dgpg.skip=true -pl '!docker-image'
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/*.xml'
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+# Cuts a GitHub Release whenever a version tag (e.g. v2.1.0) is pushed, or when
+# triggered manually from the Actions tab. Builds the NAR artifacts and attaches
+# them to the release with auto-generated notes.
+#
+# Tags are only pushable by maintainers, so this workflow never runs from fork code.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# `contents: write` is required to create the release and upload assets.
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build artifacts & publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Build the NAR artifacts. GPG signing and the docker-image module are skipped
+      # here; enable the opt-in jobs below if you want signed Central deploys / images.
+      - name: Build NAR artifacts
+        run: mvn -B -ntp clean package -Dgpg.skip=true -pl '!docker-image'
+
+      - name: Create GitHub Release and attach NARs
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            nifi-pulsar-nar/target/*.nar
+            nifi-pulsar-client-service-nar/target/*.nar
+
+  # ---------------------------------------------------------------------------
+  # OPT-IN: push the streamnative/nifi Docker image to a registry.
+  # Uncomment and configure the DOCKER_USERNAME / DOCKER_PASSWORD repo secrets
+  # (Settings → Secrets and variables → Actions). Never expose these to fork PRs.
+  # ---------------------------------------------------------------------------
+  # docker:
+  #   name: Build & push Docker image
+  #   runs-on: ubuntu-latest
+  #   needs: release
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-java@v4
+  #       with: { distribution: temurin, java-version: '21', cache: maven }
+  #     - name: Log in to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #     - name: Build image (fabric8 plugin runs in the package phase)
+  #       run: mvn -B -ntp clean package -Dgpg.skip=true
+  #     - name: Push image
+  #       run: docker push streamnative/nifi
+
+  # ---------------------------------------------------------------------------
+  # OPT-IN: deploy signed artifacts to Sonatype OSSRH / Maven Central.
+  # Requires repo secrets: OSSRH_USERNAME, OSSRH_PASSWORD,
+  # MAVEN_GPG_PRIVATE_KEY, MAVEN_GPG_PASSPHRASE.
+  # ---------------------------------------------------------------------------
+  # central-deploy:
+  #   name: Deploy to Maven Central
+  #   runs-on: ubuntu-latest
+  #   needs: release
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-java@v4
+  #       with:
+  #         distribution: temurin
+  #         java-version: '21'
+  #         cache: maven
+  #         server-id: ossrh
+  #         server-username: OSSRH_USERNAME
+  #         server-password: OSSRH_PASSWORD
+  #         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+  #         gpg-passphrase: MAVEN_GPG_PASSPHRASE
+  #     - name: Publish
+  #       run: mvn -B -ntp clean deploy -DskipTests
+  #       env:
+  #         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+  #         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+  #         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary

Adds GitHub Actions automation and inbound/fork-PR hardening to the repo.

### Workflows
- **`ci.yml`** — build + unit tests on every push/PR to `main` (Temurin Java 21, Maven caching). Skips GPG signing and the `docker-image` module for speed; uploads Surefire reports. Uses `pull_request` (not `pull_request_target`) with `permissions: contents: read`, so **fork PRs run with a read-only token and no secret access**.
- **`release.yml`** — on a `v*` tag (or manual dispatch), builds the NARs and publishes a GitHub Release with auto-generated notes and both `.nar` files attached. Docker push and Maven Central deploy are included as commented opt-in stubs.

### Fork / branch hardening
- `CODEOWNERS` — inbound PRs require owner review (once branch protection is enabled).
- `dependabot.yml` — weekly Maven + GitHub Actions updates.
- `pull_request_template.md` — contributor checklist.

### Verification
The CI build command (`mvn clean package -Dgpg.skip=true -pl '!docker-image'`) was run locally against this branch: `BUILD SUCCESS`, all modules built/tested, both NARs produced at the paths the release workflow attaches.

### Follow-ups (not in this PR)
- After this merges and CI runs once, enable branch protection requiring the `Build & Test (Java 21)` check + code-owner review.
- Reconcile the version mismatch: pom is `2.1.0`, `version` file is `v1.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)