### PR TITLE
fix: discard empty FlowFiles in async mode and make the consumer cache size configurable

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -176,6 +176,19 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .defaultValue("2")
             .build();
 
+    public static final PropertyDescriptor CONSUMER_CACHE_SIZE = new PropertyDescriptor.Builder()
+            .name("CONSUMER_CACHE_SIZE")
+            .displayName("Consumer Cache Size")
+            .description("The maximum number of Pulsar consumers this processor keeps open at once. When the "
+                    + "cache is full the least recently used consumer is closed to make room, which unsubscribes "
+                    + "it until it is needed again. Set this at or above the number of topics a Topics Pattern "
+                    + "subscription is expected to match, otherwise consumers will be closed and reopened as the "
+                    + "processor cycles through them.")
+            .required(false)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .defaultValue("20")
+            .build();
+
     public static final PropertyDescriptor ACK_TIMEOUT = new PropertyDescriptor.Builder()
             .name("ACK_TIMEOUT")
             .displayName("Acknowledgment Timeout")
@@ -331,6 +344,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         descriptorList.add(TOPICS_PATTERN);
         descriptorList.add(SUBSCRIPTION_NAME);
         descriptorList.add(SUBSCRIPTION_INITIAL_POSITION);
+        descriptorList.add(CONSUMER_CACHE_SIZE);
         descriptorList.add(CONSUMER_NAME);
         descriptorList.add(ASYNC_ENABLED);
         descriptorList.add(MAX_ASYNC_REQUESTS);
@@ -398,6 +412,12 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
 
     @OnScheduled
     public void init(ProcessContext context) {
+        // Record the size only. Replacing the cache here would abandon the consumers the previous one
+        // holds without closing them, and the broker then refuses the replacement consumer on an
+        // Exclusive subscription with "Exclusive consumer is already connected". The cache is built
+        // lazily below and disposed in cleanUp().
+        this.consumerCacheSize = context.getProperty(CONSUMER_CACHE_SIZE).asInteger();
+
         if (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean()) {
             setConsumerPool(Executors.newFixedThreadPool(context.getProperty(MAX_ASYNC_REQUESTS).asInteger()));
             setConsumerService(new ExecutorCompletionService<>(getConsumerPool()));
@@ -434,7 +454,10 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
     @OnStopped
     public void cleanUp(final ProcessContext context) {
         shutDown(context);
+        // clear() closes each cached consumer
         getConsumers().clear();
+        // drop the cache itself so a restart rebuilds it at the currently configured size
+        setConsumers(null);
     }
 
     /**
@@ -623,9 +646,14 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
        this.pulsarClientService = pulsarClientService;
     }
 
+    /** Used when the processor has not been scheduled, i.e. outside a running flow. */
+    static final int DEFAULT_CONSUMER_CACHE_SIZE = 20;
+
+    private volatile int consumerCacheSize = DEFAULT_CONSUMER_CACHE_SIZE;
+
     protected synchronized PulsarConsumerLRUCache<String, Consumer<GenericRecord>> getConsumers() {
         if (consumers == null) {
-           consumers = new PulsarConsumerLRUCache<String, Consumer<GenericRecord>>(20);
+           consumers = new PulsarConsumerLRUCache<String, Consumer<GenericRecord>>(consumerCacheSize);
         }
         return consumers;
     }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -119,10 +119,17 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             // mapped attributes changed, write the current flowfile and start a new one
                             IOUtils.closeQuietly(out);
 
-                            flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
-                            flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
-                            session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
-                            session.transfer(flowFile, REL_SUCCESS);
+                            if (msgCount.get() < 1) {
+                                // every message in this batch had an empty payload, so there is nothing to
+                                // route; the synchronous path has always discarded these
+                                session.remove(flowFile);
+                            } else {
+                                flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
+                                flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
+                                session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
+                                session.transfer(flowFile, REL_SUCCESS);
+                            }
+
                             session.commitAsync();
 
                             if (!shared) {
@@ -165,17 +172,19 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         }
                         
                         try {
-                        	//only write demarcators between messages
-                        	if (msgCount.get() > 0) {
-                        		out.write(demarcatorBytes);
-                        	}
-                        	
-                        	 byte[] data = msg.getData();
-                             
-                             if (data != null && data.length > 0) {
-                               out.write(data);
-                               msgCount.getAndIncrement();
-                             }
+                            byte[] data = msg.getData();
+
+                            if (data != null && data.length > 0) {
+                                // only write demarcators between messages that carry content: writing one
+                                // before checking the payload put a stray separator in the FlowFile for
+                                // every empty message, which reads downstream as a blank record
+                                if (msgCount.get() > 0) {
+                                    out.write(demarcatorBytes);
+                                }
+
+                                out.write(data);
+                                msgCount.getAndIncrement();
+                            }
                              
                         } catch (final IOException ioEx) {
                             session.rollback();
@@ -185,10 +194,15 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
                     IOUtils.closeQuietly(out);
 
-                    flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
-                    flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
-                    session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
-                    session.transfer(flowFile, REL_SUCCESS);
+                    if (msgCount.get() < 1) {
+                        session.remove(flowFile);
+                    } else {
+                        flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
+                        flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
+                        session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
+                        session.transfer(flowFile, REL_SUCCESS);
+                    }
+
                     session.commitAsync();
 
                     // Cumulatively acknowledge consuming the message for non-shared subs. This has to stay
@@ -279,16 +293,16 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     	consumer.acknowledge(msg);
                     }
                     
-                    // only write demarcators between messages
-                    if (msgCount.get() > 0) {
-                    	out.write(demarcatorBytes);
-                    }
-                    
                     byte[] data = msg.getData();
-                    
+
                     if (data != null && data.length > 0) {
-                      out.write(data);
-                      msgCount.getAndIncrement();
+                        // only write demarcators between messages that carry content
+                        if (msgCount.get() > 0) {
+                            out.write(demarcatorBytes);
+                        }
+
+                        out.write(data);
+                        msgCount.getAndIncrement();
                     }
                     
                 } catch (final IOException ioEx) {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarEmptyMessageTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarEmptyMessageTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Messages with an empty payload must not produce an empty FlowFile.
+ * <p>
+ * The synchronous path has always guarded its transfers with {@code if (msgCount.get() < 1)} and removed
+ * the FlowFile instead. The asynchronous path transferred unconditionally, so a poll in which every
+ * message had an empty payload emitted a FlowFile with no content and {@code message.count} of 0. The two
+ * paths disagreed; this pins them to the same behaviour.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarEmptyMessageTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/empty-payloads";
+
+    @Parameters(name = "async={0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
+    private final boolean async;
+
+    public ConsumePulsarEmptyMessageTest(final boolean async) {
+        this.async = async;
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+    }
+
+    /** A batch of nothing but empty payloads should emit nothing at all. */
+    @Test
+    public void allEmptyPayloadsProduceNoFlowFile() {
+        mockClientService.setMockMessageQueue(messages(new byte[0], new byte[0], new byte[0]));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+    }
+
+    /** A null payload is the same case and must be treated the same way. */
+    @Test
+    public void nullPayloadsProduceNoFlowFile() {
+        mockClientService.setMockMessageQueue(messages(null, null));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+    }
+
+    /** Mixed content still comes through, carrying only the messages that had a payload. */
+    @Test
+    public void emptyPayloadsAreSkippedButRealOnesArrive() {
+        mockClientService.setMockMessageQueue(messages(
+                "one".getBytes(UTF_8), new byte[0], "two".getBytes(UTF_8)));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 1);
+        final org.apache.nifi.util.MockFlowFile flowFile =
+                runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).get(0);
+        flowFile.assertContentEquals("one\ntwo");
+        assertEquals("2", flowFile.getAttribute(ConsumePulsar.MSG_COUNT));
+    }
+
+    private static List<Message<GenericRecord>> messages(final byte[]... payloads) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+        int n = 0;
+        for (final byte[] payload : payloads) {
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, payload, "1234:" + (++n) + ":0", null, null));
+        }
+        return msgs;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
@@ -61,9 +61,11 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS);
 
