### PR TITLE
fix: pool and close Pulsar producers instead of leaking every one

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -309,7 +310,32 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
     @OnScheduled
     public void init(ProcessContext context) {
         setPulsarClientService(context.getProperty(PULSAR_CLIENT_SERVICE).asControllerService(PulsarClientService.class));
+
+        // Close anything left from a previous scheduling before replacing it. Overwriting the field
+        // outright strands the old pool's producers on the broker with nothing left holding a reference
+        // to close them.
+        closePublisherPool(context);
+
         setPublisherPool(createPublisherPool(context));
+    }
+
+    /**
+     * Closes the publisher pool, and with it every producer it is holding.
+     * <p>
+     * Without this the pool built in {@link #init(ProcessContext)} was simply abandoned on stop, so
+     * stopping and restarting the processor left the previous run's producers connected to the broker.
+     * The consumer side has always done the equivalent through its LRU cache.
+     *
+     * @param context the processor context
+     */
+    @OnStopped
+    public void closePublisherPool(final ProcessContext context) {
+        final PublisherPool pool = getPublisherPool();
+
+        if (pool != null) {
+            pool.close();
+            setPublisherPool(null);
+        }
     }
 
     protected PublisherPool createPublisherPool(final ProcessContext context) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
@@ -158,6 +158,12 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
                 } catch (final Exception ex) {
                     getLogger().error("Unable to process session due to ", ex);
                     session.transfer(flowFile, REL_FAILURE);
+                } finally {
+                    // Return the lease so its producer is reused by the next FlowFile instead of being
+                    // abandoned. Without this a busy flow opens one producer - and one broker connection -
+                    // per FlowFile and never releases any of them. complete() is read above, before this
+                    // resets the lease's message count.
+                    lease.close();
                 }
             }
         }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -162,6 +162,13 @@ public class PublisherLease implements Closeable {
         }
     }
 
