### PR TITLE
ci: push Docker image to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,28 +47,57 @@ jobs:
             nifi-pulsar-nar/target/*.nar
             nifi-pulsar-client-service-nar/target/*.nar
 
-  # ---------------------------------------------------------------------------
-  # OPT-IN: push the streamnative/nifi Docker image to a registry.
-  # Uncomment and configure the DOCKER_USERNAME / DOCKER_PASSWORD repo secrets
-  # (Settings → Secrets and variables → Actions). Never expose these to fork PRs.
-  # ---------------------------------------------------------------------------
-  # docker:
-  #   name: Build & push Docker image
-  #   runs-on: ubuntu-latest
-  #   needs: release
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-java@v4
-  #       with: { distribution: temurin, java-version: '21', cache: maven }
-  #     - name: Log in to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-  #     - name: Build image (fabric8 plugin runs in the package phase)
-  #       run: mvn -B -ntp clean package -Dgpg.skip=true
-  #     - name: Push image
-  #       run: docker push streamnative/nifi
+  # Build the streamnative/nifi image and push it to GitHub Container Registry
+  # (ghcr.io). Uses the built-in GITHUB_TOKEN — no extra secrets required. The
+  # image is tagged with the release version (from the pom, our single source of
+  # truth) and `latest`.
+  docker:
+    name: Build & push Docker image (GHCR)
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Full build including the docker-image module: the fabric8 plugin produces
+      # the local image `streamnative/nifi:latest` during the package phase.
+      - name: Build image
+        run: mvn -B -ntp clean package -Dgpg.skip=true
+
+      - name: Resolve image coordinates
+        id: img
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"   # GHCR namespaces must be lowercase
+          version="$(mvn -q -N help:evaluate -Dexpression=project.version -DforceStdout)"
+          echo "image=ghcr.io/${owner}/nifi" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push
+        env:
+          IMAGE: ${{ steps.img.outputs.image }}
+          VERSION: ${{ steps.img.outputs.version }}
+        run: |
+          docker tag streamnative/nifi:latest "${IMAGE}:${VERSION}"
+          docker tag streamnative/nifi:latest "${IMAGE}:latest"
+          docker push "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:latest"
 
   # ---------------------------------------------------------------------------
   # OPT-IN: deploy signed artifacts to Sonatype OSSRH / Maven Central.


### PR DESCRIPTION
## Summary

Fills in the previously-commented Docker stub in `release.yml` with a working job that publishes the container image on every `v*` release.

- Builds the `streamnative/nifi` image via the fabric8 plugin (package phase), then re-tags and pushes to **`ghcr.io/<owner>/nifi`**.
- Tags pushed: the **release version** (resolved from the pom `<version>`, our single source of truth, so the image tag matches the artifacts even on manual dispatch) and **`latest`**.
- Auth uses the built-in **`GITHUB_TOKEN`** with `packages: write` — **no extra secrets required**.
- Runs as a separate job `needs: release`, so the image only publishes after the GitHub Release + NAR step succeeds.

The Maven Central deploy stub is left untouched.

### Notes
- Verified the workflow YAML parses and the job structure is correct. The Docker build itself runs on the GitHub runner (local Docker daemon was unavailable here); first real exercise will be the next `v*` tag.
- First push creates the GHCR package as **private** by default — make it public in the package settings if you want anonymous `docker pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
