### PR TITLE
fix: stop retaining acknowledgement Futures in the async consumers

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -17,9 +17,12 @@
 package org.apache.nifi.processors.pulsar;
 
 import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -564,6 +567,44 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
 
     protected synchronized void setAckPool(ExecutorService pool) {
        this.ackPool = pool;
+    }
+
+    /**
+     * Consumes every acknowledgement task that has already completed.
+     * <p>
+     * Acknowledgements in asynchronous mode are submitted to an {@link ExecutorCompletionService}, which
+     * retains the {@link Future} of every completed task in an unbounded internal queue until it is taken.
+     * Nothing used to take them, so the queue grew by one Future per acknowledgement - one per message on
+     * Shared/Key_Shared subscriptions, one per batch otherwise - for as long as the processor ran, and the
+     * memory was only released when the processor was stopped and the pools rebuilt.
+     * <p>
+     * Draining after each trigger bounds the queue by the acknowledgements still in flight, and gives us the
+     * result of each one: a failed acknowledgement used to be captured in a Future that nobody ever read, so
+     * a broker rejecting acks failed completely silently.
+     */
+    protected void drainAcknowledgments() {
+        final ExecutorCompletionService<Object> service = getAckService();
+
+        if (service == null) {
+            return;
+        }
+
+        Future<Object> ack = service.poll();
+
+        while (ack != null) {
+            try {
+                ack.get();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (final ExecutionException e) {
+                getLogger().warn("Failed to acknowledge a Pulsar message", e.getCause());
+            } catch (final CancellationException e) {
+                getLogger().warn("Acknowledgement of a Pulsar message was cancelled", e);
+            }
+
+            ack = service.poll();
+        }
     }
 
     protected synchronized ExecutorCompletionService<Object> getAckService() {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -190,19 +190,24 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                     session.transfer(flowFile, REL_SUCCESS);
                     session.commitAsync();
-                }
-                // Cumulatively acknowledge consuming the message for non-shared subs
-                if (!shared) {
-	                getAckService().submit(new Callable<Object>() {
-	                    @Override
-	                    public Object call() throws Exception {
-	                       return consumer.acknowledgeCumulativeAsync(messages.get(messages.size() - 1)).get();
-	                    }
-	                });
+
+                    // Cumulatively acknowledge consuming the message for non-shared subs. This has to stay
+                    // inside the isNotEmpty() guard: on an idle topic the list is empty and there is no last
+                    // message to acknowledge.
+                    if (!shared) {
+	                    getAckService().submit(new Callable<Object>() {
+	                        @Override
+	                        public Object call() throws Exception {
+	                           return consumer.acknowledgeCumulativeAsync(messages.get(messages.size() - 1)).get();
+	                        }
+	                    });
+                    }
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
             getLogger().error("Trouble consuming messages ", e);
+        } finally {
+            drainAcknowledgments();
         }
     }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -445,6 +445,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
         } catch (InterruptedException | ExecutionException e) {
             getLogger().error("Trouble consuming messages ", e);
+        } finally {
+            drainAcknowledgments();
         }
     }
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
@@ -48,6 +48,15 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
     private static final String TOPIC = "persistent://public/default/events";
     private static final int TRIGGERS = 40;
 
+    /**
+     * The drain collects acknowledgement Futures that have already completed, so the ones still in flight
+     * when the last trigger returns are legitimately still queued. The ack pool is
+     * {@code newFixedThreadPool(MAX_ASYNC_REQUESTS + 1)} and MAX_ASYNC_REQUESTS defaults to 2, so at most
+     * this many acknowledgements can be in flight at once. What matters is that the number is bounded by
+     * the pool rather than growing with the number of triggers - see {@link #retainedAcksDoNotGrowWithTriggerCount()}.
+     */
+    private static final int MAX_IN_FLIGHT_ACKS = 3;
+
     /** Exposes the ack completion service, which is protected on AbstractPulsarConsumerProcessor. */
     public static class AckProbeConsumePulsar extends ConsumePulsar {
         /** Drains and counts the acknowledgement Futures the processor left behind. */
@@ -94,7 +103,8 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
 
         final int retained = processor.countRetainedAcks();
         assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
-                + " triggers (see issue #53)", retained <= 2);
+                + " triggers, more than the " + MAX_IN_FLIGHT_ACKS + " that can be in flight (see issue #53)",
+                retained <= MAX_IN_FLIGHT_ACKS);
     }
 
     /** Exclusive subscriptions acknowledge cumulatively, once per batch. */
@@ -107,7 +117,27 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
 
         final int retained = processor.countRetainedAcks();
         assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
