### PR TITLE
fix: pool and close Pulsar producers in PublisherPool

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -310,6 +311,21 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
     public void init(ProcessContext context) {
         setPulsarClientService(context.getProperty(PULSAR_CLIENT_SERVICE).asControllerService(PulsarClientService.class));
         setPublisherPool(createPublisherPool(context));
+    }
+
+    /**
+     * Closes the publisher pool - and with it every Pulsar producer this processor opened - when the processor
+     * is stopped. Without this the pool built in {@link #init(ProcessContext)} was simply abandoned on stop, so
+     * its producers and their broker connections leaked on every stop/start cycle.
+     */
+    @OnStopped
+    public void closePublisherPool() {
+        final PublisherPool pool = getPublisherPool();
+
+        if (pool != null) {
+            pool.close();
+            setPublisherPool(null);
+        }
     }
 
     protected PublisherPool createPublisherPool(final ProcessContext context) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
@@ -132,6 +132,9 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
                         .evaluateAttributeExpressions(flowFile).getValue();
 
                 try {
+                    // leases are pooled and reused across FlowFiles, so count only the sends made for this FlowFile
+                    final long sentBefore = lease.complete();
+
                     session.read(flowFile, in -> {
                         try {
                             final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger());
@@ -146,7 +149,7 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
                         }
                     });
 
-                    long messagesSent = lease.complete();
+                    long messagesSent = lease.complete() - sentBefore;
                     session.putAttribute(flowFile, MSG_COUNT, Long.toString(messagesSent));
                     session.putAttribute(flowFile, TOPIC_NAME, topicName);
                     session.getProvenanceReporter().send(flowFile,
@@ -158,6 +161,9 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
                 } catch (final Exception ex) {
                     getLogger().error("Unable to process session due to ", ex);
                     session.transfer(flowFile, REL_FAILURE);
+                } finally {
+                    // return the producer to the pool (or close it, if the pool has already been closed)
+                    lease.close();
                 }
             }
         }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -1,12 +1,12 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements.    See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License.    You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,19 +23,38 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * A pool of {@link PublisherLease}s - one Pulsar producer each - keyed by topic.