-        // Make sure no Flowfiles were generated
+        // Make sure no Flowfiles were generated. This asserted 1 while its own comment - and the
+        // synchronous test next to it - said 0: the async path transferred the FlowFile without checking
+        // whether anything had been written to it.
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
-        assertEquals(1, flowFiles.size());
+        assertEquals(0, flowFiles.size());
     }
 
     @Test


### PR DESCRIPTION
The last two findings from the code review, both low severity. **This closes the review list.**

### 1. Empty FlowFiles in async mode

The sync path guards its transfers with `if (msgCount.get() < 1)` and removes the FlowFile; the async path transferred unconditionally, so a poll where every message had an empty payload emitted a FlowFile with no content and `message.count` of 0.

**The two existing `emptyMessageTest` cases settle the intent.** They carry the *same comment* — "Make sure no Flowfiles were generated" — but sync asserts `0` and async asserts `1`. The async assertion recorded the behaviour rather than the intent; it now asserts 0.

### 2. Stray demarcators (found by the new test, not by inspection)

The demarcator was written *before* checking whether the message had a payload, so every empty message put a separator into the FlowFile. Three messages with the middle one empty produced:

```
one\n\ntwo
```

— a blank record downstream. The demarcator now goes in only alongside content.

### 3. Consumer cache size

The LRU size was a literal `20` with no property behind it, and eviction closes the consumer, so a Topics Pattern subscription matching more than twenty topics silently closed and rebuilt consumers as it cycled. Now the **Consumer Cache Size** property, defaulting to 20.

⚠️ **The integration tests caught a bug I introduced here.** My first version replaced the cache on every `@OnScheduled`, which abandons the previous cache's consumers without closing them — the broker then refuses the replacement on an Exclusive subscription:

```
ConsumerBusyException: Exclusive consumer is already connected
```

That is the same defect fixed for the producer pool in #159, reintroduced on the consumer side. The size is now recorded at schedule time with the cache built lazily and disposed in `cleanUp()`.

**Verification:** new `ConsumePulsarEmptyMessageTest` covers all-empty, null and mixed payloads in both modes — **four of its six cases fail on `main`**. Full build green: 243 unit + 17 integration.