### PR TITLE
fix: do not throw out of ConsumePulsarRecord when no record set is opened

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -266,6 +266,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                     WriteResult result = writer.finishRecordSet();
                     IOUtils.closeQuietly(writer);
                     IOUtils.closeQuietly(rawOut);
+                    writer = null;
+                    rawOut = null;
 
                     if (result != WriteResult.EMPTY) {
                         flowFile = session.putAllAttributes(flowFile, result.getAttributes());
@@ -300,8 +302,14 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
                     if (schema == null || writer == null) {
                         parseFailures.add(msg);
-                        session.remove(flowFile);
+                        // the OutputStream has to be closed before the FlowFile can be removed, otherwise
+                        // the session rejects the removal with an IllegalStateException
+                        IOUtils.closeQuietly(writer);
                         IOUtils.closeQuietly(rawOut);
+                        session.remove(flowFile);
+                        // no record set is open now: keep the invariant that writer != null means "open"
+                        writer = null;
+                        rawOut = null;
                         getLogger().error("Unable to create a record writer to consume from the Pulsar topic");
                         continue;
                     }
@@ -332,7 +340,11 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 }
             }
 
-            WriteResult result = writer.finishRecordSet();
+            // writer is null when no record set is open: every message in this batch failed to produce a
+            // schema or a writer (each one hit the 'continue' above and went to parseFailures), or the last
+            // record set was already finished when the mapped attributes changed. There is nothing to
+            // finish in that case - the parse failures are routed below.
+            WriteResult result = writer == null ? WriteResult.EMPTY : writer.finishRecordSet();
             IOUtils.closeQuietly(writer);
             IOUtils.closeQuietly(rawOut);
 
@@ -342,7 +354,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 flowFile = session.putAttribute(flowFile, MSG_COUNT, result.getRecordCount() + "");
                 session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                 session.transfer(flowFile, REL_SUCCESS);
-            } else {
+            } else if (writer != null) {
                 // We were able to parse the records, but unable to write them to the FlowFile
                 session.rollback();
             }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordNoRecordSetTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordNoRecordSetTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockFailingRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * When no record set is ever opened - every message in the batch fails to resolve a schema, so each one
+ * takes the parse-failure path - ConsumePulsarRecord used to call finishRecordSet() on a null writer and
+ * throw a NullPointerException out of onTrigger, losing the whole session (and with it the parse failures)
+ * even though the messages had already been acknowledged.
+ */
+public class ConsumePulsarRecordNoRecordSetTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/events";
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockFailingRecordParser readerService = new MockFailingRecordParser();
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "3");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+    }
+
+    @Test
+    public void everyMessageFailingToResolveASchemaDoesNotThrow() {
+        mockClientService.setMockMessageQueue(messages(3));
+
+        // Before the fix this threw NullPointerException out of onTrigger.
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
+        // the messages are not silently dropped: they are routed for inspection
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
+        assertTrue("the unparseable payloads should reach the parse_failure relationship",
+                new String(runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_PARSE_FAILURE)
+                        .get(0).toByteArray(), UTF_8).contains("Name1"));
+    }
+
+    @Test
+    public void aSingleUnparseableMessageDoesNotThrow() {
+        mockClientService.setMockMessageQueue(messages(1));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
+    }
+
+    private static List<Message<GenericRecord>> messages(final int count) {
+        final Message<GenericRecord>[] msgs = new Message[count];
+        for (int n = 1; n <= count; n++) {
+            msgs[n - 1] = new MockPulsarMessage<GenericRecord>(TOPIC, ("Name" + n + "," + n).getBytes(UTF_8),
+                    "1234:" + n + ":0", null, null);
+        }
+        return Arrays.asList(msgs);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockFailingRecordParser.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockFailingRecordParser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub.mocks;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.serialization.RecordReader;
+import org.apache.nifi.serialization.RecordReaderFactory;
+
+/**
+ * A {@link RecordReaderFactory} that never manages to resolve a schema. It makes
+ * {@code ConsumePulsarRecord#getSchema()} return null for every message, which sends each message to
+ * the parse-failure path without ever opening a record set.
+ */
+public class MockFailingRecordParser extends AbstractControllerService implements RecordReaderFactory {
+
+    @Override
+    public RecordReader createRecordReader(Map<String, String> variables, InputStream in, long inputLength,
+                                           ComponentLog logger) throws SchemaNotFoundException {
+        throw new SchemaNotFoundException("Intentional Unit Test Exception: no schema could be resolved");
+    }
+}


### PR DESCRIPTION
Closes #146.

**Change**
- Close the `OutputStream` before removing the FlowFile, so the session accepts the removal.
- Guard the trailing `finishRecordSet()`; the matching `session.rollback()` now only runs when a record set actually existed, instead of discarding the parse failures.
- Set `writer`/`rawOut` to null wherever a record set is closed or abandoned, so `writer != null` reliably means "a record set is open".

**Verification**
New `ConsumePulsarRecordNoRecordSetTest` covers a full batch and a single unparseable message. Both fail on `main` with `IllegalStateException`. Full module suite green: 207 tests.