### PR TITLE
chore: ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .idea/
+.claude/
 .project
 .settings
 .classpath


### PR DESCRIPTION
Claude Code writes per-developer settings to `.claude/settings.local.json`, which showed up as an untracked directory in every working copy.

One line, next to the other tooling entries at the top of `.gitignore`.

Note: this ignores the whole `.claude/` directory. If you ever want to commit *shared* project settings (`.claude/settings.json`) while keeping the per-developer `settings.local.json` out, this would need a negation rule instead. Only the local file exists today, so ignoring the directory is the simpler choice for now.