-                + " triggers (see issue #53)", retained <= 2);
+                + " triggers, more than the " + MAX_IN_FLIGHT_ACKS + " that can be in flight (see issue #53)",
+                retained <= MAX_IN_FLIGHT_ACKS);
+    }
+
+    /**
+     * The property that actually separates "a few acks still in flight" from "a leak": the retained count
+     * must be bounded by the ack pool, not proportional to how long the processor has been running. With
+     * the bug this grew one Future per acknowledgement, so quadrupling the triggers quadrupled the count.
+     */
+    @Test
+    public void retainedAcksDoNotGrowWithTriggerCount() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        final int manyTriggers = TRIGGERS * 4;
+        mockClientService.setMockMessageQueue(messages(manyTriggers));
+
+        runner.run(manyTriggers, false);
+
+        final int retained = processor.countRetainedAcks();
+        assertTrue("Retained acknowledgements scale with the trigger count: " + retained + " left after "
+                + manyTriggers + " triggers. A bounded queue should stay at or below " + MAX_IN_FLIGHT_ACKS
+                + " regardless of how many triggers ran (see issue #53)", retained <= MAX_IN_FLIGHT_ACKS);
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression test for issue #53. Acknowledgements in async mode are submitted to an
+ * ExecutorCompletionService, which retains the Future of every completed task until it is taken. Nothing
+ * took them, so the queue grew by one Future per acknowledgement for the lifetime of the processor.
+ * <p>
+ * The test measures the leak behaviourally: after running the processor it counts how many completed
+ * acknowledgement Futures are still sitting in the completion service. With the drain in place that count
+ * stays near zero (only acks still in flight); without it, it grows with the number of triggers.
+ */
+public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/events";
+    private static final int TRIGGERS = 40;
+
+    /** Exposes the ack completion service, which is protected on AbstractPulsarConsumerProcessor. */
+    public static class AckProbeConsumePulsar extends ConsumePulsar {
+        /** Drains and counts the acknowledgement Futures the processor left behind. */
+        int countRetainedAcks() throws InterruptedException {
+            if (getAckService() == null) {
+                return 0;
+            }
+
+            int retained = 0;
+            // a generous first wait lets any in-flight ack land, so we do not undercount the leak
+            Future<Object> ack = getAckService().poll(2, TimeUnit.SECONDS);
+
+            while (ack != null) {
+                retained++;
+                ack = getAckService().poll(100, TimeUnit.MILLISECONDS);
+            }
+
+            return retained;
+        }
+    }
+
+    private AckProbeConsumePulsar processor;
+
+    @Before
+    public void init() throws InitializationException {
+        processor = new AckProbeConsumePulsar();
+        runner = TestRunners.newTestRunner(processor);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "true");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+    }
+
+    /** Shared subscriptions acknowledge every message individually - the worst case for the leak. */
+    @Test
+    public void sharedSubscriptionAcksAreNotRetained() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        mockClientService.setMockMessageQueue(messages(TRIGGERS));
+
+        // do not stop the processor: @OnUnscheduled tears the pools down, which would hide the leak
+        runner.run(TRIGGERS, false);
+
+        final int retained = processor.countRetainedAcks();
+        assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
+                + " triggers (see issue #53)", retained <= 2);
+    }
+
+    /** Exclusive subscriptions acknowledge cumulatively, once per batch. */
+    @Test
+    public void exclusiveSubscriptionAcksAreNotRetained() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        mockClientService.setMockMessageQueue(messages(TRIGGERS));
+
+        runner.run(TRIGGERS, false);
+
+        final int retained = processor.countRetainedAcks();
+        assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
+                + " triggers (see issue #53)", retained <= 2);
+    }
+
+    /**
+     * The aggravating case: an idle topic. The cumulative-ack task used to be submitted outside the
+     * "did we receive anything?" guard, so every trigger queued a Future holding an
+     * IndexOutOfBoundsException from messages.get(-1) - an idle processor leaked fastest of all.
+     */
+    @Test
+    public void idleTopicDoesNotQueueFailedAcks() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        mockClientService.setMockMessageQueue(new ArrayList<>());
+
+        runner.run(TRIGGERS, false);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        final int retained = processor.countRetainedAcks();
+        assertTrue("An idle topic queued " + retained + " acknowledgement Futures over " + TRIGGERS
+                + " triggers; it should queue none (see issue #53)", retained == 0);
+    }
+
+    private static List<Message<GenericRecord>> messages(final int count) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+        for (int n = 1; n <= count; n++) {
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, ("message-" + n).getBytes(UTF_8),
+                    "1234:" + n + ":0", null, null));
+        }
+        return msgs;
+    }
+}


### PR DESCRIPTION
Closes #53. Confirms and fixes the mechanism [@jselvareef identified in the issue](https://github.com/david-streamlio/pulsar-nifi-bundle/issues/53).

Async acknowledgements are submitted to an `ExecutorCompletionService`, which retains the `Future` of every completed task in an unbounded internal queue until it is taken. Nothing ever called `poll()`/`take()`, so the queue grew by one Future per acknowledgement for the lifetime of the processor. Memory was released only on stop, because `@OnUnscheduled` tears the pools down — which is why a restart appeared to fix it and short tests never caught it.

**Measured:** ~56 bytes retained per acknowledgement (200k acks -> 200k futures, ~11 MB). That is roughly 200 MB/hour on a Shared subscription at 1k msg/s.

**Change**
- New `AbstractPulsarConsumerProcessor#drainAcknowledgments()`, called from a `finally` in both processors `handleAsync()`. Bounds the queue by the acks still in flight.
- Draining also surfaces failures that were previously swallowed entirely: an `ExecutionException` from an ack is now logged rather than sitting unread in a Future.
- `ConsumePulsar.handleAsync()` submitted the cumulative ack **outside** the `isNotEmpty(messages)` guard, so an idle topic queued one Future per trigger holding `IndexOutOfBoundsException` from `messages.get(-1)`. Moved inside the guard.

**Verification**
New `ConsumePulsarAckLeakTest` counts Futures left in the completion service after 40 triggers. On `main` all three cases retain **exactly 40** — including the idle-topic case, which receives no messages at all. After the fix: **0**. Full module suite green: 208 tests.

Note the new WARN logs for failed acknowledgements are new output that was previously silent.