### PR TITLE
ci: make release version tag-driven via versions:set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
           java-version: '21'
           cache: maven
 
+      # The git tag is authoritative for a release: stamp the pom version from it
+      # (e.g. tag v2.1.0.1 -> Maven version 2.1.0.1) so artifacts and image are
+      # labeled to match the tag. On manual dispatch (no tag) the pom is left as-is.
+      - name: Stamp version from tag
+        if: github.ref_type == 'tag'
+        run: mvn -B -ntp versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false -DprocessAllModules=true
+
       # Build the NAR artifacts. GPG signing and the docker-image module are skipped
       # here; enable the opt-in jobs below if you want signed Central deploys / images.
       - name: Build NAR artifacts
@@ -49,8 +56,7 @@ jobs:
 
   # Build the streamnative/nifi image and push it to GitHub Container Registry
   # (ghcr.io). Uses the built-in GITHUB_TOKEN — no extra secrets required. The
-  # image is tagged with the release version (from the pom, our single source of
-  # truth) and `latest`.
+  # image is tagged with the release version (stamped from the git tag) and `latest`.
   docker:
     name: Build & push Docker image (GHCR)
     runs-on: ubuntu-latest
@@ -68,6 +74,11 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
+
+      # Stamp the pom version from the tag so the image tag matches the release.
+      - name: Stamp version from tag
+        if: github.ref_type == 'tag'
+        run: mvn -B -ntp versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false -DprocessAllModules=true
 
       # Full build including the docker-image module: the fabric8 plugin produces
       # the local image `streamnative/nifi:latest` during the package phase.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -34,8 +34,17 @@ line** rather than multiple Pulsar majors simultaneously.
 | `2.1.0.1` | Connector fix/dep bump, still NiFi 2.1.0 |
 | `2.2.0` | First release built for NiFi 2.2.0 |
 
-The Maven `<version>` in `pom.xml` is the single source of truth for the
-release number. There is no separate `version` file.
+### Where the version lives
+
+The **git tag is authoritative** for a release. The pom `<version>` on `main`
+stays at the NiFi base version (e.g. `2.1.0`); you do **not** hand-edit it or
+commit a bump before tagging. When you push a tag `vX.Y.Z[.R]`, the release
+workflow stamps the pom from the tag (`mvn versions:set -DnewVersion=X.Y.Z[.R]`)
+before building, so the NARs and the Docker image are labeled to match the tag.
+There is no separate `version` file.
+
+This keeps the release flow to a single action — push a tag — with no
+version-bump commit and no chance of the artifacts disagreeing with the tag.
 
 ## Pulsar client major
 
@@ -60,8 +69,10 @@ Mirrors apache/nifi's `support/nifi-N.x` model:
 ## Release tags
 
 Releases are cut by pushing a tag `v<version>` (e.g. `v2.1.0`, `v2.1.0.1`), which
-triggers `.github/workflows/release.yml` to build the NARs and publish a GitHub
-Release. The tag's numeric part must equal the pom `<version>`.
+triggers `.github/workflows/release.yml` to stamp the pom version from the tag,
+build the NARs, publish a GitHub Release, and push the Docker image to GHCR
+(`ghcr.io/<owner>/nifi:<version>` and `:latest`). The tag is the single source of
+truth — nothing needs to be committed beforehand.
 
 ## Compatibility matrix
 


### PR DESCRIPTION
## Summary

Fixes the version-labeling flaw exposed by the `v2.1.0.1` test release, where the tag said `2.1.0.1` but the NARs and GHCR image were labeled `2.1.0` (the unbumped pom version).

- Both the `release` and `docker` jobs now run `mvn versions:set -DnewVersion=${tag#v}` before building, so artifacts and the image are labeled to match the git tag.
- The **git tag is now the single source of truth** for a release. The pom `<version>` on `main` stays at the NiFi base version (`2.1.0`); no pre-tag version-bump commit is needed.
- `VERSIONING.md` updated to document the tag-driven flow.

The stamp step is guarded by `if: github.ref_type == 'tag'`, so a manual `workflow_dispatch` leaves the pom as-is.

## Follow-up after merge
The mislabeled `v2.1.0.1` release + tag and the `2.1.0` GHCR image will be deleted, then `v2.1.0.1` re-cut on the fixed `main` so everything is consistently labeled `2.1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
