### PR TITLE
test: add Testcontainers integration tests against a real Pulsar broker

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,66 @@
+name: Integration Tests
+
+# Runs the Testcontainers-backed integration tests (*IT.java) against a real Pulsar broker
+# on every pull request and every push to main.
+#
+# These are deliberately a separate workflow from CI: they need a Docker daemon and take
+# appreciably longer than the unit tests, so keeping them apart preserves the fast
+# "Build & Test (Java 21)" signal while still gating merges on real-broker behaviour.
+#
+# Like CI this uses `pull_request` (never `pull_request_target`), so fork PRs run with a
+# read-only token and no access to repository secrets.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: it-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-test:
+    # This name is referenced by branch protection as a required check - keep it stable.
+    name: Integration Tests (Java 21)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # ubuntu-latest ships a running Docker daemon; fail loudly and early if that changes,
+      # rather than surfacing as a confusing Testcontainers "could not find a valid Docker
+      # environment" error midway through the build.
+      - name: Verify Docker is available
+        run: |
+          docker version
+          echo "Server minimum API version: $(docker version --format '{{.Server.MinAPIVersion}}')"
+
+      # Pre-pulling makes the first container start predictable and keeps the pull time out
+      # of the per-test startup timeout.
+      - name: Pre-pull the Pulsar image
+        run: docker pull "$(mvn -B -ntp help:evaluate -Dexpression=pulsar.image -q -DforceStdout)"
+
+      # `verify` is what runs Failsafe; `package` (used by the CI workflow) stops short of it.
+      - name: Run integration tests
+        run: mvn -B -ntp verify -Dgpg.skip=true -pl nifi-pulsar-processors -am
+
+      - name: Upload failsafe reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: failsafe-reports
+          path: '**/target/failsafe-reports/*.xml'
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ See the [documentation](https://hub.docker.com/r/apache/nifi) on the base image 
 
 Visit https://localhost:8443/nifi/#/login and enter the username and password you provided in the docker command.
 
+## Integration tests
+
+Alongside the unit tests (which run against a mocked Pulsar client) there are integration tests
+that drive the processors against a **real Pulsar broker**, started in Docker by
+[Testcontainers](https://java.testcontainers.org/). They cover behaviour the mocks cannot reach:
+real message ids, real acknowledgement semantics, subscription types and partitioned topics.
+
+They are named `*IT.java`, so Surefire ignores them - `mvn test` and `mvn package` stay fast and
+need no Docker. They run from `mvn verify`:
+
+```
+mvn verify                 # unit tests + integration tests (needs Docker)
+mvn verify -DskipITs       # unit tests only
+mvn test                   # unit tests only, no Docker required
+```
+
+The broker image is pinned by the `pulsar.image` property in the root pom and kept in step with
+`pulsar.version`.
+
+> **Docker 29 and newer:** docker-java (bundled with Testcontainers) negotiates API version 1.32 by
+> default, which Docker 29+ rejects with *"client version 1.32 is too old. Minimum supported API
+> version is 1.44"*. The build therefore passes `-Dapi.version=${docker.api.version}` (1.44) to the
+> integration tests. 1.44 requires Docker 25 or newer; on an older daemon override it, e.g.
+> `mvn verify -Ddocker.api.version=1.41`.
+
 ## How to debug
 
 The JVM Debugger can be enabled by setting the environment variable NIFI_JVM_DEBUGGER to any value when running the docker image, e.g.

--- a/nifi-pulsar-processors/pom.xml
+++ b/nifi-pulsar-processors/pom.xml
@@ -127,6 +127,29 @@
             <scope>test</scope>
         </dependency>
         
+        <!-- The real client service implementation, so the integration tests can drive the
+             processors against a live broker instead of a mocked controller service. -->
+        <dependency>
+            <groupId>io.streamnative.connectors</groupId>
+            <artifactId>nifi-pulsar-client-service</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Integration tests: a real Pulsar broker in Docker. Version comes from the
+             testcontainers BOM imported by the parent pom. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>pulsar</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -148,5 +171,37 @@
 		</dependency>
         
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Integration tests (*IT.java) start a real Pulsar broker via Testcontainers, so they
+                 need a working Docker daemon and take appreciably longer than the unit tests.
+                 Surefire does not pick up the *IT suffix, so `mvn test` and `mvn package` stay fast
+                 and Docker-free; these run from `mvn verify`, and can be skipped with -DskipITs. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <!-- see docker.api.version in the parent pom -->
+                        <api.version>${docker.api.version}</api.version>
+                        <pulsar.image>${pulsar.image}</pulsar.image>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/AbstractPulsarIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/AbstractPulsarIT.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.pulsar.PulsarClientService;
+import org.apache.nifi.pulsar.StandardPulsarClientService;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Base class for tests that exercise the processors against a real Pulsar broker started in Docker.
+ * <p>
+ * The unit tests in this module all run against a mocked {@code PulsarClientService}, which means the
+ * processors have never been executed against a real broker: anything that depends on genuine broker
+ * behaviour - acknowledgement semantics, subscription types, partitioned topics, schemas - is currently
+ * unverified. These integration tests close that gap.
+ * <p>
+ * One broker is started per test class ({@code @ClassRule}) and shared by its tests, since container
+ * startup dominates the runtime. The image is pinned by the {@code pulsar.image} property in the parent
+ * pom so it stays in step with the Pulsar client version the bundle builds against.
+ * <p>
+ * These are named {@code *IT} so Surefire ignores them: {@code mvn test} and {@code mvn package} stay
+ * fast and need no Docker. They run from {@code mvn verify}.
+ */
+public abstract class AbstractPulsarIT {
+
+    /** Overridable so the image can be pinned from the build; falls back to the client version. */
+    private static final DockerImageName PULSAR_IMAGE = DockerImageName
+            .parse(System.getProperty("pulsar.image", "apachepulsar/pulsar:4.2.4"))
+            .asCompatibleSubstituteFor("apachepulsar/pulsar");
+
+    @ClassRule
+    public static final PulsarContainer PULSAR = new PulsarContainer(PULSAR_IMAGE)
+            .withStartupTimeout(java.time.Duration.ofMinutes(3));
+
+    private static PulsarClient client;
+
+    @BeforeClass
+    public static void startClient() throws PulsarClientException {
+        client = PulsarClient.builder().serviceUrl(PULSAR.getPulsarBrokerUrl()).build();
+    }
+
+    @AfterClass
+    public static void stopClient() throws PulsarClientException {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    /** A client connected to the containerised broker, for arranging and asserting outside the processors. */
+    protected static PulsarClient getClient() {
+        return client;
+    }
+
+    protected static String getBrokerUrl() {
+        return PULSAR.getPulsarBrokerUrl();
+    }
+
+    /**
+     * Registers a real {@link StandardPulsarClientService} pointed at the container and wires it into the
+     * runner, so the processor under test talks to an actual broker instead of a Mockito mock.
+     *
+     * @param runner the runner for the processor under test
+     * @param identifier the controller service id to register under
+     */
+    protected void addRealPulsarClientService(final TestRunner runner, final String identifier)
+            throws InitializationException {
+        final ControllerService service = new StandardPulsarClientService();
+        runner.addControllerService(identifier, service);
+        runner.setProperty(service, StandardPulsarClientService.PULSAR_SERVICE_URL, getBrokerUrl());
+        runner.enableControllerService(service);
+        runner.assertValid(service);
+    }
+
+    /** Publishes messages to a topic using a plain client, independent of the processors. */
+    protected void publish(final String topic, final String... messages) throws PulsarClientException {
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            for (final String message : messages) {
+                producer.send(message.getBytes());
+            }
+        }
+    }
+
+    /** Waits until {@code condition} holds, so tests do not depend on broker timing. */
+    protected static void await(final String description, final java.util.concurrent.Callable<Boolean> condition)
+            throws Exception {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+
+        while (System.nanoTime() < deadline) {
+            if (Boolean.TRUE.equals(condition.call())) {
+                return;
+            }
+            Thread.sleep(250);
+        }
+
+        throw new AssertionError("Timed out after 30s waiting for: " + description);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarIT.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Exercises {@link ConsumePulsar} against a real broker. These cover the behaviour that the mocked unit
+ * tests cannot reach: real message ids, real acknowledgement semantics and real subscription types.
+ */
+public class ConsumePulsarIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        // A brand new Pulsar subscription starts at the latest position, so anything published before the
+        // processor first connects would never be delivered. The tests arrange messages up front, so they
+        // read the topic from the beginning.
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+    }
+
+    /** The basic contract: what is published is what comes out. */
+    @Test
+    public void consumesWhatWasPublished() throws Exception {
+        final String topic = topic("roundtrip");
+        subscribeTo(topic, "roundtrip-sub", 10);
+
+        publish(topic, "one", "two", "three");
+
+        final List<MockFlowFile> flowFiles = runUntilTransferred(1);
+        flowFiles.get(0).assertContentEquals("one\ntwo\nthree");
+        flowFiles.get(0).assertAttributeEquals(ConsumePulsar.MSG_COUNT, "3");
+    }
+
+    /**
+     * The regression that motivated #142, verified end to end: with a real broker every message carries a
+     * genuinely unique message id, which is exactly the condition the mocked tests could not reproduce.
+     */
+    @Test
+    public void batchSizeIsHonouredWithRealMessageIds() throws Exception {
+        final String topic = topic("batching");
+        subscribeTo(topic, "batching-sub", 10);
+
+        publish(topic, IntStream.rangeClosed(1, 10).mapToObj(n -> "m" + n).toArray(String[]::new));
+
+        final List<MockFlowFile> flowFiles = runUntilTransferred(1);
+        assertEquals("10 messages with a batch size of 10 must produce a single FlowFile", 1, flowFiles.size());
+        flowFiles.get(0).assertAttributeEquals(ConsumePulsar.MSG_COUNT, "10");
+        flowFiles.get(0).assertContentEquals(IntStream.rangeClosed(1, 10)
+                .mapToObj(n -> "m" + n).collect(Collectors.joining("\n")));
+
+        // real ids, so the first/last batch attributes are meaningful and distinct
+        final String first = flowFiles.get(0).getAttribute("pulsar.message.id.first");
+        final String last = flowFiles.get(0).getAttribute("pulsar.message.id.last");
+        assertTrue("expected a real first message id, got " + first, first != null && !first.isEmpty());
+        assertTrue("expected a real last message id, got " + last, last != null && !last.isEmpty());
+        assertTrue("first and last ids should differ across a 10 message batch", !first.equals(last));
+        flowFiles.get(0).assertAttributeNotExists("pulsar.message.id");
+    }
+
+    /** More messages than the batch size must split across FlowFiles rather than be dropped. */
+    @Test
+    public void moreMessagesThanBatchSizeSplitAcrossFlowFiles() throws Exception {
+        final String topic = topic("split");
+        subscribeTo(topic, "split-sub", 4);
+
+        publish(topic, IntStream.rangeClosed(1, 10).mapToObj(n -> "m" + n).toArray(String[]::new));
+
+        final List<MockFlowFile> flowFiles = runUntilTransferred(3);
+        assertEquals("4", flowFiles.get(0).getAttribute(ConsumePulsar.MSG_COUNT));
+        assertEquals("4", flowFiles.get(1).getAttribute(ConsumePulsar.MSG_COUNT));
+        assertEquals("2", flowFiles.get(2).getAttribute(ConsumePulsar.MSG_COUNT));
+    }
+
+    /**
+     * Acknowledgements really reach the broker: a second subscriber on the same subscription must not be
+     * redelivered what the first one already consumed and acked.
+     */
+    @Test
+    public void acknowledgedMessagesAreNotRedelivered() throws Exception {
+        final String topic = topic("acks");
+        subscribeTo(topic, "acks-sub", 10);
+
+        publish(topic, "a", "b", "c");
+        runUntilTransferred(1);
+
+        // a fresh runner on the SAME subscription should find nothing left to consume
+        runner.clearTransferState();
+        runner.run(3, true);
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** Unique per test so the tests sharing one broker cannot interfere with each other. */
+    private static String topic(final String name) {
+        return "persistent://public/default/" + name + "-" + System.nanoTime();
+    }
+
+    private void subscribeTo(final String topic, final String subscription, final int batchSize) {
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, subscription);
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, String.valueOf(batchSize));
+    }
+
+    /** Triggers until the expected number of FlowFiles has been produced, so timing cannot flake the test. */
+    private List<MockFlowFile> runUntilTransferred(final int expected) throws Exception {
+        await(expected + " FlowFile(s) transferred to success", () -> {
+            runner.run(1, false);
+            return runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).size() >= expected;
+        });
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, expected);
+        return runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
         <protobuf3.version>4.36.0</protobuf3.version>
         <pulsar.version>4.2.4</pulsar.version>
         <slf4j-simple.version>2.0.18</slf4j-simple.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <!-- Pulsar broker image for the integration tests; kept in step with pulsar.version. -->
+        <pulsar.image>apachepulsar/pulsar:4.2.4</pulsar.image>
+        <!-- Docker API version the integration tests negotiate with. docker-java pins 1.32 by default,
+             which Docker 29+ refuses ("client version 1.32 is too old, minimum supported API is 1.44").
+             1.44 needs Docker >= 25; on an older daemon override with -Ddocker.api.version=1.41. -->
+        <docker.api.version>1.44</docker.api.version>
         <java.version>21</java.version>
 
         <!-- Maven plugin versions -->
@@ -112,6 +119,7 @@
         <nifi-nar-maven-plugin.version>2.4.0</nifi-nar-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-versions-plugin.version>2.5</maven-versions-plugin.version>
+        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
 
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
@@ -124,6 +132,18 @@
         <module>nifi-pulsar-nar</module>
         <module>docker-image</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
Closes #151.

Adds the integration test layer the project has never had, plus a workflow so it gates merges.

**What is here**
- `AbstractPulsarIT` starts a real Pulsar broker per test class via Testcontainers and wires a real `StandardPulsarClientService` into the runner.
- `ConsumePulsarIT`: publish/consume round trip, batch size honoured **with real unique message ids**, splitting across FlowFiles, and acknowledgements genuinely reaching the broker (no redelivery on the same subscription).
- Named `*IT.java` so Surefire skips them: `mvn test` and `mvn package` stay fast and need no Docker. Failsafe runs them from `mvn verify`; `-DskipITs` opts out.
- New **Integration Tests (Java 21)** workflow on every PR and push to main, kept separate from the fast CI check. Uses `pull_request` (never `pull_request_target`), matching the existing CI security posture.
- Broker image pinned by `pulsar.image` next to `pulsar.version`.

**Verified locally:** 4/4 integration tests pass against a real `apachepulsar/pulsar:4.2.4` broker; full build green (205 unit + 19 client-service + 4 IT).

**One gotcha worth knowing about.** docker-java (bundled in Testcontainers 1.21.3) negotiates Docker API **1.32**, which Docker **29+** rejects outright:

> client version 1.32 is too old. Minimum supported API version is 1.44

It surfaces as a misleading `Could not find a valid Docker environment`. The build passes `-Dapi.version=\${docker.api.version}` (1.44) to work around it. 1.44 needs Docker >= 25; on an older daemon override with `-Ddocker.api.version=1.41`. Documented in the README.

**Follow-up:** once this merges and the check has reported once, "Integration Tests (Java 21)" should be added to branch protection as a required check so it blocks merges.