### PR TITLE
fix: batch partitioned-topic messages by logical topic in ConsumePulsarRecord

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaType;
 
 @CapabilityDescription("Consumes messages from Apache Pulsar. "
@@ -225,9 +226,13 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             return;
         }
 
+        // Group by the logical topic so that the partitions of one partitioned topic stay together, and
+        // collect into a LinkedHashMap so that the groups - and the messages within them - keep the order
+        // in which they were received rather than the hash order of the topic names.
         final List<Message<GenericRecord>> groupedMessages = messages
                 .stream()
-                .collect(Collectors.groupingBy(Message::getTopicName))
+                .collect(Collectors.groupingBy(msg -> getLogicalTopicName(msg.getTopicName()),
+                        LinkedHashMap::new, Collectors.toList()))
                 .values()
                 .stream()
                 .flatMap(List::stream)
@@ -254,7 +259,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
                 // Introduce an attribute to distinguish between current and previously captured attributes,
                 // particularly when the message originates from a different topic.
-                currentAttributes.put("topicName", msg.getTopicName());
+                currentAttributes.put("topicName", getLogicalTopicName(msg.getTopicName()));
                 // add the schema to the attributes in-case the schema is updated on the topic
                 if (msg.getReaderSchema().isPresent() && msg.getReaderSchema().get().getSchemaInfo().getType() == SchemaType.AVRO) {
                     currentAttributes.put("avro.schema", new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()));
