### PR TITLE
fix: run TestConsumePulsar.chunkedMessageConfigTest

### DIFF
--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -127,6 +127,7 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         verify(mockClientService.getMockConsumerBuilder(), times(1)).autoUpdatePartitionsInterval(120, TimeUnit.SECONDS);
     }
 
+    @Test
     public void chunkedMessageConfigTest() {
         when(mockMessage.getData()).thenReturn("Mocked Message".getBytes());
         mockClientService.setMockMessage(mockMessage);


### PR DESCRIPTION
Closes #143.

`chunkedMessageConfigTest()` was declared without `@Test`, so JUnit never ran it and the chunked-message consumer configuration went unverified.

Adding the annotation is the whole change — the method passes as written, covering `autoAckOldestChunkedMessageOnQueueFull`, `expireTimeOfIncompleteChunkedMessage` and `maxPendingChunkedMessage` on the consumer builder.

**Verification:** `TestConsumePulsar` now reports **11 tests instead of 10**, all passing. Full module suite green.