### PR TITLE
ci: group Dependabot updates + auto-merge non-major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  # Keep Maven dependencies (Pulsar, NiFi, Jackson, etc.) patched.
+  # All Maven dependency + plugin updates collapse into a SINGLE grouped PR
+  # (instead of one PR per dependency). Patch/minor bundles auto-merge once CI
+  # is green; a bundle that contains any major bump is held for manual review
+  # (see .github/workflows/dependabot-auto-merge.yml).
   - package-ecosystem: maven
     directory: "/"
     schedule:
@@ -8,6 +11,10 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
+    groups:
+      maven-all:
+        patterns:
+          - "*"
     ignore:
       # The NiFi parent POM is intentionally pinned to 2.1.0. Bumping it to a
       # newer NiFi (e.g. 2.9.0) drags in a parent that bans JUnit 4 and requires
@@ -19,7 +26,7 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
 
-  # Keep the GitHub Actions used in the workflows above up to date and pinned.
+  # All GitHub Actions updates collapse into a SINGLE grouped PR.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -27,3 +34,7 @@ updates:
     labels:
       - dependencies
       - ci
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge for Dependabot PRs that contain no major
+# version bumps. GitHub still waits for the required "Build & Test (Java 21)"
+# check to pass before merging, so nothing merges on a red build. Bundles that
+# include a major bump are left for manual review.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Approve and enable auto-merge for non-major updates
+        # For a grouped PR, update-type is the highest semver change across the
+        # group, so a group containing any major bump is held here.
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the "10 PRs in 7 minutes, merge/rebase each one serially" pain.

## What changes
- **`dependabot.yml`** — all Maven updates now collapse into a **single grouped PR** (and all GitHub Actions updates into a single grouped PR). Dependabot groups per ecosystem, so it's 1 Maven PR + 1 Actions PR max, not one-PR-per-dependency.
- **`dependabot-auto-merge.yml`** — auto-approves and enables auto-merge for Dependabot PRs with **no major** version bump. The required `Build & Test (Java 21)` check must still pass before anything merges. A bundle containing a major bump (e.g. mockito 3→5) is **held for manual review**.

## Paired repo settings (already applied)
- Repo **auto-merge enabled**.
- GitHub Actions **may approve PRs**.
- Branch protection: keeps **1 required review + the CI check**, drops the *code-owner* hard-gate so the bot's approval lets green patch/minor bundles merge hands-free. Fork PRs still can't self-merge (the workflow only approves `dependabot[bot]` PRs).

## Result
Weeks with only patch/minor → one PR, merges itself on green. Weeks with a major → one PR, waits for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)