+ * <p>
+ * {@link #obtainPublisher(String)} hands out an idle lease for the topic when there is one and only creates a new
+ * producer when every lease for that topic is in use. Closing a lease returns it to the pool; it does not close the
+ * producer. Closing the pool closes every producer it created, idle or in use, and any lease closed after that closes
+ * its producer instead of returning to the pool. Both close paths are idempotent.
+ * <p>
+ * Before this the idle queue was never written to, so every {@code obtainPublisher()} created a new producer, a lease's
+ * {@code close()} removed it from an always-empty queue instead of closing it, and {@link #close()} drained that same
+ * empty queue: every producer this bundle opened, and its broker connection, was leaked.
+ */
 public class PublisherPool implements Closeable {
 
     private final ComponentLog logger;
     private final Map<String, Object> pulsarProducerProperties;
-
     private final PulsarClient pulsarClient;
 
-    private final BlockingQueue<PublisherLease> publisherQueue;
+    /** Idle leases per topic, ready to be handed out again. */
+    private final Map<String, Queue<PooledPublisherLease>> idleLeases = new ConcurrentHashMap<>();
+
+    /** Every lease created by this pool whose producer is still open, idle or in use. */
+    private final Set<PooledPublisherLease> openLeases = ConcurrentHashMap.newKeySet();
 
     private volatile boolean closed = false;
 
@@ -43,68 +62,121 @@ public class PublisherPool implements Closeable {
         this.logger = logger;
         this.pulsarProducerProperties = pulsarProducerProperties;
         this.pulsarClient = pulsarClient;
-        this.publisherQueue = new LinkedBlockingQueue<>();
     }
 
+    /**
+     * Returns a lease for the topic: an idle one if available, otherwise a newly created producer.
+     *
+     * @param topicName the topic to publish to
+     * @return the lease, or {@code null} when the topic is blank or the producer cannot be created
+     * @throws IllegalStateException if the pool has been closed
+     */
     public PublisherLease obtainPublisher(String topicName) {
         if (isClosed()) {
             throw new IllegalStateException("Connection Pool is closed");
         }
 
-        PublisherLease lease = null;
+        if (StringUtils.isBlank(topicName)) {
+            return null;
+        }
+
+        final PooledPublisherLease idle = idleLeasesFor(topicName).poll();
+        if (idle != null) {
+            return idle;
+        }
 
         try {
-            lease = createLease(topicName);
+            return createLease(topicName);
         } catch (PulsarClientException pcEx) {
-           logger.error("Unable to create producer", pcEx);
+            logger.error("Unable to create producer", pcEx);
+            return null;
+        }
+    }
+
+    private Queue<PooledPublisherLease> idleLeasesFor(final String topicName) {
+        return idleLeases.computeIfAbsent(topicName, topic -> new ConcurrentLinkedQueue<>());
+    }
+
+    private PooledPublisherLease createLease(String topicName) throws PulsarClientException {
+        final Map<String, Object> properties = new HashMap<>(pulsarProducerProperties);
+
+        final Producer producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .loadConf(properties)
+                .create();
+
+        final PooledPublisherLease lease = new PooledPublisherLease(producer, topicName);
+        openLeases.add(lease);
+
+        if (isClosed()) {
+            // the pool was closed while this producer was being created: do not hand out a lease that
+            // nothing would ever close
+            lease.closeProducer();
+            throw new IllegalStateException("Connection Pool is closed");
         }
 
         return lease;
     }
 
-    private PublisherLease createLease(String topicName) throws PulsarClientException {
-        if (StringUtils.isBlank(topicName)) {
-            return null;
-        }
-        
-        final Map<String, Object> properties = new HashMap<>(pulsarProducerProperties);
-        Producer producer = pulsarClient.newProducer()
-                .topic(topicName)
-                .loadConf(properties)
-                .create();
+    /**
+     * @return the number of producers currently open, idle or in use
+     */
+    public int getOpenProducerCount() {
+        return openLeases.size();
+    }
 
-        final PublisherLease lease = new PublisherLease(producer, logger) {
-            private volatile boolean closed = false;
-
-            @Override
-            public void close() {
-                if (isClosed()) {
-                    if (closed) {
-                        return;
-                    }
-
-                    closed = true;
-                    super.close();
-                } else {
-                    publisherQueue.remove(this);
-                }
-            }
-        };
-
-        return lease;
+    /**
+     * @return the number of producers currently idle and available to {@link #obtainPublisher(String)}
+     */
+    public int getIdleProducerCount() {
+        return idleLeases.values().stream().mapToInt(Queue::size).sum();
     }
 
     public synchronized boolean isClosed() {
         return closed;
     }
 
+    /**
+     * Closes every producer created by this pool, idle or in use. A lease that is still in use keeps working until
+     * its owner closes it, at which point its producer is closed as well (once).
+     */
     @Override
     public synchronized void close() {
         closed = true;
+        idleLeases.clear();
 
-        PublisherLease lease;
-        while ((lease = publisherQueue.poll()) != null) {
-            lease.close();
+        for (PooledPublisherLease lease : new ArrayList<>(openLeases)) {
+            lease.closeProducer();
+        }
+    }
+
+    /**
+     * A lease whose {@code close()} returns the producer to the pool while the pool is open and closes it afterwards.
+     */
+    private final class PooledPublisherLease extends PublisherLease {
+        private final String topicName;
+        private final AtomicBoolean producerClosed = new AtomicBoolean(false);
+
+        private PooledPublisherLease(final Producer producer, final String topicName) {
+            super(producer, logger);
+            this.topicName = topicName;
+        }
+
+        @Override
+        public void close() {
+            if (PublisherPool.this.isClosed()) {
+                closeProducer();
+            } else {
+                // return the producer to the pool; PublisherPool.close() closes it later because it stays in openLeases
+                idleLeasesFor(topicName).offer(this);
+            }
+        }
+
+        private void closeProducer() {
+            if (producerClosed.compareAndSet(false, true)) {
+                openLeases.remove(this);
+                super.close();
+            }
         }
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishProducerPoolTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishProducerPoolTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord.RECORD_READER;
+import static org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord.RECORD_WRITER;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.Test;
+
+/**
+ * The publishers must reuse one producer per topic across FlowFiles and close it when the processor stops.
+ * Before the PublisherPool fix PublishPulsarRecord opened one producer per FlowFile and neither processor ever
+ * closed a producer.
+ */
+public class PublishProducerPoolTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    private static final String TOPIC = "pool-topic";
+
+    private void initRecordRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+
+        final MockRecordParser readerService = new MockRecordParser();
+        readerService.addSchemaField("name", RecordFieldType.STRING);
+        readerService.addSchemaField("age", RecordFieldType.INT);
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(RECORD_READER, "record-reader");
+        runner.setProperty(RECORD_WRITER, "record-writer");
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, TOPIC);
+    }
+
+    @Test
+    public void publishPulsarRecordReusesOneProducerPerTopicAndClosesItOnStop() throws InitializationException, PulsarClientException {
+        initRecordRunner();
+
+        for (int i = 0; i < 3; i++) {
+            runner.enqueue("Mary Jane, 32\nJohn Doe, 40".getBytes(StandardCharsets.UTF_8));
+        }
+        runner.run(3, true);
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 3);
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PublishPulsarRecord.REL_SUCCESS);
+        for (MockFlowFile flowFile : flowFiles) {
+            // the lease is reused, so the count must be per FlowFile rather than cumulative
+            flowFile.assertAttributeEquals(AbstractPulsarProducerProcessor.MSG_COUNT, "2");
+            flowFile.assertAttributeEquals(AbstractPulsarProducerProcessor.TOPIC_NAME, TOPIC);
+        }
+
+        // one producer for the three FlowFiles, closed exactly once when the processor stopped
+        verify(mockClientService.getMockProducerBuilder(), times(1)).create();
+        verify(mockClientService.getMockProducer(), times(1)).close();
+
+        // a restart builds a new pool and therefore a new producer
+        runner.enqueue("Mary Jane, 32".getBytes(StandardCharsets.UTF_8));
+        runner.run(1, true);
+        verify(mockClientService.getMockProducerBuilder(), times(2)).create();
+        verify(mockClientService.getMockProducer(), times(2)).close();
+    }
+
+    @Test
+    public void publishPulsarReusesOneProducerPerTopicAndClosesItOnStop() throws InitializationException, PulsarClientException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, TOPIC);
+
+        for (int i = 0; i < 3; i++) {
+            runner.enqueue("message".getBytes(StandardCharsets.UTF_8));
+        }
+        runner.run(3, true);
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 3);
+        verify(mockClientService.getMockProducerBuilder(), times(1)).create();
+        verify(mockClientService.getMockProducer(), times(1)).close();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for the producer leak: the pool must hand out idle producers again, and closing the pool
+ * must close every producer it created.
+ */
+@SuppressWarnings("unchecked")
+public class PublisherPoolTest {
+
+    private PulsarClient client;
+    private ProducerBuilder<byte[]> builder;
+    private final List<Producer<byte[]>> producers = new ArrayList<>();
+    private final List<String> requestedTopics = new ArrayList<>();
+    private PublisherPool pool;
+
+    @Before
+    public void setUp() throws PulsarClientException {
+        client = mock(PulsarClient.class);
+        builder = mock(ProducerBuilder.class, RETURNS_SELF);
+        when(client.newProducer()).thenReturn(builder);
+        // doAnswer(...).when(...) so that (re)stubbing never invokes a previous answer
+        doAnswer(invocation -> {
+            requestedTopics.add(invocation.getArgument(0));
+            return builder;
+        }).when(builder).topic(anyString());
+        doAnswer(invocation -> {
+            final Producer<byte[]> producer = mock(Producer.class);
+            when(producer.getTopic()).thenReturn(requestedTopics.get(requestedTopics.size() - 1));
+            producers.add(producer);
+            return producer;
+        }).when(builder).create();
+
+        pool = new PublisherPool(mock(ComponentLog.class), Collections.emptyMap(), client);
+    }
+
+    @Test
+    public void closingALeaseReturnsTheProducerToThePool() throws PulsarClientException {
+        final PublisherLease first = pool.obtainPublisher("topic-a");
+        first.close();
+        final PublisherLease second = pool.obtainPublisher("topic-a");
+
+        assertSame("an idle lease for the same topic must be handed out again", first, second);
+        verify(builder, times(1)).create();
+        verify(producers.get(0), never()).close();
+        assertEquals(1, pool.getOpenProducerCount());
+        assertEquals(0, pool.getIdleProducerCount());
+    }
+
+    @Test
+    public void aNewProducerIsCreatedOnlyWhenEveryLeaseForTheTopicIsInUse() throws PulsarClientException {
+        final PublisherLease first = pool.obtainPublisher("topic-a");
+        final PublisherLease second = pool.obtainPublisher("topic-a");
+
+        assertNotSame(first, second);
+        verify(builder, times(2)).create();
+
+        first.close();
+        second.close();
+        assertEquals(2, pool.getIdleProducerCount());
+
+        pool.obtainPublisher("topic-a");
+        pool.obtainPublisher("topic-a");
+        verify(builder, times(2)).create();
+        assertEquals(0, pool.getIdleProducerCount());
+        assertEquals(2, pool.getOpenProducerCount());
+    }
+
+    @Test
+    public void producersArePooledPerTopic() throws PulsarClientException {
+        pool.obtainPublisher("topic-a").close();
+        final PublisherLease other = pool.obtainPublisher("topic-b");
+
+        verify(builder, times(2)).create();
+        assertEquals("topic-b", other.getTopicName());
+        assertEquals(1, pool.getIdleProducerCount());
+
+        assertEquals("topic-a", pool.obtainPublisher("topic-a").getTopicName());
+        verify(builder, times(2)).create();
+    }
+
+    @Test
+    public void closingThePoolClosesIdleAndInUseProducersExactlyOnce() throws PulsarClientException {
+        final PublisherLease inUse = pool.obtainPublisher("topic-a");
+        pool.obtainPublisher("topic-b").close();
+        assertEquals(2, pool.getOpenProducerCount());
+
+        pool.close();
+
+        for (Producer<byte[]> producer : producers) {
+            verify(producer, times(1)).flush();
+            verify(producer, times(1)).close();
+        }
+        assertEquals(0, pool.getOpenProducerCount());
+        assertEquals(0, pool.getIdleProducerCount());
+        assertTrue(pool.isClosed());
+
+        // the lease that was in use is closed by its owner later: its producer must not be closed twice
+        inUse.close();
+        verify(producers.get(0), times(1)).close();
+    }
+
+    @Test
+    public void aLeaseClosedAfterThePoolClosesItsProducerInsteadOfReturning() throws PulsarClientException {
+        final PublisherLease lease = pool.obtainPublisher("topic-a");
+        pool.close();
+        verify(producers.get(0), times(1)).close();
+
+        lease.close();
+        lease.close();
+        verify(producers.get(0), times(1)).close();
+        assertEquals(0, pool.getIdleProducerCount());
+    }
+
+    @Test
+    public void obtainAfterCloseIsRejected() {
+        pool.close();
+        try {
+            pool.obtainPublisher("topic-a");
+            fail("expected IllegalStateException");
+        } catch (final IllegalStateException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void blankTopicYieldsNoProducer() throws PulsarClientException {
+        assertNull(pool.obtainPublisher(""));
+        assertNull(pool.obtainPublisher(null));
+        verify(builder, never()).create();
+        assertEquals(0, pool.getOpenProducerCount());
+    }
+
+    @Test
+    public void producerCreationFailureYieldsNullAndLeaksNothing() throws PulsarClientException {
+        doThrow(new PulsarClientException("cannot create")).when(builder).create();
+
+        assertNull(pool.obtainPublisher("topic-a"));
+        assertEquals(0, pool.getOpenProducerCount());
+        assertEquals(0, pool.getIdleProducerCount());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #156.

`PublisherPool.publisherQueue` was never written to, so the pool was a factory with a dead queue attached: every `obtainPublisher()` built a new producer, a lease's `close()` removed it from the always-empty queue instead of closing it, and `PublisherPool.close()` drained that same empty queue. Every producer the bundle opened, and its broker connection, was leaked; `PublishPulsarRecord` compounded it by obtaining a lease per FlowFile and never closing it, and `AbstractPulsarProducerProcessor` abandoned the pool on stop.

### What changed

- **`PublisherPool`** keeps an idle queue per topic plus the set of every open lease. `obtainPublisher()` hands out an idle producer for the topic and only creates a new one when all leases for that topic are in use. Closing a lease returns it to the pool; closing the pool closes every producer it created, idle **or in use**, and a lease closed after that closes its producer instead of returning. Both paths are idempotent, including the race of a producer created while the pool is closing. Two accessors (`getOpenProducerCount()`, `getIdleProducerCount()`) expose the state for tests and diagnostics.
- **`AbstractPulsarProducerProcessor`** gains `@OnStopped closePublisherPool()`, mirroring how the consumer side releases its consumers through the LRU cache.
- **`PublishPulsarRecord`** returns its lease in a `finally` block after each FlowFile and reports `msg.count` per FlowFile (the lease counter is cumulative now that leases are reused). `PublishPulsar` needed no change: its per-topic `currentLease` reuse and `@OnUnscheduled` cleanup now return the producer to the pool, and `@OnStopped` closes it.

### Tests

- `PublisherPoolTest`: idle producer reused for the same topic, new producer only when all leases for the topic are in use, per-topic pooling, `close()` closes idle and in-use producers exactly once, lease closed after the pool closes its producer once, obtain after close rejected, blank topic and creation failure leak nothing.
- `PublishProducerPoolTest`: three FlowFiles to one topic use one producer and it is closed exactly once when the processor stops, for both `PublishPulsar` and `PublishPulsarRecord`; `msg.count` stays per FlowFile; a restart builds a new producer.

Behaviour visible to users: one producer per topic per processor instead of one per FlowFile (`PublishPulsarRecord`) or one per topic switch (`PublishPulsar`), and producers/connections are released when the processor is stopped.

Not run locally: the Testcontainers integration tests from #152 (no Docker daemon on this machine); the unit suite and `mvn clean package` pass.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `mvn clean package` succeeds locally with Java 21 (`mvn clean package -Dgpg.skip=true -pl '!docker-image'` on this branch)
- [x] Added or updated tests where it makes sense
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