+    /**
+     * Clears the message count so a pooled lease does not carry one FlowFile's total into the next.
+     */
+    void reset() {
+        this.messagesSent.set(0L);
+    }
+
     public long complete() {
         return this.messagesSent.get();
     }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
 public class PublisherPool implements Closeable {
@@ -35,7 +36,11 @@ public class PublisherPool implements Closeable {
 
     private final PulsarClient pulsarClient;
 
-    private final BlockingQueue<PublisherLease> publisherQueue;
+    /**
+     * Idle leases, keyed by topic. A lease wraps a producer bound to one topic, so a single shared queue
+     * could hand a caller a producer for the wrong topic - which is why the queue has to be per topic.
+     */
+    private final Map<String, BlockingQueue<PublisherLease>> publisherQueues;
 
     private volatile boolean closed = false;
 
@@ -43,7 +48,7 @@ public class PublisherPool implements Closeable {
         this.logger = logger;
         this.pulsarProducerProperties = pulsarProducerProperties;
         this.pulsarClient = pulsarClient;
-        this.publisherQueue = new LinkedBlockingQueue<>();
+        this.publisherQueues = new ConcurrentHashMap<>();
     }
 
     public PublisherLease obtainPublisher(String topicName) {
@@ -51,22 +56,31 @@ public class PublisherPool implements Closeable {
             throw new IllegalStateException("Connection Pool is closed");
         }
 
-        PublisherLease lease = null;
-
-        try {
-            lease = createLease(topicName);
-        } catch (PulsarClientException pcEx) {
-           logger.error("Unable to create producer", pcEx);
-        }
-
-        return lease;
-    }
-
-    private PublisherLease createLease(String topicName) throws PulsarClientException {
         if (StringUtils.isBlank(topicName)) {
             return null;
         }
-        
+
+        final PublisherLease pooled = queueFor(topicName).poll();
+
+        if (pooled != null) {
+            // the counter is cumulative per lease, so clear it before the next FlowFile uses it
+            pooled.reset();
+            return pooled;
+        }
+
+        try {
+            return createLease(topicName);
+        } catch (PulsarClientException pcEx) {
+            logger.error("Unable to create producer", pcEx);
+            return null;
+        }
+    }
+
+    private BlockingQueue<PublisherLease> queueFor(final String topicName) {
+        return publisherQueues.computeIfAbsent(topicName, t -> new LinkedBlockingQueue<>());
+    }
+
+    private PublisherLease createLease(final String topicName) throws PulsarClientException {
         final Map<String, Object> properties = new HashMap<>(pulsarProducerProperties);
         Producer producer = pulsarClient.newProducer()
                 .topic(topicName)
@@ -78,15 +92,23 @@ public class PublisherPool implements Closeable {
 
             @Override
             public void close() {
-                if (isClosed()) {
-                    if (closed) {
-                        return;
-                    }
+                if (closed) {
+                    return;
+                }
 
+                if (isClosed()) {
+                    // the pool is gone, so this really is the end of the producer's life
                     closed = true;
                     super.close();
                 } else {
-                    publisherQueue.remove(this);
+                    // hand it back for the next FlowFile on this topic rather than dropping it. This used
+                    // to be publisherQueue.remove(this) on a queue nothing ever added to, so the producer
+                    // was never returned and never closed - it simply leaked.
+                    reset();
+                    if (!queueFor(topicName).offer(this)) {
+                        closed = true;
+                        super.close();
+                    }
                 }
             }
         };
@@ -102,9 +124,14 @@ public class PublisherPool implements Closeable {
     public synchronized void close() {
         closed = true;
 
-        PublisherLease lease;
-        while ((lease = publisherQueue.poll()) != null) {
-            lease.close();
+        for (final BlockingQueue<PublisherLease> queue : publisherQueues.values()) {
+            PublisherLease lease;
+            while ((lease = queue.poll()) != null) {
+                // the pool is closed now, so this closes the underlying producer
+                lease.close();
+            }
         }
+
+        publisherQueues.clear();
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarLifecycleIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarLifecycleIT.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Producer lifecycle against a real broker.
+ * <p>
+ * The publish path had no real-broker coverage at all, which is how it went unnoticed that
+ * {@code PublisherPool} never pooled and never closed anything: leases were returned to a queue nothing
+ * ever added to, so every producer the bundle opened - and its broker connection - was leaked. These
+ * tests assert against what the broker itself reports, which is the only place that leak is visible.
+ */
+public class PublishPulsarLifecycleIT extends AbstractPulsarIT {
+
+    /** Pulsar reports connected producers per topic in its stats endpoint. */
+    private static final Pattern PRODUCER_NAME = Pattern.compile("\"producerName\"");
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    /**
+     * The headline leak: many FlowFiles must not mean many producers. Before the fix each obtained lease
+     * was abandoned rather than returned, so the connected-producer count tracked the FlowFile count.
+     */
+    @Test
+    public void producerCountDoesNotGrowWithFlowFiles() throws Exception {
+        final String topic = topic("producer-count");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+
+        for (int n = 1; n <= 25; n++) {
+            runner.enqueue(("message-" + n).getBytes());
+        }
+        runner.run(25, false);
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 25);
+
+        final int producers = connectedProducers(topic);
+        assertTrue("25 FlowFiles opened " + producers + " producers on the broker; a pool should hold one "
+                + "per topic, not one per FlowFile", producers <= 2);
+    }
+
+    /** Stopping the processor must hand every producer back to the broker, not abandon it. */
+    @Test
+    public void stoppingTheProcessorClosesItsProducers() throws Exception {
+        final String topic = topic("producer-close");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+
+        runner.enqueue("hello".getBytes());
+        runner.run(1, false);
+        assertTrue("expected a producer while running", connectedProducers(topic) >= 1);
+
+        // stopOnFinish runs @OnUnscheduled and @OnStopped, which is where the pool is closed
+        runner.run(1, true);
+
+        await("the broker to report no connected producers", () -> connectedProducers(topic) == 0);
+        assertEquals(0, connectedProducers(topic));
+    }
+
+    /** Restarting repeatedly must not accumulate producers from previous runs. */
+    @Test
+    public void restartingDoesNotAccumulateProducers() throws Exception {
+        final String topic = topic("producer-restart");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+
+        for (int round = 1; round <= 3; round++) {
+            runner.enqueue(("round-" + round).getBytes());
+            runner.run(1, true);
+            await("producers released after round " + round, () -> connectedProducers(topic) == 0);
+        }
+
+        assertEquals("three start/stop rounds should leave nothing connected", 0, connectedProducers(topic));
+    }
+
+    /** Publishing to several topics keeps one producer each, not one per FlowFile per topic. */
+    @Test
+    public void eachTopicKeepsASingleProducer() throws Exception {
+        final String topic = topic("multi");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "${target.topic}");
+
+        for (int n = 1; n <= 12; n++) {
+            runner.enqueue(("message-" + n).getBytes(),
+                    java.util.Collections.singletonMap("target.topic", topic + "-" + (n % 3)));
+        }
+        runner.run(12, false);
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 12);
+
+        for (int partition = 0; partition < 3; partition++) {
+            final int producers = connectedProducers(topic + "-" + partition);
+            assertTrue("topic " + partition + " has " + producers + " producers for 4 FlowFiles",
+                    producers <= 2);
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static String topic(final String name) {
+        return "persistent://public/default/" + name + "-" + System.nanoTime();
+    }
+
+    /**
+     * Asks the broker how many producers are currently connected to a topic. Uses the admin REST endpoint
+     * directly so the test does not depend on an admin client version that may drift from the client.
+     */
+    private static int connectedProducers(final String topic) throws Exception {
+        final String shortName = topic.substring(topic.lastIndexOf('/') + 1);
+        final String url = PULSAR.getHttpServiceUrl()
+                + "/admin/v2/persistent/public/default/" + shortName + "/stats";
+
+        final HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == 404) {
+            return 0;   // topic not created yet, so nothing is connected to it
+        }
+
+        if (response.statusCode() != 200) {
+            throw new AssertionError("Unable to read topic stats (" + response.statusCode() + "): " + response.body());
+        }
+
+        final Matcher matcher = PRODUCER_NAME.matcher(response.body());
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolLifecycleTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolLifecycleTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.nifi.util.MockComponentLog;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Lifecycle contract for {@link PublisherPool}.
+ * <p>
+ * The pool never pooled and never closed anything: {@code publisherQueue} was only ever read from, so
+ * {@code obtainPublisher()} built a fresh Pulsar producer on every call, a lease's {@code close()} hit
+ * {@code publisherQueue.remove(this)} on a permanently empty queue instead of closing the producer, and
+ * {@code PublisherPool.close()} drained that same empty queue. The net effect was that every producer the
+ * bundle opened - and its broker connection - was leaked.
+ */
+public class PublisherPoolLifecycleTest {
+
+    private static final String TOPIC_A = "persistent://public/default/alpha";
+    private static final String TOPIC_B = "persistent://public/default/beta";
+
+    private PulsarClient client;
+    private List<Producer<?>> created;
+
+    @Before
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void init() throws Exception {
+        created = new ArrayList<>();
+        final String[] lastTopic = new String[1];
+
+        final ProducerBuilder builder = mock(ProducerBuilder.class);
+        when(builder.topic(anyString())).thenAnswer(invocation -> {
+            lastTopic[0] = invocation.getArgument(0);
+            return builder;
+        });
+        when(builder.loadConf(any())).thenReturn(builder);
+        // stubbed once: re-stubbing create() inside an answer would invoke it and build a stray producer
+        when(builder.create()).thenAnswer(invocation -> {
+            final Producer producer = mock(Producer.class);
+            when(producer.getTopic()).thenReturn(lastTopic[0]);
+            when(producer.newMessage()).thenAnswer(m -> messageBuilder());
+            created.add(producer);
+            return producer;
+        });
+
+        client = mock(PulsarClient.class);
+        when(client.newProducer()).thenReturn(builder);
+    }
+
+    /** Enough of the fluent send chain for publish() to run against a mock producer. */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static TypedMessageBuilder messageBuilder() throws Exception {
+        final TypedMessageBuilder tmb = mock(TypedMessageBuilder.class);
+        when(tmb.properties(any())).thenReturn(tmb);
+        when(tmb.value(any())).thenReturn(tmb);
+        when(tmb.key(any())).thenReturn(tmb);
+        when(tmb.send()).thenReturn(mock(MessageId.class));
+        return tmb;
+    }
+
+    private PublisherPool newPool() {
+        return new PublisherPool(new MockComponentLog("id", new Object()), new HashMap<>(), client);
+    }
+
+    /** Releasing a lease while the pool is open must return it for reuse, not silently drop it. */
+    @Test
+    public void aReleasedLeaseIsReusedForTheSameTopic() {
+        final PublisherPool pool = newPool();
+
+        final PublisherLease first = pool.obtainPublisher(TOPIC_A);
+        assertNotNull(first);
+        first.close();
+
+        final PublisherLease second = pool.obtainPublisher(TOPIC_A);
+        assertSame("a released lease should be handed back out rather than a new producer built", first, second);
+        assertEquals("only one producer should have been created for one topic", 1, created.size());
+    }
+
+    /** Leases are bound to a producer for one topic, so they must never be handed to a different topic. */
+    @Test
+    public void aLeaseIsNeverReusedForADifferentTopic() {
+        final PublisherPool pool = newPool();
+
+        final PublisherLease alpha = pool.obtainPublisher(TOPIC_A);
+        alpha.close();
+
+        final PublisherLease beta = pool.obtainPublisher(TOPIC_B);
+        assertEquals("the beta lease must not be the alpha producer", TOPIC_B, beta.getTopicName());
+        assertEquals(2, created.size());
+    }
+
+    /** Closing the pool must close every producer it handed out, including the ones returned to it. */
+    @Test
+    public void closingThePoolClosesEveryProducer() throws Exception {
+        final PublisherPool pool = newPool();
+
+        pool.obtainPublisher(TOPIC_A).close();
+        pool.obtainPublisher(TOPIC_B).close();
+        assertEquals(2, created.size());
+
+        pool.close();
+
+        for (final Producer<?> producer : created) {
+            verify(producer, times(1)).close();
+        }
+    }
+
+    /** A lease still checked out when the pool closes must not outlive it. */
+    @Test
+    public void aLeaseClosedAfterThePoolClosesItsProducer() throws Exception {
+        final PublisherPool pool = newPool();
+
+        final PublisherLease lease = pool.obtainPublisher(TOPIC_A);
+        pool.close();
+        lease.close();
+
+        verify(created.get(0), times(1)).close();
+    }
+
+    /**
+     * The message counter is cumulative for the lifetime of a lease, so a reused lease has to start from
+     * zero again - otherwise PublishPulsarRecord's msg.count attribute over-reports on the second FlowFile
+     * and every one after it.
+     */
+    @Test
+    public void aReusedLeaseStartsCountingFromZero() throws Exception {
+        final PublisherPool pool = newPool();
+
+        final PublisherLease lease = pool.obtainPublisher(TOPIC_A);
+        lease.publish(new org.apache.nifi.util.MockFlowFile(1L),
+                new java.io.ByteArrayInputStream("a\nb\nc".getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                null, new HashMap<>(), "\n".getBytes(java.nio.charset.StandardCharsets.UTF_8), false);
+        assertEquals(3, lease.complete());
+        lease.close();
+
+        final PublisherLease reused = pool.obtainPublisher(TOPIC_A);
+        assertSame(lease, reused);
+        assertEquals("a lease handed back out must not carry the previous FlowFile's count", 0, reused.complete());
+    }
+}


### PR DESCRIPTION
Closes #156.

**Change**
- The idle-lease queue is now **per topic** — a lease wraps a producer bound to one topic, so a single shared queue could hand a caller a producer for the wrong topic. Releasing a lease returns it for reuse; closing the pool closes every producer it holds.
- `PublisherLease.reset()` clears the cumulative message count when a lease is handed back out. Without this, reuse would make `msg.count` over-report on the second FlowFile and every one after — the trap flagged in the review.
- `PublishPulsarRecord` releases its lease in a `finally`, after reading `complete()`.
- `AbstractPulsarProducerProcessor` gains `@OnStopped` to close the pool, and `@OnScheduled` now closes any pool left from a previous scheduling rather than overwriting the field and stranding it.

**That last point was found by the test, not by reading.** `stoppingTheProcessorClosesItsProducers` failed on the first run because scheduling twice replaced the pool without closing the first one.

**Verification**
- `PublisherPoolLifecycleTest` (unit): reuse, per-topic isolation, close propagation, counter reset. **Three of five fail on `main`.**
- `PublishPulsarLifecycleIT` (real broker): asserts against the broker's own stats endpoint, which is the only place this leak is visible. 25 FlowFiles now hold **one** producer instead of 25, and stopping or restarting leaves **zero** connected.

Full build green: 226 unit + 8 integration.