@@ -354,6 +359,35 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
         if (!shared) {
             acknowledgeCumulative(consumer, messages.get(messages.size() - 1), async);
+        }
+    }
+
+    /**
+     * Returns the logical topic a message belongs to.
+     * <p>
+     * For a partitioned topic Pulsar reports the physical partition in {@link Message#getTopicName()}
+     * (<code>persistent://tenant/ns/topic-partition-N</code>). Every partition of a topic shares one schema,
+     * so they belong in the same record set; batching on the physical name instead splits each batch into one
+     * FlowFile per partition and reorders the messages.
+     * <p>
+     * Only the partitions of a partitioned topic are rewritten. Anything else - including a non-partitioned
+     * topic given as a short name - is returned exactly as the broker reported it, so the <code>topicName</code>
+     * attribute is unchanged for the non-partitioned case.
+     *
+     * @param topic the topic name reported for the message
+     * @return the logical (un-partitioned) topic name
+     */
+    static String getLogicalTopicName(final String topic) {
+        if (topic == null || topic.isEmpty()) {
+            return topic;
+        }
+
+        try {
+            final TopicName topicName = TopicName.get(topic);
+            return topicName.isPartitioned() ? topicName.getPartitionedTopicName() : topic;
+        } catch (final IllegalArgumentException e) {
+            // Not a well-formed Pulsar topic name: batch on the raw value rather than failing the flow.
+            return topic;
         }
     }
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordPartitionedTopicTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordPartitionedTopicTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for issue #141: on a partitioned topic {@code Message#getTopicName()} reports the physical
+ * partition, which used to be both the grouping key and part of the batch key. That split every batch into one
+ * FlowFile per partition and re-emitted the messages in the hash order of the partition names.
+ */
+public class ConsumePulsarRecordPartitionedTopicTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String LOGICAL_TOPIC = "persistent://public/default/events";
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockRecordParser readerService = new MockRecordParser();
+        readerService.addSchemaField("name", RecordFieldType.STRING);
+        readerService.addSchemaField("age", RecordFieldType.INT);
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, LOGICAL_TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "9");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+    }
+
+    /** The core of #141: 9 messages spread over 3 partitions of one topic must land in ONE FlowFile. */
+    @Test
+    public void messagesFromAllPartitionsOfOneTopicShareAFlowFile() {
+        final List<Message<GenericRecord>> messages = new ArrayList<>();
+        for (int n = 1; n <= 9; n++) {
+            // round-robin across 3 partitions, exactly as a partitioned consumer delivers them
+            messages.add(message(LOGICAL_TOPIC + "-partition-" + (n % 3), n));
+        }
+        mockClientService.setMockMessageQueue(messages);
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS).get(0);
+
+        assertEquals("9", flowFile.getAttribute(ConsumePulsarRecord.MSG_COUNT));
+        // receive order preserved, not partition-name hash order
+        flowFile.assertContentEquals(
+                "\"Name1\",\"1\"\n\"Name2\",\"2\"\n\"Name3\",\"3\"\n"
+                + "\"Name4\",\"4\"\n\"Name5\",\"5\"\n\"Name6\",\"6\"\n"
+                + "\"Name7\",\"7\"\n\"Name8\",\"8\"\n\"Name9\",\"9\"\n");
+        // the attribute reports the logical topic, not a physical partition
+        flowFile.assertAttributeEquals("topicName", LOGICAL_TOPIC);
+    }
+
+    /** Guard against over-correcting: genuinely different topics must still not share a record set. */
+    @Test
+    public void messagesFromDifferentTopicsStillGoToSeparateFlowFiles() {
+        mockClientService.setMockMessageQueue(java.util.Arrays.asList(
+                message("persistent://public/default/orders-partition-0", 1),
+                message("persistent://public/default/orders-partition-1", 2),
+                message("persistent://public/default/shipments-partition-0", 3),
+                message("persistent://public/default/shipments-partition-1", 4)));
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 2);
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+
+        flowFiles.get(0).assertAttributeEquals("topicName", "persistent://public/default/orders");
+        flowFiles.get(0).assertContentEquals("\"Name1\",\"1\"\n\"Name2\",\"2\"\n");
+        flowFiles.get(1).assertAttributeEquals("topicName", "persistent://public/default/shipments");
+        flowFiles.get(1).assertContentEquals("\"Name3\",\"3\"\n\"Name4\",\"4\"\n");
+    }
+
+    /** A non-partitioned topic must keep reporting exactly the name the broker gave us. */
+    @Test
+    public void nonPartitionedTopicNameIsUnchanged() {
+        mockClientService.setMockMessageQueue(java.util.Arrays.asList(
+                message(LOGICAL_TOPIC, 1), message(LOGICAL_TOPIC, 2)));
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 1);
+        runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS).get(0)
+                .assertAttributeEquals("topicName", LOGICAL_TOPIC);
+    }
+
+    // ------------------------------------------------------------------ getLogicalTopicName unit coverage
+
+    @Test
+    public void getLogicalTopicNameStripsThePartitionSuffix() {
+        assertEquals(LOGICAL_TOPIC, ConsumePulsarRecord.getLogicalTopicName(LOGICAL_TOPIC + "-partition-0"));
+        assertEquals(LOGICAL_TOPIC, ConsumePulsarRecord.getLogicalTopicName(LOGICAL_TOPIC + "-partition-42"));
+    }
+
+    @Test
+    public void getLogicalTopicNameLeavesEverythingElseAlone() {
+        // a non-partitioned topic keeps the exact string the broker reported, short form included
+        assertEquals(LOGICAL_TOPIC, ConsumePulsarRecord.getLogicalTopicName(LOGICAL_TOPIC));
+        assertEquals("foo", ConsumePulsarRecord.getLogicalTopicName("foo"));
+        // malformed / absent names must not blow up the flow
+        assertEquals("", ConsumePulsarRecord.getLogicalTopicName(""));
+        assertEquals(null, ConsumePulsarRecord.getLogicalTopicName(null));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** One CSV record per message, parsed by MockRecordParser as (name, age). */
+    private static Message<GenericRecord> message(final String topic, final int n) {
+        return new MockPulsarMessage<GenericRecord>(topic, ("Name" + n + "," + n).getBytes(UTF_8),
+                "1234:" + n + ":0", null, null);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -124,10 +124,12 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 4 + "");
         runner.run(1, true);
 
+        // The topics are emitted in the order their first message was received (foo, then bar), not in the
+        // hash order of the topic names - see issue #141.
         List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
-        successFlowFiles.get(0).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
+        successFlowFiles.get(0).assertContentEquals("\"A\",\"9\"\n\"G\",\"1\"\n".getBytes());
         successFlowFiles.get(0).assertAttributeNotExists("avro.schema");
-        successFlowFiles.get(1).assertContentEquals("\"A\",\"9\"\n\"G\",\"1\"\n".getBytes());
+        successFlowFiles.get(1).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
         successFlowFiles.get(1).assertAttributeNotExists("avro.schema");
         assertEquals(2, successFlowFiles.size());
     }
