### PR TITLE
fix: honour Consumer Message Batch Size in ConsumePulsar and ConsumePulsarRecord

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -281,7 +281,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .displayName("Consumer Message Batch Size")
             .description("Set the maximum number of messages consumed at a time, and published to a single FlowFile. "
                     + "default: 1000. If set to a value greater than 1, messages within the FlowFile will be seperated "
-                    + "by the Message Demarcator.")
+                    + "by the Message Demarcator. Consecutive messages are written to the same FlowFile as long as their "
+                    + "Mapped FlowFile Attributes are identical; a change in those attributes starts a new FlowFile before "
+                    + "the batch size is reached.")
             .required(false)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .defaultValue("1000")
@@ -294,7 +296,12 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .description("A comma-delimited list of FlowFile attributes to set based on message metadata (currently key and properties)."
                     + " Syntax for an individual mapping is <attribute name>[=<source property name or key>]."
                     + " To map the message key to an attribute, use the reserved name __KEY__ (ex. my-attribute=__KEY__ )."
-                    + " If the optional source name is omitted, it is assumed to be the same as the attribute.")
+                    + " If the optional source name is omitted, it is assumed to be the same as the attribute."
+                    + " These attributes also determine which messages may share a FlowFile: consecutive messages with"
+                    + " identical mapped values are batched together (up to the Consumer Message Batch Size), while a change"
+                    + " in any mapped value starts a new FlowFile. Message metadata that is not mapped here (message id,"
+                    + " message properties) is added to the FlowFile as 'pulsar.message.id*' / 'pulsar.property.*' attributes"
+                    + " but never splits a batch.")
             .required(false)
             .addValidator(Validator.VALID)
             .defaultValue("")
@@ -586,25 +593,27 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         this.consumers = consumers;
     }
 
