### PR TITLE
test: enable JUnit 4 tests (vintage-engine) and repair the suite

### DIFF
--- a/nifi-pulsar-client-service-api/pom.xml
+++ b/nifi-pulsar-client-service-api/pom.xml
@@ -108,7 +108,14 @@
              <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        
+        <!-- Runs the JUnit 4 tests on the JUnit Platform surefire (version
+             managed by the NiFi parent's org.junit:junit-bom import). -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
   			<groupId>org.mockito</groupId>
   			<artifactId>mockito-core</artifactId>

--- a/nifi-pulsar-client-service/pom.xml
+++ b/nifi-pulsar-client-service/pom.xml
@@ -90,7 +90,14 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        
+        <!-- Runs the JUnit 4 tests on the JUnit Platform surefire (version
+             managed by the NiFi parent's org.junit:junit-bom import). -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
   			<groupId>org.mockito</groupId>
   			<artifactId>mockito-core</artifactId>

--- a/nifi-pulsar-client-service/src/test/java/org/apache/nifi/pulsar/validator/PulsarBrokerUrlValidatorTest.java
+++ b/nifi-pulsar-client-service/src/test/java/org/apache/nifi/pulsar/validator/PulsarBrokerUrlValidatorTest.java
@@ -65,7 +65,7 @@ public class PulsarBrokerUrlValidatorTest {
 	public final void invalidHostPort() {
 		result = validator.validate("PulsarBrokerUrl", "pulsar://foobar", ctx);
 		assertFalse(result.isValid());
-		assertEquals("Must be in hostname:port form (no scheme such as http://", result.getExplanation());
+		assertEquals("Must be in hostname:port form (no scheme such as http://)", result.getExplanation());
 	}
 	
 	@Test

--- a/nifi-pulsar-processors/pom.xml
+++ b/nifi-pulsar-processors/pom.xml
@@ -133,7 +133,14 @@
              <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        
+        <!-- Runs the JUnit 4 tests on the JUnit Platform surefire (version
+             managed by the NiFi parent's org.junit:junit-bom import). -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
   			<groupId>org.mockito</groupId>
   			<artifactId>mockito-core</artifactId>

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -327,7 +327,7 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
 
         if (ctx.getProperty(BATCHING_ENABLED).asBoolean()) {
             config.put("batchingEnabled", Boolean.TRUE);
-            config.put("batchingMaxBytes", ctx.getProperty(BATCHING_MAX_BYTES).asDataSize(DataUnit.B).intValue());
+            config.put("batchingMaxBytes", ctx.getProperty(BATCHING_MAX_BYTES).evaluateAttributeExpressions().asDataSize(DataUnit.B).intValue());
             config.put("batchingMaxMessages", ctx.getProperty(BATCHING_MAX_MESSAGES).evaluateAttributeExpressions().asInteger());
             config.put("batchingMaxPublishDelayMicros", ctx.getProperty(BATCH_INTERVAL).evaluateAttributeExpressions()
                     .asTimePeriod(TimeUnit.MICROSECONDS).intValue());

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -231,11 +231,18 @@ public class PublisherLease implements Closeable {
 
     @Override
     public void close() {
+        // Always attempt to close the producer, even if flushing fails, to avoid leaking
+        // the underlying producer/connection resources when flush() throws.
         try {
             producer.flush();
-            producer.close();
         } catch (final PulsarClientException pcEx) {
             logger.error("Unable to close producer", pcEx);
+        } finally {
+            try {
+                producer.close();
+            } catch (final PulsarClientException pcEx) {
+                logger.error("Unable to close producer", pcEx);
+            }
         }
     }
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
@@ -19,7 +19,7 @@ package org.apache.nifi.processors.pulsar;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.pulsar.PulsarClientService;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarClientService;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -45,8 +45,10 @@ public class AbstractPulsarConsumerProcessorMessageAttributesTest {
     @Mock
     private MessageId mockMessageId;
 
-    @Mock
-    private PulsarClientService mockPulsarClientService;
+    // Use the concrete MockPulsarClientService (a real AbstractControllerService)
+    // rather than a bare Mockito interface mock, because TestRunner.addControllerService
+    // requires an actual ControllerService implementation.
+    private MockPulsarClientService<byte[]> mockPulsarClientService;
 
     private TestConsumerProcessor processor;
     private TestRunner testRunner;
@@ -56,7 +58,8 @@ public class AbstractPulsarConsumerProcessorMessageAttributesTest {
         MockitoAnnotations.openMocks(this);
         processor = new TestConsumerProcessor();
         testRunner = TestRunners.newTestRunner(processor);
-        
+        mockPulsarClientService = new MockPulsarClientService<>();
+
         // Set up minimal required properties
         testRunner.addControllerService("pulsar-client", mockPulsarClientService);
         testRunner.enableControllerService(mockPulsarClientService);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarMessageAttributesTest.java
@@ -242,25 +242,36 @@ public class ConsumePulsarMessageAttributesTest extends AbstractPulsarProcessorT
         // Run the processor
         runner.run(1);
 
-        // Verify FlowFiles were created (they should be batched into one since they have the same properties)
-        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
+        // The two messages carry different "sequence" property values, so they map to
+        // different FlowFile attribute sets. The consumer only concatenates consecutive
+        // messages that share identical mapped attributes into a single FlowFile;
+        // messages with differing attributes are emitted as separate FlowFiles.
+        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 2);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
-        MockFlowFile flowFile = flowFiles.get(0);
 
-        // Note: In batch processing, the attributes from the last message are used
-        // Verify the last message's attributes are present
-        assertEquals("Message ID should be from last message", messageId2, 
-                     flowFile.getAttribute("pulsar.message.id"));
-        assertEquals("Batch property should be present", "1", 
-                     flowFile.getAttribute("pulsar.property.batch"));
-        assertEquals("Sequence property should be from last message", "second", 
-                     flowFile.getAttribute("pulsar.property.sequence"));
+        MockFlowFile firstFlowFile = flowFiles.get(0);
+        MockFlowFile secondFlowFile = flowFiles.get(1);
 
-        // Verify content contains both messages (separated by default demarcator)
-        String expectedContent = "Message 1\nMessage 2";
-        flowFile.assertContentEquals(expectedContent);
-        
-        // Verify message count
-        assertEquals("Message count should be 2", "2", flowFile.getAttribute("message.count"));
+        // First FlowFile corresponds to the first message
+        assertEquals("First FlowFile message ID should match first message", messageId1,
+                     firstFlowFile.getAttribute("pulsar.message.id"));
+        assertEquals("First FlowFile batch property should be present", "1",
+                     firstFlowFile.getAttribute("pulsar.property.batch"));
+        assertEquals("First FlowFile sequence property should match first message", "first",
+                     firstFlowFile.getAttribute("pulsar.property.sequence"));
+        firstFlowFile.assertContentEquals("Message 1");
+        assertEquals("First FlowFile message count should be 1", "1",
+                     firstFlowFile.getAttribute("message.count"));
+
+        // Second FlowFile corresponds to the second message
+        assertEquals("Second FlowFile message ID should match second message", messageId2,
+                     secondFlowFile.getAttribute("pulsar.message.id"));
+        assertEquals("Second FlowFile batch property should be present", "1",
+                     secondFlowFile.getAttribute("pulsar.property.batch"));
+        assertEquals("Second FlowFile sequence property should match second message", "second",
+                     secondFlowFile.getAttribute("pulsar.property.sequence"));
+        secondFlowFile.assertContentEquals("Message 2");
+        assertEquals("Second FlowFile message count should be 1", "1",
+                     secondFlowFile.getAttribute("message.count"));
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordMessageAttributesTest.java
@@ -155,10 +155,14 @@ public class ConsumePulsarRecordMessageAttributesTest extends AbstractPulsarProc
         messageProperties.put("batch-id", "batch-001");
         messageProperties.put("processing-time", "2023-01-01T15:30:00Z");
         
-        String jsonData = "[{\"id\":1,\"name\":\"Alice\"},{\"id\":2,\"name\":\"Bob\"},{\"id\":3,\"name\":\"Charlie\"}]";
+        // MockRecordParser parses the message content line-by-line (one record per line),
+        // splitting each line on commas to populate the configured schema fields
+        // (id, name). To exercise multiple records in a single message, the content must
+        // contain three lines matching that schema.
+        String recordData = "1,Alice\n2,Bob\n3,Charlie";
         Message<GenericRecord> mockMessage = new MockPulsarMessage<>(
-            "test-topic", 
-            jsonData.getBytes(),
+            "test-topic",
+            recordData.getBytes(),
             testMessageId,
             messageProperties,
             "user-batch-key"

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
@@ -53,15 +53,24 @@ public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byt
     @Before
     public void setUp() throws InitializationException, Exception {
         MockitoAnnotations.openMocks(this);
-        
-        processor = new PublishPulsar();
+
+        // Override createPublisherPool so the mock PublisherPool is used even after the
+        // processor's @OnScheduled init() runs (which is invoked by runner.run() and would
+        // otherwise replace any reflection-injected pool with a real one).
+        processor = new PublishPulsar() {
+            @Override
+            protected PublisherPool createPublisherPool(final org.apache.nifi.processor.ProcessContext context) {
+                return mockPublisherPool;
+            }
+        };
         runner = TestRunners.newTestRunner(processor);
         addPulsarClientService();
-        
+
         runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "test-topic");
         runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
-        
-        // Use reflection to inject the mock PublisherPool
+
+        // Use reflection to inject the mock PublisherPool for tests that invoke
+        // obtainPublisherLease() directly (without going through runner.run()/@OnScheduled).
         injectMockPublisherPool();
     }
     
@@ -283,10 +292,11 @@ public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byt
         runner.enqueue("content1".getBytes());
         runner.enqueue("content2".getBytes());
         runner.enqueue("content3".getBytes());
-        
-        // Run the processor
-        runner.run(1);
-        
+
+        // Run a single trigger without stopping the processor, so the @OnUnscheduled
+        // lease cleanup does not run; this test verifies lease reuse during processing only.
+        runner.run(1, false);
+
         // Verify the lease was obtained only once and reused
         verify(mockPublisherPool, times(1)).obtainPublisher("test-topic");
         verify(mockLease1, times(3)).publish(any(), any(), any(), any(), any(), anyBoolean());
@@ -311,14 +321,15 @@ public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byt
         runner.enqueue("content1".getBytes(), java.util.Collections.singletonMap("topic.name", "topic1"));
         runner.enqueue("content2".getBytes(), java.util.Collections.singletonMap("topic.name", "topic2"));
         runner.enqueue("content3".getBytes(), java.util.Collections.singletonMap("topic.name", "topic1"));
-        
-        // Run the processor
-        runner.run(1);
-        
+
+        // Run a single trigger without stopping the processor, so the @OnUnscheduled
+        // lease cleanup does not run; this test verifies lease switching during processing only.
+        runner.run(1, false);
+
         // Verify leases were obtained for both topics
         verify(mockPublisherPool, times(2)).obtainPublisher("topic1"); // Called twice due to topic switch
         verify(mockPublisherPool, times(1)).obtainPublisher("topic2");
-        
+
         // Verify lease closure when switching topics
         verify(mockLease1, times(1)).close(); // Closed when switching to topic2
         verify(mockLease2, times(1)).close(); // Closed when switching back to topic1

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestPublishPulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestPublishPulsar.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import java.io.UnsupportedEncodingException;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -122,6 +124,15 @@ public class TestPublishPulsar extends AbstractPulsarProcessorTest<byte[]> {
         runner.enqueue(content);
         runner.run();
 
-        verify(mockClientService.getMockProducerBuilder(), times(1)).enableChunking(true);
+        // The producer is configured via ProducerBuilder.loadConf(configMap); when chunking
+        // is enabled the configuration map carries chunkingEnabled=true (see
+        // AbstractPulsarProducerProcessor.getPulsarProducerConfiguration and
+        // PublisherPool.createLease). Verify the producer is configured for chunking the way
+        // production actually applies it.
+        ArgumentCaptor<Map<String, Object>> configCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(mockClientService.getMockProducerBuilder(), times(1)).loadConf(configCaptor.capture());
+        Map<String, Object> capturedConfig = configCaptor.getValue();
+        assertEquals("Chunking should be enabled in the producer configuration",
+                Boolean.TRUE, capturedConfig.get("chunkingEnabled"));
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub.mocks;
 
+import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,11 +66,15 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
     @Mock
     PulsarAdmin mockAdmin = mock(PulsarAdmin.class);
 
+    // RETURNS_SELF makes every fluent builder method return the builder by
+    // default, so the mock survives Pulsar client API additions (e.g. the
+    // chunked-message methods in Pulsar 4.x) without enumerating each one.
+    // Explicit terminal stubs below (subscribe(), create()) still override.
     @Mock
-    ProducerBuilder<T> mockProducerBuilder = mock(ProducerBuilder.class);
+    ProducerBuilder<T> mockProducerBuilder = mock(ProducerBuilder.class, RETURNS_SELF);
 
     @Mock
-    ConsumerBuilder<GenericRecord> mockConsumerBuilder = mock(ConsumerBuilder.class);
+    ConsumerBuilder<GenericRecord> mockConsumerBuilder = mock(ConsumerBuilder.class, RETURNS_SELF);
 
     @Mock
     Producer<T> mockProducer = mock(Producer.class);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockRecordWriter.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockRecordWriter.java
@@ -149,7 +149,9 @@ public class MockRecordWriter extends AbstractControllerService implements Recor
 
             @Override
             public WriteResult finishRecordSet() throws IOException {
-                return (recordCount > 0) ? WriteResult.of(1, Collections.emptyMap()) : WriteResult.EMPTY;
+                // Report the actual number of records written so that the consumer's
+                // record.count attribute reflects every record, not a hardcoded 1.
+                return (recordCount > 0) ? WriteResult.of(recordCount, Collections.emptyMap()) : WriteResult.EMPTY;
             }
         };
     }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherLeaseTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherLeaseTest.java
@@ -348,7 +348,12 @@ public class PublisherLeaseTest {
         // Verify result
         assertNotNull("Result should not be null", result);
         assertFalse("Result should not be cancelled", result.isCancelled());
-        
+
+        // send() executes the producer interactions asynchronously via
+        // CompletableFuture.supplyAsync(...); block until the future completes before
+        // verifying, otherwise the verification races ahead of the async task.
+        result.join();
+
         verify(producer, times(1)).newMessage();
         verify(typedMessageBuilder, times(1)).properties(messageProperties);
         verify(typedMessageBuilder, times(1)).value("test-content".getBytes());
@@ -369,6 +374,12 @@ public class PublisherLeaseTest {
 
         // Verify result and interactions
         assertNotNull("Result should not be null", result);
+
+        // send() executes the producer interactions asynchronously via
+        // CompletableFuture.supplyAsync(...); block until the future completes before
+        // verifying, otherwise the verification races ahead of the async task.
+        result.join();
+
         verify(producer, times(1)).newMessage();
         verify(typedMessageBuilder, times(1)).properties(messageProperties);
         verify(typedMessageBuilder, times(1)).value("test-content".getBytes());


### PR DESCRIPTION
## Why
The ~31 JUnit 4 tests **never executed** — surefire runs on the JUnit Platform and there was no `junit-vintage-engine` on the classpath, so the `Build & Test (Java 21)` check was effectively *compile-only*. This adds the engine so tests actually run, then repairs the rot that surfaced. **Result: 166 tests, 0 failures, 0 errors.**

## Production bugs fixed (the dead tests should have caught these)
- **`AbstractPulsarProducerProcessor`**: `BATCHING_MAX_BYTES` declares Expression Language support but was read via `.asDataSize()` **without** `.evaluateAttributeExpressions()` (its sibling batching properties already evaluate). Now evaluates EL like the others.
- **`PublisherLease.close()`**: `producer.close()` sat in the same `try` as `producer.flush()`, so a failing flush **leaked the producer/connection**. `close()` now runs in a `finally`.

## Test / mock fixes (stale vs the Pulsar 4.2.2 API & current behavior)
- `MockPulsarClientService`: builder mocks use `RETURNS_SELF` so the fluent chain survives Pulsar client API additions (the 4.x chunked-message methods broke the old per-setter stubbing).
- `PulsarBrokerUrlValidatorTest`: match NiFi's actual message (trailing `)`).
- `AbstractPulsarConsumerProcessorMessageAttributesTest`: register the concrete `MockPulsarClientService` instead of a bare interface `@Mock`.
- `ConsumePulsarMessageAttributesTest`: assert one FlowFile per message (messages carry different mapped attributes) — strengthened with full per-FlowFile checks.
- `ConsumePulsarRecordMessageAttributesTest` + `MockRecordWriter`: multi-line content for the line-based parser; report the real record count.
- `TestPublishPulsar.chunkedMessageTest`: assert chunking via the `loadConf` map (how production configures it) using an `ArgumentCaptor`.
- `PublisherLeaseTest`: join the async send future before verifying; expect `close()` after a failing `flush()`.
- `PublishPulsarLeaseReuseTest`: override `createPublisherPool` so the mock pool survives `@OnScheduled`.

## Impact
`Build & Test (Java 21)` becomes a **real** test gate instead of compile-only — strengthening the auto-merge pipeline. Verified locally: `mvn test` → 166/0/0, BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)