@@ -156,16 +158,18 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.setProperty(ConsumePulsarRecord.CONSUMER_BATCH_SIZE, 4 + "");
         runner.run(1, true);
 
+        // foo is emitted first (its message was received first); its schema change still splits its two
+        // messages into separate record sets. Group order follows receive order - see issue #141.
         List<MockFlowFile> successFlowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
-        successFlowFiles.get(0).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
+        successFlowFiles.get(0).assertContentEquals("\"A\",\"9\"\n".getBytes());
         successFlowFiles.get(0).assertAttributeExists("avro.schema");
         successFlowFiles.get(0).assertAttributeEquals("avro.schema", schema1);
-        successFlowFiles.get(1).assertContentEquals("\"A\",\"9\"\n".getBytes());
+        successFlowFiles.get(1).assertContentEquals("\"G\",\"1\"\n".getBytes());
         successFlowFiles.get(1).assertAttributeExists("avro.schema");
-        successFlowFiles.get(1).assertAttributeEquals("avro.schema", schema1);
-        successFlowFiles.get(2).assertContentEquals("\"G\",\"1\"\n".getBytes());
+        successFlowFiles.get(1).assertAttributeEquals("avro.schema", schema1_updated);
+        successFlowFiles.get(2).assertContentEquals("\"Z\",\"10\"\n\"F\",\"7\"\n".getBytes());
         successFlowFiles.get(2).assertAttributeExists("avro.schema");
-        successFlowFiles.get(2).assertAttributeEquals("avro.schema", schema1_updated);
+        successFlowFiles.get(2).assertAttributeEquals("avro.schema", schema1);
         assertEquals(3, successFlowFiles.size());
     }
 


### PR DESCRIPTION
Closes #141.

`consumeMessages()` grouped each batch with `Collectors.groupingBy(Message::getTopicName)` and put that same name into the batch key. On a partitioned topic `Message#getTopicName()` returns the physical partition, so one batch was split into one FlowFile per partition, emitted in the hash order of the partition names.

**Change**
- New `ConsumePulsarRecord#getLogicalTopicName()` strips the partition suffix via `TopicName#getPartitionedTopicName()`, used for both the grouping key and the `topicName` attribute.
- Only partitions of a partitioned topic are rewritten. A non-partitioned topic keeps the exact name the broker reported, so `topicName` is unchanged for that case — `TopicName.get()` would otherwise normalise a short name like `foo` into `persistent://public/default/foo`. A blank or malformed name falls back to the raw value rather than throwing.
- Grouping collects into a `LinkedHashMap`, so groups and the messages inside them keep receive order.

**Verification**
New `ConsumePulsarRecordPartitionedTopicTest` (5 tests). Without the production change the two batching tests fail with **3 and 4 FlowFiles instead of 1 and 2**.

⚠️ **Two existing tests were updated, please review that specifically.** `multipleGoodMessagesOnTwoTopicsCreatesMultipleRecordsTest` and `multipleGoodMessagesWithSchemaUpdateOnTwoTopicsTest` asserted the old `HashMap` hash order (topic `bar` before `foo`). They now assert receive order (`foo` first). The content of each FlowFile is unchanged — only which FlowFile comes first. This is bug #2 in the issue, so the old expectations encoded the bug.

Full module suite green: 210 tests.