+    /**
+     * Returns the attributes that decide whether a message may share a FlowFile with the previous one:
+     * the user-configured "Mapped FlowFile Attributes" only. Consecutive messages whose mapped values are
+     * identical are written to the same FlowFile (up to the Consumer Message Batch Size); a change in any
+     * mapped value closes the current FlowFile and starts a new one.
+     * <p>
+     * Per-message metadata such as the message id or the message properties is deliberately NOT part of
+     * this map: it changes with every message, so including it here would close the FlowFile after each
+     * message and defeat batching. That metadata is added to the FlowFile through
+     * {@link org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes}, with semantics that stay
+     * coherent when a FlowFile contains several messages.
+     *
+     * @param context - The Processor context
+     * @param msg - The message being consumed
+     * @return the mapped attribute values of the message (never null, possibly empty)
+     */
     protected Map<String, String> getMappedFlowFileAttributes(ProcessContext context, final Message<GenericRecord> msg) {
         String mappings = context.getProperty(MAPPED_FLOWFILE_ATTRIBUTES).getValue();
-        
-        Map<String, String> mappedAttributes = PropertyMappingUtils.getMappedValues(mappings,
+
+        return PropertyMappingUtils.getMappedValues(mappings,
         		(p) -> PULSAR_MESSAGE_KEY.equals(p) ? msg.getKey() : msg.getProperty(p));
-        
-        // Always add Pulsar Message ID with proper annotation
-        if (msg.getMessageId() != null) {
-            mappedAttributes.put("pulsar.message.id", msg.getMessageId().toString());
-        }
-        
-        // Always add all Pulsar message properties with proper annotation  
-        if (msg.getProperties() != null && !msg.getProperties().isEmpty()) {
-            for (Map.Entry<String, String> entry : msg.getProperties().entrySet()) {
-                mappedAttributes.put("pulsar.property." + entry.getKey(), entry.getValue());
-            }
-        }
-        
-        return mappedAttributes;
     }
     
     protected boolean isSharedSubscription(ProcessContext context) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -51,8 +52,14 @@ import org.apache.commons.io.IOUtils;
 @InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
 @WritesAttributes({
     @WritesAttribute(attribute = "message.count", description = "The number of messages received from Pulsar"),
-    @WritesAttribute(attribute = "pulsar.message.id", description = "The unique identifier of the Pulsar message"),
-    @WritesAttribute(attribute = "pulsar.property.*", description = "All properties from the Pulsar message, prefixed with 'pulsar.property.'")
+    @WritesAttribute(attribute = MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE,
+        description = "The unique identifier of the Pulsar message. Only set when the FlowFile contains exactly one message"),
+    @WritesAttribute(attribute = MessageBatchAttributes.FIRST_MESSAGE_ID_ATTRIBUTE,
+        description = "The identifier of the first Pulsar message written to the FlowFile"),
+    @WritesAttribute(attribute = MessageBatchAttributes.LAST_MESSAGE_ID_ATTRIBUTE,
+        description = "The identifier of the last Pulsar message written to the FlowFile"),
+    @WritesAttribute(attribute = "pulsar.property.*", description = "The properties of the Pulsar message(s), prefixed with 'pulsar.property.'. "
+        + "When the FlowFile contains several messages, only the properties whose value is identical in every message are set")
 })
 public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
@@ -103,6 +110,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     Map<String, String> lastAttributes = null;
                     Message<GenericRecord> lastMessage = null;
                     Map<String, String> currentAttributes = null;
+                    MessageBatchAttributes batchAttributes = null;
 
                     for (Message<GenericRecord> msg : messages) {
                         currentAttributes = getMappedFlowFileAttributes(context, msg);
@@ -111,6 +119,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             // mapped attributes changed, write the current flowfile and start a new one
                             IOUtils.closeQuietly(out);
 
+                            flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                             flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
                             session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                             session.transfer(flowFile, REL_SUCCESS);
@@ -135,6 +144,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         if (lastAttributes == null) {
                             flowFile = session.create();
                             flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                            batchAttributes = new MessageBatchAttributes();
 
                             out = session.write(flowFile);
                             msgCount.set(0);
@@ -142,6 +152,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
                         lastAttributes = currentAttributes;
                         lastMessage = msg;
+                        batchAttributes.add(msg);
  
                         if (shared) {
                         	// acknowledge each message individually for shared subs
@@ -174,6 +185,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
                     IOUtils.closeQuietly(out);
 
+                    flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                     flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
                     session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                     session.transfer(flowFile, REL_SUCCESS);
@@ -215,6 +227,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
             Map<String, String> lastAttributes = null;
             Map<String, String> currentAttributes = null;
+            MessageBatchAttributes batchAttributes = null;
 
             while (loopCounter.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
@@ -230,6 +243,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         session.remove(flowFile);
                         session.commitAsync();
                     } else {
+                        flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                         flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
                         session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                         session.transfer(flowFile, REL_SUCCESS);
@@ -244,6 +258,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 if (lastMsg == null) {
                     flowFile = session.create();
                     flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                    batchAttributes = new MessageBatchAttributes();
 
                     out = session.write(flowFile);
                     msgCount.set(0);
@@ -252,6 +267,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 try {
                     lastMsg = msg;
                     lastAttributes = currentAttributes;
+                    batchAttributes.add(msg);
                     loopCounter.incrementAndGet();
                     
                     if (shared) {
@@ -293,6 +309,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     session.commitAsync();
                 }
             } else {
+                flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                 flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
                 session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                 session.transfer(flowFile, REL_SUCCESS);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -48,6 +48,7 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.*;
 import org.apache.nifi.serialization.record.Record;
@@ -70,8 +71,14 @@ import org.apache.pulsar.common.schema.SchemaType;
 @Tags({"Pulsar", "Get", "Record", "csv", "avro", "json", "Ingest", "Ingress", "Topic", "PubSub", "Consume"})
 @WritesAttributes({
         @WritesAttribute(attribute = "record.count", description = "The number of records received"),
-        @WritesAttribute(attribute = "pulsar.message.id", description = "The unique identifier of the Pulsar message"),
-        @WritesAttribute(attribute = "pulsar.property.*", description = "All properties from the Pulsar message, prefixed with 'pulsar.property.'")
+        @WritesAttribute(attribute = MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE,
+            description = "The unique identifier of the Pulsar message. Only set when the FlowFile was built from exactly one message"),
+        @WritesAttribute(attribute = MessageBatchAttributes.FIRST_MESSAGE_ID_ATTRIBUTE,
+            description = "The identifier of the first Pulsar message written to the FlowFile"),
+        @WritesAttribute(attribute = MessageBatchAttributes.LAST_MESSAGE_ID_ATTRIBUTE,
+            description = "The identifier of the last Pulsar message written to the FlowFile"),
+        @WritesAttribute(attribute = "pulsar.property.*", description = "The properties of the Pulsar message(s), prefixed with 'pulsar.property.'. "
+            + "When the FlowFile contains several messages, only the properties whose value is identical in every message are set")
 })
 @InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
 @SeeAlso({PublishPulsar.class, ConsumePulsar.class, PublishPulsarRecord.class})
@@ -237,6 +244,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         Map<String, String> lastAttributes = null;
         Message<GenericRecord> lastMessage = null;
         Map<String, String> currentAttributes = null;
+        MessageBatchAttributes batchAttributes = null;
 
         // Cumulative acks are NOT permitted on Shared subscriptions
         final boolean shared = isSharedSubscription(context);
@@ -261,6 +269,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
                     if (result != WriteResult.EMPTY) {
                         flowFile = session.putAllAttributes(flowFile, result.getAttributes());
+                        flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                         flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
                         session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                         session.transfer(flowFile, REL_SUCCESS);
@@ -284,6 +293,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 if (lastMessage == null) {
                     flowFile = session.create();
                     flowFile = session.putAllAttributes(flowFile, currentAttributes);
+                    batchAttributes = new MessageBatchAttributes();
                     schema = getSchema(flowFile, readerFactory, data);
                     rawOut = session.write(flowFile);
                     writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);
@@ -301,6 +311,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
                 lastAttributes = currentAttributes;
                 lastMessage = msg;
+                batchAttributes.add(msg);
 
                 if (shared) {
                     acknowledge(consumer, msg, async);
@@ -327,6 +338,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
             if (result != WriteResult.EMPTY) {
                 flowFile = session.putAllAttributes(flowFile, result.getAttributes());
+                flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                 flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
                 session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                 session.transfer(flowFile, REL_SUCCESS);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/MessageBatchAttributes.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/MessageBatchAttributes.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.    See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.    You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+/**
+ * Accumulates the Pulsar metadata (message id, message properties) of the messages written into a
+ * single FlowFile and derives the FlowFile attributes that describe the whole batch.
+ *
+ * <p>This metadata is informational only. It is deliberately kept out of the comparison that decides
+ * whether a message may be appended to the FlowFile currently being written (the user-configured
+ * "Mapped FlowFile Attributes", see {@code AbstractPulsarConsumerProcessor#getMappedFlowFileAttributes}):
+ * a value such as the message id changes with every message, so including it in that comparison would
+ * close the FlowFile after each message and defeat "Consumer Message Batch Size".</p>
+ *
+ * <p>Attributes produced by {@link #toAttributes()}:</p>
+ * <ul>
+ *   <li>{@value #MESSAGE_ID_ATTRIBUTE}: set only when the FlowFile holds exactly one message (unchanged
+ *       behaviour for single-message FlowFiles). Omitted otherwise, because no single id describes a
+ *       batch of messages.</li>
+ *   <li>{@value #FIRST_MESSAGE_ID_ATTRIBUTE} / {@value #LAST_MESSAGE_ID_ATTRIBUTE}: ids of the first and
+ *       of the last message in the FlowFile, always set when the ids are available. The full list of ids
+ *       is intentionally never materialised as an attribute.</li>
+ *   <li>{@value #PROPERTY_ATTRIBUTE_PREFIX}{@code <name>}: every message property whose value is identical
+ *       for all messages in the FlowFile ("keep only common attributes", the same rule NiFi's MergeContent
+ *       applies). A single-message FlowFile therefore carries all of its properties. To force messages
+ *       with different values of a property into different FlowFiles, map that property through
+ *       "Mapped FlowFile Attributes".</li>
+ * </ul>
+ */
+public final class MessageBatchAttributes {
+
+    public static final String MESSAGE_ID_ATTRIBUTE = "pulsar.message.id";
+    public static final String FIRST_MESSAGE_ID_ATTRIBUTE = "pulsar.message.id.first";
+    public static final String LAST_MESSAGE_ID_ATTRIBUTE = "pulsar.message.id.last";
+    public static final String PROPERTY_ATTRIBUTE_PREFIX = "pulsar.property.";
+
+    private int messageCount;
+    private MessageId firstMessageId;
+    private MessageId lastMessageId;
+    private Map<String, String> commonProperties;
+
+    /**
+     * Records the metadata of a message that has been written into the FlowFile.
+     *
+     * @param message the message just appended to the FlowFile
+     */
+    public void add(final Message<?> message) {
+        final MessageId messageId = message.getMessageId();
+        final Map<String, String> properties = message.getProperties();
+
+        if (messageCount == 0) {
+            firstMessageId = messageId;
+            commonProperties = properties == null ? new HashMap<>() : new HashMap<>(properties);
+        } else {
+            // keep only the properties that carry the same value in every message of the batch
+            commonProperties.entrySet().removeIf(entry ->
+                    properties == null || !Objects.equals(entry.getValue(), properties.get(entry.getKey())));
+        }
+
+        lastMessageId = messageId;
+        messageCount++;
+    }
+
+    /**
+     * @return the number of messages recorded so far
+     */
+    public int getMessageCount() {
+        return messageCount;
+    }
+
+    /**
+     * @return the FlowFile attributes describing the messages recorded so far (empty if none)
+     */
+    public Map<String, String> toAttributes() {
+        final Map<String, String> attributes = new HashMap<>();
+
+        if (messageCount == 0) {
+            return attributes;
+        }
+
+        if (firstMessageId != null) {
+            if (messageCount == 1) {
+                attributes.put(MESSAGE_ID_ATTRIBUTE, firstMessageId.toString());
+            }
+            attributes.put(FIRST_MESSAGE_ID_ATTRIBUTE, firstMessageId.toString());
+        }
+
+        if (lastMessageId != null) {
+            attributes.put(LAST_MESSAGE_ID_ATTRIBUTE, lastMessageId.toString());
+        }
+
+        for (Map.Entry<String, String> entry : commonProperties.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                attributes.put(PROPERTY_ATTRIBUTE_PREFIX + entry.getKey(), entry.getValue());
+            }
+        }
+
+        return attributes;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
@@ -20,6 +20,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarClientService;
+import org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -35,8 +36,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+/**
+ * Verifies the contract of {@link AbstractPulsarConsumerProcessor#getMappedFlowFileAttributes}: its result is
+ * the set of attributes that decides whether consecutive messages may share a FlowFile, so it must contain the
+ * user-configured "Mapped FlowFile Attributes" only. Per-message metadata (message id, message properties) is
+ * published through {@link MessageBatchAttributes} instead and must never leak into this map; if it did, every
+ * message would start a new FlowFile and "Consumer Message Batch Size" would be defeated.
+ */
 public class AbstractPulsarConsumerProcessorMessageAttributesTest {
 
     @Mock
@@ -66,165 +75,90 @@ public class AbstractPulsarConsumerProcessorMessageAttributesTest {
         testRunner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
         testRunner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "test-topic");
         testRunner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "test-subscription");
+
+        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
+        when(mockMessageId.toString()).thenReturn("123:456:789");
+    }
+
+    private void givenMessageProperties(final Map<String, String> properties) {
+        when(mockMessage.getProperties()).thenReturn(properties);
+        when(mockMessage.getProperty(anyString())).thenAnswer(invocation -> properties.get(invocation.<String>getArgument(0)));
     }
 
     @Test
-    public void testMessageIdIsAddedToFlowFileAttributes() {
-        // Setup mock message with message ID
-        String expectedMessageId = "123:456:789";
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn(expectedMessageId);
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(new HashMap<>());
+    public void testMessageIdIsNotPartOfMappedAttributes() {
+        givenMessageProperties(new HashMap<>());
 
-        // Test the method
         Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
 
-        // Verify message ID is present
-        assertTrue("Message ID should be present in attributes", attributes.containsKey("pulsar.message.id"));
-        assertEquals("Message ID should match expected value", expectedMessageId, attributes.get("pulsar.message.id"));
+        assertFalse("The message id changes with every message and must not take part in the batch comparison",
+                attributes.containsKey(MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE));
+        assertTrue("Without mappings the batch key must be empty but was " + attributes, attributes.isEmpty());
     }
 
     @Test
-    public void testMessagePropertiesAreAddedToFlowFileAttributes() {
-        // Setup mock message with properties
+    public void testMessagePropertiesAreNotPartOfMappedAttributesUnlessMapped() {
         Map<String, String> messageProperties = new HashMap<>();
         messageProperties.put("source", "test-application");
         messageProperties.put("version", "1.2.3");
         messageProperties.put("environment", "production");
+        givenMessageProperties(messageProperties);
 
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn("test-id");
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(messageProperties);
-
-        // Test the method
         Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
 
-        // Verify all properties are present with proper prefix
-        assertTrue("Source property should be present", attributes.containsKey("pulsar.property.source"));
-        assertEquals("Source property should match", "test-application", attributes.get("pulsar.property.source"));
-
-        assertTrue("Version property should be present", attributes.containsKey("pulsar.property.version"));
-        assertEquals("Version property should match", "1.2.3", attributes.get("pulsar.property.version"));
-
-        assertTrue("Environment property should be present", attributes.containsKey("pulsar.property.environment"));
-        assertEquals("Environment property should match", "production", attributes.get("pulsar.property.environment"));
-    }
-
-    @Test
-    public void testNullMessageIdHandledGracefully() {
-        // Setup mock message with null message ID
-        when(mockMessage.getMessageId()).thenReturn(null);
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(new HashMap<>());
-
-        // Test the method
-        Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
-
-        // Verify no message ID is added when null
-        assertFalse("Message ID should not be present when null", attributes.containsKey("pulsar.message.id"));
-    }
-
-    @Test
-    public void testEmptyPropertiesHandledGracefully() {
-        // Setup mock message with empty properties
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn("test-id");
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(new HashMap<>());
-
-        // Test the method
-        Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
-
-        // Verify message ID is still present
-        assertTrue("Message ID should be present", attributes.containsKey("pulsar.message.id"));
-
-        // Verify no property attributes are added
-        for (String key : attributes.keySet()) {
-            assertFalse("No property attributes should be present with empty properties", 
-                       key.startsWith("pulsar.property."));
-        }
-    }
-
-    @Test
-    public void testNullPropertiesHandledGracefully() {
-        // Setup mock message with null properties
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn("test-id");
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(null);
-
-        // Test the method
-        Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
-
-        // Verify message ID is still present
-        assertTrue("Message ID should be present", attributes.containsKey("pulsar.message.id"));
-
-        // Verify no property attributes are added
-        for (String key : attributes.keySet()) {
-            assertFalse("No property attributes should be present with null properties", 
-                       key.startsWith("pulsar.property."));
-        }
+        assertTrue("Unmapped message properties must not take part in the batch comparison but found " + attributes,
+                attributes.isEmpty());
     }
 
     @Test
     public void testMessageKeyAndCustomMappingsStillWork() {
-        // Setup mock message with key and properties
-        String messageKey = "test-key";
         Map<String, String> messageProperties = new HashMap<>();
         messageProperties.put("custom-prop", "custom-value");
+        messageProperties.put("other-prop", "other-value");
+        givenMessageProperties(messageProperties);
+        when(mockMessage.getKey()).thenReturn("test-key");
 
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn("test-id");
-        when(mockMessage.getKey()).thenReturn(messageKey);
-        when(mockMessage.getProperties()).thenReturn(messageProperties);
-        when(mockMessage.getProperty("custom-prop")).thenReturn("custom-value");
-
-        // Set up custom mapping for the key
         testRunner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "message.key=__KEY__,custom.attr=custom-prop");
 
-        // Test the method
         Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
 
-        // Verify custom mappings still work
-        assertTrue("Custom message key mapping should work", attributes.containsKey("message.key"));
-        assertEquals("Message key should match", messageKey, attributes.get("message.key"));
-
-        assertTrue("Custom property mapping should work", attributes.containsKey("custom.attr"));
+        assertEquals("Only the configured mappings take part in the batch comparison: " + attributes, 2, attributes.size());
+        assertEquals("Message key should match", "test-key", attributes.get("message.key"));
         assertEquals("Custom property should match", "custom-value", attributes.get("custom.attr"));
-
-        // Verify new automatic attributes are also present
-        assertTrue("Message ID should be present", attributes.containsKey("pulsar.message.id"));
-        assertTrue("Property should be present with prefix", attributes.containsKey("pulsar.property.custom-prop"));
+        assertFalse(attributes.containsKey(MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE));
+        assertFalse(attributes.containsKey(MessageBatchAttributes.PROPERTY_ATTRIBUTE_PREFIX + "custom-prop"));
+        assertFalse(attributes.containsKey(MessageBatchAttributes.PROPERTY_ATTRIBUTE_PREFIX + "other-prop"));
     }
 
     @Test
-    public void testSpecialCharactersInPropertyNames() {
-        // Setup mock message with properties containing special characters
-        Map<String, String> messageProperties = new HashMap<>();
-        messageProperties.put("property-with-dashes", "value1");
-        messageProperties.put("property.with.dots", "value2");
-        messageProperties.put("property_with_underscores", "value3");
-        messageProperties.put("property with spaces", "value4");
+    public void testMappedAttributesOnlyDifferWhenMappedValuesDiffer() {
+        testRunner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "tenant");
 
-        when(mockMessage.getMessageId()).thenReturn(mockMessageId);
-        when(mockMessageId.toString()).thenReturn("test-id");
-        when(mockMessage.getKey()).thenReturn(null);
-        when(mockMessage.getProperties()).thenReturn(messageProperties);
+        Map<String, String> first = new HashMap<>();
+        first.put("tenant", "A");
+        first.put("trace-id", "trace-1");
+        givenMessageProperties(first);
+        when(mockMessageId.toString()).thenReturn("1:0:-1");
+        Map<String, String> firstAttributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
 
-        // Test the method
-        Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
+        // same tenant, different message id and a different unmapped property: compatible with the first message
+        Map<String, String> second = new HashMap<>();
+        second.put("tenant", "A");
+        second.put("trace-id", "trace-2");
+        givenMessageProperties(second);
+        when(mockMessageId.toString()).thenReturn("1:1:-1");
+        Map<String, String> secondAttributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
 
-        // Verify all properties are preserved with their original names
-        assertTrue("Property with dashes should be present", 
-                   attributes.containsKey("pulsar.property.property-with-dashes"));
-        assertTrue("Property with dots should be present", 
-                   attributes.containsKey("pulsar.property.property.with.dots"));
-        assertTrue("Property with underscores should be present", 
-                   attributes.containsKey("pulsar.property.property_with_underscores"));
-        assertTrue("Property with spaces should be present", 
-                   attributes.containsKey("pulsar.property.property with spaces"));
+        // different tenant: must start a new FlowFile
+        Map<String, String> third = new HashMap<>();
+        third.put("tenant", "B");
+        third.put("trace-id", "trace-2");
+        givenMessageProperties(third);
+        Map<String, String> thirdAttributes = processor.testGetMappedFlowFileAttributes(testRunner.getProcessContext(), mockMessage);
+
+        assertEquals(firstAttributes, secondAttributes);
+        assertNotEquals(secondAttributes, thirdAttributes);
+        assertEquals("B", thirdAttributes.get("tenant"));
     }
 
     // Test processor that extends AbstractPulsarConsumerProcessor for testing purposes

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarBatchingTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarBatchingTest.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.FIRST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.LAST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.PROPERTY_ATTRIBUTE_PREFIX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Regression tests for "Consumer Message Batch Size" on {@link ConsumePulsar}: a batch of compatible messages must
+ * end up in ONE FlowFile even though every Pulsar message carries a unique message id (and possibly unique
+ * properties). Before the fix the message id took part in the "may these messages share a FlowFile" comparison, so
+ * every message produced its own FlowFile regardless of the configured batch size.
+ * <p>
+ * Every scenario runs with {@code Async Enabled = false} and {@code = true}: both code paths implement the batching.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarBatchingTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/events";
+
+    @Parameters(name = "async={0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
+    private final boolean async;
+
+    public ConsumePulsarBatchingTest(final boolean async) {
+        this.async = async;
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        // Mapped FlowFile Attributes intentionally left at its (empty) default
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 1 & 4
+
+    @Test
+    public void tenMessagesWithUniqueMessageIdsProduceOneFlowFile() throws PulsarClientException {
+        mockClientService.setMockMessageQueue(messages(1, 10, null));
+
+        runner.run(1, true);
+
+        assertBatch(successFlowFiles(1).get(0), 1, 10);
+        // the loop stops on the batch-size counter, so receive() is not called an 11th time
+        verify(mockClientService.getMockConsumer(), times(10)).receive(0, TimeUnit.SECONDS);
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 2
+
+    @Test
+    public void partialBatchProducesOneFlowFileWithTheAvailableMessages() {
+        mockClientService.setMockMessageQueue(messages(1, 4, null));
+
+        runner.run(1, true);
+
+        assertBatch(successFlowFiles(1).get(0), 1, 4);
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 3
+
+    @Test
+    public void moreMessagesThanBatchSizeProduceOneFlowFilePerBatch() {
+        mockClientService.setMockMessageQueue(messages(1, 25, null));
+
+        runner.run(3, true);
+
+        List<MockFlowFile> flowFiles = successFlowFiles(3);
+        assertBatch(flowFiles.get(0), 1, 10);
+        assertBatch(flowFiles.get(1), 11, 20);
+        assertBatch(flowFiles.get(2), 21, 25);
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 4
+
+    @Test
+    public void uniquePerMessagePropertiesDoNotSplitTheBatch() {
+        List<Message<GenericRecord>> messages = new ArrayList<>();
+        for (int n = 1; n <= 10; n++) {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("source", "device-gateway");
+            properties.put("trace-id", "trace-" + n);
+            messages.add(message(n, properties, null));
+        }
+        mockClientService.setMockMessageQueue(messages);
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 1, 10);
+        // a property shared by every message of the batch is kept, a per-message one is not
+        flowFile.assertAttributeEquals(PROPERTY_ATTRIBUTE_PREFIX + "source", "device-gateway");
+        flowFile.assertAttributeNotExists(PROPERTY_ATTRIBUTE_PREFIX + "trace-id");
+    }
+
+    @Test
+    public void singleMessageFlowFileKeepsThePreviousAttributeContract() {
+        mockClientService.setMockMessageQueue(messages(7, 7, Collections.singletonMap("source", "device-gateway")));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 7, 7);
+        flowFile.assertAttributeEquals(MESSAGE_ID_ATTRIBUTE, messageId(7));
+        flowFile.assertAttributeEquals(PROPERTY_ATTRIBUTE_PREFIX + "source", "device-gateway");
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 5
+
+    @Test
+    public void identicalMappedAttributeKeepsMessagesInOneFlowFile() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "tenant");
+        mockClientService.setMockMessageQueue(messages(1, 3, Collections.singletonMap("tenant", "A")));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 1, 3);
+        flowFile.assertAttributeEquals("tenant", "A");
+        flowFile.assertAttributeEquals(PROPERTY_ATTRIBUTE_PREFIX + "tenant", "A");
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 6
+
+    @Test
+    public void changedMappedAttributeStartsANewFlowFile() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "tenant");
+        List<Message<GenericRecord>> messages = new ArrayList<>();
+        messages.addAll(messages(1, 2, Collections.singletonMap("tenant", "A")));
+        messages.addAll(messages(3, 4, Collections.singletonMap("tenant", "B")));
+        mockClientService.setMockMessageQueue(messages);
+
+        runner.run(1, true);
+
+        List<MockFlowFile> flowFiles = successFlowFiles(2);
+        assertBatch(flowFiles.get(0), 1, 2);
+        flowFiles.get(0).assertAttributeEquals("tenant", "A");
+        assertBatch(flowFiles.get(1), 3, 4);
+        flowFiles.get(1).assertAttributeEquals("tenant", "B");
+    }
+
+    // ------------------------------------------------------------------------------------------------ Test 7
+
+    @Test
+    public void newlineDemarcatorSeparatesMessagesWithoutTrailingDelimiter() {
+        mockClientService.setMockMessageQueue(Arrays.asList(
+                message(1, "message1"), message(2, "message2"), message(3, "message3")));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        flowFile.assertContentEquals("message1\nmessage2\nmessage3");
+        flowFile.assertAttributeEquals(ConsumePulsar.MSG_COUNT, "3");
+    }
+
+    @Test
+    public void customDemarcatorIsHonoured() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "|#|");
+        mockClientService.setMockMessageQueue(Arrays.asList(
+                message(1, "message1"), message(2, "message2"), message(3, "message3")));
+
+        runner.run(1, true);
+
+        successFlowFiles(1).get(0).assertContentEquals("message1|#|message2|#|message3");
+    }
+
+    // ------------------------------------------------------------------------------------------------ Shared subscription
+
+    @Test
+    public void sharedSubscriptionBatchesMessagesToo() throws PulsarClientException {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        mockClientService.setMockMessageQueue(messages(1, 10, null));
+
+        runner.run(1, true);
+
+        assertBatch(successFlowFiles(1).get(0), 1, 10);
+        // shared subscriptions acknowledge every message individually
+        if (async) {
+            verify(mockClientService.getMockConsumer(), times(10)).acknowledgeAsync(any(Message.class));
+        } else {
+            verify(mockClientService.getMockConsumer(), times(10)).acknowledge(any(Message.class));
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------------ helpers
+
+    /** Message id of the n-th message: "ledgerId:entryId:partitionIndex", as delivered by a partitioned topic. */
+    private static String messageId(final int n) {
+        return "1234:" + n + ":" + (n % 3);
+    }
+
+    private static Message<GenericRecord> message(final int n, final Map<String, String> properties, final String key) {
+        return new MockPulsarMessage<>(TOPIC + "-partition-" + (n % 3), ("{\"id\":" + n + "}").getBytes(UTF_8),
+                messageId(n), properties, key);
+    }
+
+    private static Message<GenericRecord> message(final int n, final String content) {
+        return new MockPulsarMessage<>(TOPIC + "-partition-" + (n % 3), content.getBytes(UTF_8), messageId(n), null, null);
+    }
+
+    private static List<Message<GenericRecord>> messages(final int first, final int last, final Map<String, String> properties) {
+        return IntStream.rangeClosed(first, last).mapToObj(n -> message(n, properties, null)).collect(Collectors.toList());
+    }
+
+    private List<MockFlowFile> successFlowFiles(final int expectedCount) {
+        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, expectedCount);
+        return runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
+    }
+
+    /** Asserts that the FlowFile holds exactly the messages first..last, in order, with coherent batch attributes. */
+    private static void assertBatch(final MockFlowFile flowFile, final int first, final int last) {
+        final int count = last - first + 1;
+
+        flowFile.assertAttributeEquals(ConsumePulsar.MSG_COUNT, String.valueOf(count));
+        flowFile.assertContentEquals(IntStream.rangeClosed(first, last)
+                .mapToObj(n -> "{\"id\":" + n + "}")
+                .collect(Collectors.joining("\n")));
+
+        flowFile.assertAttributeEquals(FIRST_MESSAGE_ID_ATTRIBUTE, messageId(first));
+        flowFile.assertAttributeEquals(LAST_MESSAGE_ID_ATTRIBUTE, messageId(last));
+        if (count == 1) {
+            flowFile.assertAttributeEquals(MESSAGE_ID_ATTRIBUTE, messageId(first));
+        } else {
+            flowFile.assertAttributeNotExists(MESSAGE_ID_ATTRIBUTE);
+        }
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarMessageAttributesTest.java
@@ -242,36 +242,26 @@ public class ConsumePulsarMessageAttributesTest extends AbstractPulsarProcessorT
         // Run the processor
         runner.run(1);
 
-        // The two messages carry different "sequence" property values, so they map to
-        // different FlowFile attribute sets. The consumer only concatenates consecutive
-        // messages that share identical mapped attributes into a single FlowFile;
-        // messages with differing attributes are emitted as separate FlowFiles.
-        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 2);
+        // The two messages have different ids and a different "sequence" property, but neither is a
+        // mapped attribute: per-message metadata must never split a batch. Both messages therefore land
+        // in ONE FlowFile (Consumer Message Batch Size = 2) whose metadata attributes describe the batch.
+        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
+        MockFlowFile flowFile = flowFiles.get(0);
 
-        MockFlowFile firstFlowFile = flowFiles.get(0);
-        MockFlowFile secondFlowFile = flowFiles.get(1);
+        flowFile.assertContentEquals("Message 1\nMessage 2");
+        assertEquals("Message count should be 2", "2", flowFile.getAttribute("message.count"));
 
-        // First FlowFile corresponds to the first message
-        assertEquals("First FlowFile message ID should match first message", messageId1,
-                     firstFlowFile.getAttribute("pulsar.message.id"));
-        assertEquals("First FlowFile batch property should be present", "1",
-                     firstFlowFile.getAttribute("pulsar.property.batch"));
-        assertEquals("First FlowFile sequence property should match first message", "first",
-                     firstFlowFile.getAttribute("pulsar.property.sequence"));
-        firstFlowFile.assertContentEquals("Message 1");
-        assertEquals("First FlowFile message count should be 1", "1",
-                     firstFlowFile.getAttribute("message.count"));
+        // No single message id describes a two-message FlowFile: only the first/last ids are published
+        flowFile.assertAttributeNotExists("pulsar.message.id");
+        assertEquals("First message id should be from the first message", messageId1,
+                     flowFile.getAttribute("pulsar.message.id.first"));
+        assertEquals("Last message id should be from the last message", messageId2,
+                     flowFile.getAttribute("pulsar.message.id.last"));
 
-        // Second FlowFile corresponds to the second message
-        assertEquals("Second FlowFile message ID should match second message", messageId2,
-                     secondFlowFile.getAttribute("pulsar.message.id"));
-        assertEquals("Second FlowFile batch property should be present", "1",
-                     secondFlowFile.getAttribute("pulsar.property.batch"));
-        assertEquals("Second FlowFile sequence property should match second message", "second",
-                     secondFlowFile.getAttribute("pulsar.property.sequence"));
-        secondFlowFile.assertContentEquals("Message 2");
-        assertEquals("Second FlowFile message count should be 1", "1",
-                     secondFlowFile.getAttribute("message.count"));
+        // Properties shared by every message in the batch are kept, the differing one is dropped
+        assertEquals("Common batch property should be present", "1",
+                     flowFile.getAttribute("pulsar.property.batch"));
+        flowFile.assertAttributeNotExists("pulsar.property.sequence");
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordBatchingTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordBatchingTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.FIRST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.LAST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.PROPERTY_ATTRIBUTE_PREFIX;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Regression tests for "Consumer Message Batch Size" on {@link ConsumePulsarRecord}, which shares the batching logic
+ * (and shared the bug) of {@link ConsumePulsar}: records from a batch of compatible messages must be written to ONE
+ * FlowFile even though every message carries a unique message id. Runs with Async Enabled = false and = true.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarRecordBatchingTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/records";
+
+    @Parameters(name = "async={0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
+    private final boolean async;
+
+    public ConsumePulsarRecordBatchingTest(final boolean async) {
+        this.async = async;
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockRecordParser readerService = new MockRecordParser();
+        readerService.addSchemaField("name", RecordFieldType.STRING);
+        readerService.addSchemaField("age", RecordFieldType.INT);
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        // in async mode the processor keeps polling its completion service for this long after the last batch
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, async ? "1 sec" : "0 sec");
+    }
+
+    @Test
+    public void tenMessagesWithUniqueMessageIdsProduceOneFlowFile() {
+        mockClientService.setMockMessageQueue(messages(1, 10, null));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 1, 10);
+        flowFile.assertAttributeEquals("topicName", TOPIC);
+    }
+
+    @Test
+    public void partialBatchProducesOneFlowFileWithTheAvailableRecords() {
+        mockClientService.setMockMessageQueue(messages(1, 4, null));
+
+        runner.run(1, true);
+
+        assertBatch(successFlowFiles(1).get(0), 1, 4);
+    }
+
+    @Test
+    public void moreMessagesThanBatchSizeProduceOneFlowFilePerBatch() {
+        mockClientService.setMockMessageQueue(messages(1, 25, null));
+
+        runner.run(3, true);
+
+        List<MockFlowFile> flowFiles = successFlowFiles(3);
+        assertBatch(flowFiles.get(0), 1, 10);
+        assertBatch(flowFiles.get(1), 11, 20);
+        assertBatch(flowFiles.get(2), 21, 25);
+    }
+
+    @Test
+    public void uniquePerMessagePropertiesDoNotSplitTheBatch() {
+        List<Message<GenericRecord>> messages = new ArrayList<>();
+        for (int n = 1; n <= 10; n++) {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("source", "crm");
+            properties.put("trace-id", "trace-" + n);
+            messages.add(message(n, properties));
+        }
+        mockClientService.setMockMessageQueue(messages);
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 1, 10);
+        flowFile.assertAttributeEquals(PROPERTY_ATTRIBUTE_PREFIX + "source", "crm");
+        flowFile.assertAttributeNotExists(PROPERTY_ATTRIBUTE_PREFIX + "trace-id");
+    }
+
+    @Test
+    public void singleMessageFlowFileKeepsThePreviousAttributeContract() {
+        mockClientService.setMockMessageQueue(messages(5, 5, Collections.singletonMap("source", "crm")));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 5, 5);
+        flowFile.assertAttributeEquals(MESSAGE_ID_ATTRIBUTE, messageId(5));
+        flowFile.assertAttributeEquals(PROPERTY_ATTRIBUTE_PREFIX + "source", "crm");
+    }
+
+    @Test
+    public void identicalMappedAttributeKeepsMessagesInOneFlowFile() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "tenant");
+        mockClientService.setMockMessageQueue(messages(1, 3, Collections.singletonMap("tenant", "A")));
+
+        runner.run(1, true);
+
+        MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertBatch(flowFile, 1, 3);
+        flowFile.assertAttributeEquals("tenant", "A");
+    }
+
+    @Test
+    public void changedMappedAttributeStartsANewFlowFile() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "tenant");
+        List<Message<GenericRecord>> messages = new ArrayList<>();
+        messages.addAll(messages(1, 2, Collections.singletonMap("tenant", "A")));
+        messages.addAll(messages(3, 4, Collections.singletonMap("tenant", "B")));
+        mockClientService.setMockMessageQueue(messages);
+
+        runner.run(1, true);
+
+        List<MockFlowFile> flowFiles = successFlowFiles(2);
+        assertBatch(flowFiles.get(0), 1, 2);
+        flowFiles.get(0).assertAttributeEquals("tenant", "A");
+        assertBatch(flowFiles.get(1), 3, 4);
+        flowFiles.get(1).assertAttributeEquals("tenant", "B");
+    }
+
+    // ------------------------------------------------------------------------------------------------ helpers
+
+    private static String messageId(final int n) {
+        return "5678:" + n + ":-1";
+    }
+
+    /** One CSV record per message, parsed by MockRecordParser as (name, age). */
+    private static Message<GenericRecord> message(final int n, final Map<String, String> properties) {
+        return new MockPulsarMessage<>(TOPIC, ("Name" + n + "," + n).getBytes(UTF_8), messageId(n), properties, null);
+    }
+
+    private static List<Message<GenericRecord>> messages(final int first, final int last, final Map<String, String> properties) {
+        return IntStream.rangeClosed(first, last).mapToObj(n -> message(n, properties)).collect(Collectors.toList());
+    }
+
+    private List<MockFlowFile> successFlowFiles(final int expectedCount) {
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, expectedCount);
+        return runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+    }
+
+    /** Asserts that the FlowFile holds exactly the records of messages first..last, in order, with coherent batch attributes. */
+    private static void assertBatch(final MockFlowFile flowFile, final int first, final int last) {
+        final int count = last - first + 1;
+
+        flowFile.assertAttributeEquals(ConsumePulsarRecord.MSG_COUNT, String.valueOf(count));
+        flowFile.assertContentEquals(IntStream.rangeClosed(first, last)
+                .mapToObj(n -> "\"Name" + n + "\",\"" + n + "\"\n")
+                .collect(Collectors.joining()));
+
+        flowFile.assertAttributeEquals(FIRST_MESSAGE_ID_ATTRIBUTE, messageId(first));
+        flowFile.assertAttributeEquals(LAST_MESSAGE_ID_ATTRIBUTE, messageId(last));
+        if (count == 1) {
+            flowFile.assertAttributeEquals(MESSAGE_ID_ATTRIBUTE, messageId(first));
+        } else {
+            flowFile.assertAttributeNotExists(MESSAGE_ID_ATTRIBUTE);
+        }
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -202,6 +203,26 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
         } catch (PulsarClientException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Queues the given messages for the consumer: {@code receive()}, {@code receive(0, SECONDS)} and
+     * {@code receiveAsync()} return them in order and then {@code null} once the queue is drained, which is
+     * how a real consumer behaves when its receiver queue is empty. Unlike {@link #setMockMessages(List)}
+     * the last message is not repeated forever, so tests can assert on exact batch sizes.
+     */
+    public void setMockMessageQueue(List<Message<GenericRecord>> messages) {
+        this.mockMessages = messages.toArray(new Message[]{});
+        final Queue<Message<GenericRecord>> queue = new ConcurrentLinkedQueue<>(messages);
+
+        try {
+            doAnswer(invocation -> queue.poll()).when(mockConsumer).receive();
+            doAnswer(invocation -> queue.poll()).when(mockConsumer).receive(0, TimeUnit.SECONDS);
+        } catch (PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
+
+        doAnswer(invocation -> CompletableFuture.completedFuture(queue.poll())).when(mockConsumer).receiveAsync();
     }
 
     public Producer<T> getMockProducer() {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/MessageBatchAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/MessageBatchAttributesTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.FIRST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.LAST_MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.MESSAGE_ID_ATTRIBUTE;
+import static org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes.PROPERTY_ATTRIBUTE_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Test;
+
+public class MessageBatchAttributesTest {
+
+    private static Message<GenericRecord> message(String messageId, Map<String, String> properties) {
+        return new MockPulsarMessage<>("test-topic", "payload".getBytes(), messageId, properties, null);
+    }
+
+    private static Map<String, String> properties(String... keyValues) {
+        Map<String, String> properties = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            properties.put(keyValues[i], keyValues[i + 1]);
+        }
+        return properties;
+    }
+
+    @Test
+    public void noMessagesYieldNoAttributes() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+
+        assertEquals(0, batch.getMessageCount());
+        assertTrue(batch.toAttributes().isEmpty());
+    }
+
+    @Test
+    public void singleMessageExposesItsIdAndAllOfItsProperties() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message("123:456:789", properties("source", "test-application", "version", "1.2.3")));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertEquals(1, batch.getMessageCount());
+        assertEquals("123:456:789", attributes.get(MESSAGE_ID_ATTRIBUTE));
+        assertEquals("123:456:789", attributes.get(FIRST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals("123:456:789", attributes.get(LAST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals("test-application", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "source"));
+        assertEquals("1.2.3", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "version"));
+        assertEquals(5, attributes.size());
+    }
+
+    @Test
+    public void multipleMessagesExposeFirstAndLastIdButNoSingleId() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message("1:0:2", null));
+        batch.add(message("1:1:2", null));
+        batch.add(message("1:2:2", null));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertEquals(3, batch.getMessageCount());
+        assertFalse("A multi-message FlowFile has no single message id", attributes.containsKey(MESSAGE_ID_ATTRIBUTE));
+        assertEquals("1:0:2", attributes.get(FIRST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals("1:2:2", attributes.get(LAST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals(2, attributes.size());
+    }
+
+    @Test
+    public void multipleMessagesKeepOnlyThePropertiesCommonToAllOfThem() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message("1:0:-1", properties("source", "app", "trace-id", "trace-1", "only-first", "x")));
+        batch.add(message("1:1:-1", properties("source", "app", "trace-id", "trace-2")));
+        batch.add(message("1:2:-1", properties("source", "app", "trace-id", "trace-3", "only-last", "y")));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertEquals("app", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "source"));
+        assertFalse("A property whose value differs between messages is not published", attributes.containsKey(PROPERTY_ATTRIBUTE_PREFIX + "trace-id"));
+        assertFalse("A property missing from some messages is not published", attributes.containsKey(PROPERTY_ATTRIBUTE_PREFIX + "only-first"));
+        assertFalse("A property missing from some messages is not published", attributes.containsKey(PROPERTY_ATTRIBUTE_PREFIX + "only-last"));
+    }
+
+    @Test
+    public void messageWithoutPropertiesClearsTheCommonProperties() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message("1:0:-1", properties("source", "app")));
+        batch.add(message("1:1:-1", null));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertFalse(attributes.containsKey(PROPERTY_ATTRIBUTE_PREFIX + "source"));
+        assertEquals("1:0:-1", attributes.get(FIRST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals("1:1:-1", attributes.get(LAST_MESSAGE_ID_ATTRIBUTE));
+    }
+
+    @Test
+    public void nullMessageIdIsHandledGracefully() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message(null, properties("source", "app")));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertFalse(attributes.containsKey(MESSAGE_ID_ATTRIBUTE));
+        assertFalse(attributes.containsKey(FIRST_MESSAGE_ID_ATTRIBUTE));
+        assertFalse(attributes.containsKey(LAST_MESSAGE_ID_ATTRIBUTE));
+        assertEquals("app", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "source"));
+    }
+
+    @Test
+    public void nullAndEmptyPropertiesAreHandledGracefully() {
+        MessageBatchAttributes nullProperties = new MessageBatchAttributes();
+        nullProperties.add(message("1:0:-1", null));
+
+        MessageBatchAttributes emptyProperties = new MessageBatchAttributes();
+        emptyProperties.add(message("1:0:-1", new HashMap<>()));
+
+        for (Map<String, String> attributes : new Map[] {nullProperties.toAttributes(), emptyProperties.toAttributes()}) {
+            assertEquals("1:0:-1", attributes.get(MESSAGE_ID_ATTRIBUTE));
+            for (String key : attributes.keySet()) {
+                assertFalse("No property attribute expected but found " + key, key.startsWith(PROPERTY_ATTRIBUTE_PREFIX));
+            }
+        }
+    }
+
+    @Test
+    public void specialCharactersInPropertyNamesArePreserved() {
+        MessageBatchAttributes batch = new MessageBatchAttributes();
+        batch.add(message("1:0:-1", properties(
+                "property-with-dashes", "value1",
+                "property.with.dots", "value2",
+                "property_with_underscores", "value3",
+                "property with spaces", "value4")));
+
+        Map<String, String> attributes = batch.toAttributes();
+
+        assertEquals("value1", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "property-with-dashes"));
+        assertEquals("value2", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "property.with.dots"));
+        assertEquals("value3", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "property_with_underscores"));
+        assertEquals("value4", attributes.get(PROPERTY_ATTRIBUTE_PREFIX + "property with spaces"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #140.

Since c15d96a (#67 / #92) `ConsumePulsar` and `ConsumePulsarRecord` emit one FlowFile per message regardless of **Consumer Message Batch Size**: `getMappedFlowFileAttributes()` returned the user-mapped attributes *plus* `pulsar.message.id` and `pulsar.property.*`, and all three consume loops compare that map between consecutive messages to decide whether to keep writing to the same FlowFile. The always-unique message id made the comparison fail for every message, so the effective batch size was 1.

### What changed

- `AbstractPulsarConsumerProcessor.getMappedFlowFileAttributes()` returns the user-configured *Mapped FlowFile Attributes* only (its original contract). They remain the only attributes that decide whether consecutive messages share a FlowFile, so `tenant=A,A,B,B → 2 FlowFiles` keeps working.
- New `utils/MessageBatchAttributes` accumulates the per-message metadata of one FlowFile and derives attributes that stay coherent when the FlowFile holds several messages:

| Attribute | FlowFile with 1 message | FlowFile with N > 1 messages |
|---|---|---|
| `pulsar.message.id` | id of the message (unchanged) | not set |
| `pulsar.message.id.first` / `pulsar.message.id.last` | id of the message | ids of the first / last message |
| `pulsar.property.<name>` | every message property | only the properties whose value is identical in all N messages (MergeContent's "keep only common attributes" rule) |

- `ConsumePulsar` (sync and async paths) and `ConsumePulsarRecord` share the accumulator (three lines per loop). `@WritesAttribute` docs and the *Consumer Message Batch Size* / *Mapped FlowFile Attributes* descriptions now state the batching rule.

### Tests

- `ConsumePulsarBatchingTest` and `ConsumePulsarRecordBatchingTest` (JUnit 4 `Parameterized` over `Async Enabled`): full, partial and multiple batches, unique message ids in the partitioned `ledger:entry:partition` format, unique per-message properties, mapped attributes equal / changing, demarcators, shared subscription.
- `MessageBatchAttributesTest`: attribute semantics (single vs. multiple messages, common properties, null ids/properties).
- `MockPulsarClientService.setMockMessageQueue()` returns `null` once drained, like a real consumer, so exact batch sizes can be asserted.
- Updated to the fixed contract: `AbstractPulsarConsumerProcessorMessageAttributesTest` (metadata must not be part of the batch key) and `ConsumePulsarMessageAttributesTest.testConsumePulsarWithMultipleMessages` (back to one FlowFile with `message.count = 2`, as the test was originally written before f8a15fb).

### Compatibility notes

- Single-message FlowFiles keep the previous attributes; `pulsar.message.id.first` / `.last` are additive.
- Multi-message FlowFiles no longer carry `pulsar.message.id` or per-message properties. To split FlowFiles on a property, map it through *Mapped FlowFile Attributes*.
- `ConsumePulsarRecord`: the Record Reader no longer sees `pulsar.message.id` / `pulsar.property.*` at reader-creation time (metadata is set when the batch is closed); mapped attributes, `topicName` and `avro.schema` are still set before the reader is created.
- Acknowledgement behaviour is unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `mvn clean package` succeeds locally with Java 21 (`mvn clean package -Dgpg.skip=true -pl '!docker-image'` on this branch: 228 tests, 0 failures)
- [x] Added or updated tests where it makes sense
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
