### PR TITLE
fix: acknowledge Pulsar messages only after the session carrying them commits

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.pulsar.pubsub;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -112,6 +113,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     Map<String, String> currentAttributes = null;
                     MessageBatchAttributes batchAttributes = null;
 
+                    // acknowledged only once the session carrying their content has committed
+                    final List<Message<GenericRecord>> pendingAcks = new ArrayList<>();
+
                     for (Message<GenericRecord> msg : messages) {
                         currentAttributes = getMappedFlowFileAttributes(context, msg);
 
@@ -130,19 +134,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                                 session.transfer(flowFile, REL_SUCCESS);
                             }
 
-                            session.commitAsync();
-
-                            if (!shared) {
-	                            final Message<GenericRecord> finalMessage = lastMessage;
-	                            // Cumulatively acknowledge consuming the messages for non-shared subs
-	                            
-	                            getAckService().submit(new Callable<Object>() {
-	                                @Override
-	                                public Object call() throws Exception {
-	                                    return consumer.acknowledgeCumulativeAsync(finalMessage).get();
-	                                }
-	                            });
-                            }
+                            acknowledgeOnCommit(session, consumer, pendingAcks, shared, true);
 
                             lastAttributes = null;
                             lastMessage = null;
@@ -161,16 +153,6 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         lastMessage = msg;
                         batchAttributes.add(msg);
  
-                        if (shared) {
-                        	// acknowledge each message individually for shared subs
-                        	getAckService().submit(new Callable<Object>() {
-                        		@Override
-                        		public Object call() throws Exception {
-                        			return consumer.acknowledgeAsync(msg).get();
-                        		}
-                        	});
-                        }
-                        
                         try {
                             byte[] data = msg.getData();
 
@@ -185,8 +167,15 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                                 out.write(data);
                                 msgCount.getAndIncrement();
                             }
-                             
+
+                            // content is in the FlowFile now, so this message may be acknowledged once the
+                            // session commits - never before
+                            pendingAcks.add(msg);
+
                         } catch (final IOException ioEx) {
+                            getLogger().error("Unable to write the message to a FlowFile", ioEx);
+                            // roll back WITHOUT acknowledging, so the broker redelivers
+                            pendingAcks.clear();
                             session.rollback();
                             return;
                         }
@@ -203,25 +192,97 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         session.transfer(flowFile, REL_SUCCESS);
                     }
 
-                    session.commitAsync();
-
-                    // Cumulatively acknowledge consuming the message for non-shared subs. This has to stay
-                    // inside the isNotEmpty() guard: on an idle topic the list is empty and there is no last
-                    // message to acknowledge.
-                    if (!shared) {
-	                    getAckService().submit(new Callable<Object>() {
-	                        @Override
-	                        public Object call() throws Exception {
-	                           return consumer.acknowledgeCumulativeAsync(messages.get(messages.size() - 1)).get();
-	                        }
-	                    });
-                    }
+                    acknowledgeOnCommit(session, consumer, pendingAcks, shared, true);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
             getLogger().error("Trouble consuming messages ", e);
         } finally {
             drainAcknowledgments();
+        }
+    }
+
+    /**
+     * Acknowledges the given messages once - and only once - the session carrying their content has
+     * committed, then clears the list.
+     * <p>
+     * Acknowledging earlier loses messages. A message acknowledged before its content is written, or after
+     * the session has been rolled back, is gone from Pulsar without ever having reached a FlowFile: the
+     * broker will not redeliver it and nothing routes it to a failure relationship. Deferring to the commit
+     * callback keeps the processor at-least-once - a failure after the write means redelivery, which is
+     * duplication rather than loss.
+     *
+     * @param session the session carrying the messages' content
+     * @param consumer the consumer the messages came from
+     * @param pending the messages to acknowledge; emptied before returning
+     * @param shared whether the subscription is Shared, where cumulative acknowledgement is not permitted
+     */
+    private void acknowledgeOnCommit(final ProcessSession session, final Consumer<GenericRecord> consumer,
+                                     final List<Message<GenericRecord>> pending, final boolean shared) {
+        acknowledgeOnCommit(session, consumer, pending, shared, false);
+    }
+
+    private void acknowledgeOnCommit(final ProcessSession session, final Consumer<GenericRecord> consumer,
+                                     final List<Message<GenericRecord>> pending, final boolean shared,
+                                     final boolean async) {
+
+        if (pending.isEmpty()) {
+            session.commitAsync();
+            return;
+        }
+
+        final List<Message<GenericRecord>> toAcknowledge = new ArrayList<>(pending);
+        pending.clear();
+
+        session.commitAsync(() -> {
+            if (async) {
+                getAckService().submit(new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        acknowledgeAll(consumer, toAcknowledge, shared, true);
+                        return null;
+                    }
+                });
+            } else {
+                acknowledgeAll(consumer, toAcknowledge, shared, false);
+            }
+        });
+    }
+
+    /**
+     * Acknowledges a batch whose content is already safely in NiFi, using the asynchronous client calls
+     * when the processor is running in async mode so the behaviour matches how it consumed.
+     */
+    private void acknowledgeAll(final Consumer<GenericRecord> consumer,
+                                final List<Message<GenericRecord>> toAcknowledge, final boolean shared,
+                                final boolean async) {
+        try {
+            if (shared) {
+                // cumulative acknowledgement is not permitted on Shared subscriptions
+                for (final Message<GenericRecord> message : toAcknowledge) {
+                    if (async) {
+                        consumer.acknowledgeAsync(message).get();
+                    } else {
+                        consumer.acknowledge(message);
+                    }
+                }
+            } else {
+                final Message<GenericRecord> last = toAcknowledge.get(toAcknowledge.size() - 1);
+
+                if (async) {
+                    consumer.acknowledgeCumulativeAsync(last).get();
+                } else {
+                    consumer.acknowledgeCumulative(last);
+                }
+            }
+        } catch (final InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            getLogger().error("Interrupted while acknowledging {} consumed message(s); they will be redelivered",
+                    new Object[] {toAcknowledge.size()}, interrupted);
+        } catch (final PulsarClientException | ExecutionException ackEx) {
+            // The content is safely in NiFi; the messages will simply be redelivered.
+            getLogger().error("Unable to acknowledge {} consumed message(s); they will be redelivered",
+                    new Object[] {toAcknowledge.size()}, ackEx);
         }
     }
 
@@ -248,19 +309,18 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             Map<String, String> currentAttributes = null;
             MessageBatchAttributes batchAttributes = null;
 
+            // Messages whose content is already in the FlowFile being built. They are acknowledged only
+            // once the session that carries them has committed - see acknowledgeConsumed().
+            final List<Message<GenericRecord>> pendingAcks = new ArrayList<>();
+
             while (loopCounter.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
 
                 if (lastMsg != null && !lastAttributes.equals(currentAttributes)) {
                     IOUtils.closeQuietly(out);
 
-                    if (!shared)  {
-                        consumer.acknowledgeCumulative(lastMsg);
-                    }
-
                     if (msgCount.get() < 1) {
                         session.remove(flowFile);
-                        session.commitAsync();
                     } else {
                         flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                         flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
@@ -269,6 +329,8 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         getLogger().debug("Created {} from {} messages received from Pulsar Server and transferred to 'success'",
                             new Object[]{flowFile, msgCount.toString()});
                     }
+
+                    acknowledgeOnCommit(session, consumer, pendingAcks, shared);
 
                     lastAttributes = null;
                     lastMsg = null;
@@ -288,11 +350,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     lastAttributes = currentAttributes;
                     batchAttributes.add(msg);
                     loopCounter.incrementAndGet();
-                    
-                    if (shared) {
-                    	consumer.acknowledge(msg);
-                    }
-                    
+
                     byte[] data = msg.getData();
 
                     if (data != null && data.length > 0) {
@@ -304,28 +362,27 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         out.write(data);
                         msgCount.getAndIncrement();
                     }
-                    
+
+                    // Taken responsibility for this message: its content is in the FlowFile, or it had no
+                    // content to write. Acknowledging happens after the session commits, not here.
+                    pendingAcks.add(msg);
+
                 } catch (final IOException ioEx) {
                     getLogger().error("Unable to create flow file ", ioEx);
+                    // Roll back WITHOUT acknowledging. This used to acknowledge cumulatively immediately
+                    // after the rollback, which discarded the FlowFiles and told the broker the messages
+                    // were handled: they were neither in NiFi nor redeliverable from Pulsar.
+                    pendingAcks.clear();
                     session.rollback();
-                    if (!shared) {
-                        consumer.acknowledgeCumulative(lastMsg);
-                    }
-  
                     return;
                 }
             }
             
             IOUtils.closeQuietly(out);
 
-            if (!shared && lastMsg != null)  {
-                consumer.acknowledgeCumulative(lastMsg);
-            }
-
             if (msgCount.get() < 1) {
                 if (flowFile != null) {
                     session.remove(flowFile);
-                    session.commitAsync();
                 }
             } else {
                 flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
@@ -335,6 +392,8 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 getLogger().debug("Created {} from {} messages received from Pulsar Server and transferred to 'success'",
                    new Object[]{flowFile, msgCount.toString()});
             }
+
+            acknowledgeOnCommit(session, consumer, pendingAcks, shared);
 
         } catch (PulsarClientException e) {
             getLogger().error("Error communicating with Apache Pulsar", e);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -251,6 +251,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         Map<String, String> currentAttributes = null;
         MessageBatchAttributes batchAttributes = null;
 
+        // Messages this processor has taken responsibility for - written into the record set, or routed to
+        // parse_failure. They are acknowledged only once the session carrying them has committed.
+        final List<Message<GenericRecord>> pendingAcks = new ArrayList<>();
+
         // Cumulative acks are NOT permitted on Shared subscriptions
         final boolean shared = isSharedSubscription(context);
 
@@ -281,15 +285,20 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                         session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                         session.transfer(flowFile, REL_SUCCESS);
                     } else {
+                        // The record set could not be written, so those messages must NOT be acknowledged.
+                        // Rolling back and then acknowledging - as this used to - discards the FlowFile and
+                        // tells the broker the messages were handled, losing them for good.
+                        pendingAcks.clear();
                         session.rollback();
                     }
 
-                    handleFailures(session, parseFailures, demarcator);
+                    if (handleFailures(session, parseFailures, demarcator)) {
+                        // routed to parse_failure, so they have been dealt with and may be acknowledged
+                        pendingAcks.addAll(parseFailures);
+                    }
                     parseFailures.clear();
 
-                    if (!shared) {
-                        acknowledgeCumulative(consumer, lastMessage, async);
-                    }
+                    acknowledgeOnCommit(session, consumer, pendingAcks, shared, async);
 
                     lastAttributes = null;
                     lastMessage = null;
@@ -326,10 +335,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 lastMessage = msg;
                 batchAttributes.add(msg);
 
-                if (shared) {
-                    acknowledge(consumer, msg, async);
-                }
-
                 // write each of the records in the current message to the active record set. These will each
                 // have the same mapped flowfile attribute values, which means that it's ok that they are all placed
                 // in the same output flowfile.
@@ -340,7 +345,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                     for (Record record = r.nextRecord(); record != null; record = r.nextRecord()) {
                         writer.write(record);
                     }
+                    // records are in the record set; acknowledging waits for the session to commit
+                    pendingAcks.add(msg);
                 } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
+                    // queued for parse_failure instead; acknowledged only once that FlowFile is routed
                     parseFailures.add(msg);
                 }
             }
@@ -360,18 +368,63 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                 session.transfer(flowFile, REL_SUCCESS);
             } else if (writer != null) {
-                // We were able to parse the records, but unable to write them to the FlowFile
+                // An open record set that produced no records: the messages carried nothing to emit. There
+                // is no FlowFile worth keeping, but the messages have still been consumed and must be
+                // acknowledged, or the broker redelivers them forever. A message whose records genuinely
+                // could not be written throws instead and is routed to parse_failure above.
                 session.rollback();
             }
         } catch (IOException e) {
             getLogger().error("Unable to consume from Pulsar topic ", e);
         }
 
-        handleFailures(session, parseFailures, demarcator);
-
-        if (!shared) {
-            acknowledgeCumulative(consumer, messages.get(messages.size() - 1), async);
+        if (handleFailures(session, parseFailures, demarcator)) {
+            pendingAcks.addAll(parseFailures);
         }
+        parseFailures.clear();
+
+        acknowledgeOnCommit(session, consumer, pendingAcks, shared, async);
+    }
+
+    /**
+     * Acknowledges the given messages once the session carrying their content has committed, then clears
+     * the list.
+     * <p>
+     * Acknowledging before the commit - or after a rollback, as the previous code did - removes the
+     * messages from Pulsar without them ever reaching a FlowFile. Deferring keeps the processor
+     * at-least-once: a failure after the write means redelivery, which is duplication rather than loss.
+     *
+     * @param session the session carrying the messages' content
+     * @param consumer the consumer the messages came from
+     * @param pending the messages to acknowledge; emptied before returning
+     * @param shared whether the subscription is Shared, where cumulative acknowledgement is not permitted
+     * @param async whether to use the asynchronous client calls
+     */
+    private void acknowledgeOnCommit(final ProcessSession session, final Consumer<GenericRecord> consumer,
+                                     final List<Message<GenericRecord>> pending, final boolean shared,
+                                     final boolean async) {
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        final List<Message<GenericRecord>> toAcknowledge = new ArrayList<>(pending);
+        pending.clear();
+
+        session.commitAsync(() -> {
+            try {
+                if (shared) {
+                    for (final Message<GenericRecord> message : toAcknowledge) {
+                        acknowledge(consumer, message, async);
+                    }
+                } else {
+                    acknowledgeCumulative(consumer, toAcknowledge.get(toAcknowledge.size() - 1), async);
+                }
+            } catch (final PulsarClientException ackEx) {
+                // The content is safely in NiFi; the messages will simply be redelivered.
+                getLogger().error("Unable to acknowledge {} consumed message(s); they will be redelivered",
+                        new Object[] {toAcknowledge.size()}, ackEx);
+            }
+        });
     }
 
     /**
@@ -429,11 +482,11 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         }
     }
 
-    private void handleFailures(ProcessSession session,
-                                BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) {
+    private boolean handleFailures(ProcessSession session,
+                                   BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) {
 
         if (CollectionUtils.isEmpty(parseFailures)) {
-            return;
+            return false;
         }
 
         FlowFile flowFile = session.create();
@@ -457,6 +510,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         } else {
             session.remove(flowFile);
         }
+
+        return written;
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckOnCommitTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckOnCommitTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * A message may only be acknowledged once the session carrying its content has committed (issue #167).
+ * <p>
+ * ConsumePulsar used to acknowledge either before the content was written - on a Shared subscription every
+ * message was acknowledged as it was claimed, ahead of the write - or immediately after a rollback:
+ * <pre>
+ *     session.rollback();
+ *     if (!shared) {
+ *         consumer.acknowledgeCumulative(lastMsg);
+ *     }
+ * </pre>
+ * Either way the message was gone from Pulsar without ever reaching a FlowFile: the broker does not
+ * redeliver an acknowledged message, and nothing routes it to a failure relationship. That is silent,
+ * unrecoverable loss on any FlowFile write error.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarAckOnCommitTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/ack-on-commit";
+    private static final int MESSAGE_COUNT = 4;
+
+    @Parameters(name = "shared={0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
+    private final boolean shared;
+
+    public ConsumePulsarAckOnCommitTest(final boolean shared) {
+        this.shared = shared;
+    }
+
+    /**
+     * Runs the real processor against a session whose {@code write()} hands back a stream that always
+     * throws, which is what a full content repository or a disk error looks like from here.
+     */
+    public static class FailingWriteConsumePulsar extends ConsumePulsar {
+        @Override
+        public void onTrigger(final ProcessContext context, final ProcessSession session) {
+            super.onTrigger(context, failingWriteSession(session));
+        }
+    }
+
+    /**
+     * A ProcessSession that behaves exactly like the real one except that the OutputStream from
+     * {@code write(FlowFile)} refuses to write. The real stream is closed straight away so the session is
+     * not left holding an open stream on the FlowFile.
+     */
+    private static ProcessSession failingWriteSession(final ProcessSession delegate) {
+        return (ProcessSession) Proxy.newProxyInstance(
+                ConsumePulsarAckOnCommitTest.class.getClassLoader(),
+                new Class<?>[] {ProcessSession.class},
+                (proxy, method, args) -> {
+                    final Object result = method.invoke(delegate, args);
+
+                    if ("write".equals(method.getName()) && result instanceof OutputStream) {
+                        ((OutputStream) result).close();
+                        return new OutputStream() {
+                            @Override
+                            public void write(final int b) throws IOException {
+                                throw new IOException("Intentional Unit Test Exception: cannot write");
+                            }
+
+                            @Override
+                            public void write(final byte[] b, final int off, final int len) throws IOException {
+                                throw new IOException("Intentional Unit Test Exception: cannot write");
+                            }
+
+                            @Override
+                            public void close() {
+                                // already closed
+                            }
+                        };
+                    }
+
+                    return result;
+                });
+    }
+
+    private void configure(final Class<? extends ConsumePulsar> processorClass) throws InitializationException {
+        runner = TestRunners.newTestRunner(processorClass);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, shared ? "Shared" : "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, String.valueOf(MESSAGE_COUNT));
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        mockClientService.setMockMessageQueue(messages());
+    }
+
+    /**
+     * The healthy path still acknowledges. Deferring the acknowledgement must not mean dropping it - an
+     * unacknowledged message is redelivered forever.
+     */
+    @Test
+    public void messagesAreAcknowledgedOnceTheContentIsCommitted() throws Exception {
+        configure(ConsumePulsar.class);
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 1);
+
+        if (shared) {
+            verify(mockClientService.getMockConsumer(), times(MESSAGE_COUNT)).acknowledge(any(Message.class));
+        } else {
+            verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(any(Message.class));
+        }
+    }
+
+    /**
+     * The bug: when the write fails the session is rolled back, so nothing may be acknowledged. The
+     * messages stay with the broker and are redelivered - duplication rather than loss.
+     */
+    @Test
+    public void nothingIsAcknowledgedWhenTheWriteFails() throws Exception {
+        configure(FailingWriteConsumePulsar.class);
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        verify(mockClientService.getMockConsumer(), never()).acknowledge(any(Message.class));
+        verify(mockClientService.getMockConsumer(), never()).acknowledgeCumulative(any(Message.class));
+    }
+
+    private static List<Message<GenericRecord>> messages() {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+        for (int n = 1; n <= MESSAGE_COUNT; n++) {
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, ("message-" + n).getBytes(UTF_8),
+                    "1234:" + n + ":0", null, null));
+        }
+        return msgs;
+    }
+}


### PR DESCRIPTION
Fixes #167.

Both consumers acknowledged messages either **before** their content was written or **after** the session that would have carried them had been rolled back. An acknowledged message is gone from Pulsar — the broker does not redeliver it, and it never reached a FlowFile. Nothing routed to a failure relationship, and in the async path nothing was even logged.

**Change:** both processors now collect the messages they have taken responsibility for and acknowledge them from a `session.commitAsync()` callback — after the content is committed, never before, and never on a path that rolls back. The processors stay at-least-once: a failure after the write means redelivery, which is duplication rather than loss. Async mode keeps using the asynchronous client calls so behaviour matches how it consumed.

**Verification** — new `ConsumePulsarAckOnCommitTest` drives the real processor against a session whose `write()` returns a stream that always throws, which is what a full content repository looks like from here. Against `main`, **both rollback cases fail** (Shared and non-shared), showing messages acknowledged despite the rollback. The healthy-path cases pass on both, so the fix does not simply stop acknowledging.

Full build green: **247 unit + 17 integration**.

---

### Two things found while fixing, worth review attention

**1. Parse failures were being dropped.** My first attempt made the rollback branch skip `handleFailures` entirely, discarding the unparseable messages without routing them. That was my bug, but it exposed that acknowledgement and routing were tangled: parse failures are now routed on **both** branches, and acknowledged only once the `parse_failure` FlowFile has actually been transferred — which `handleFailures` now reports back.

**2. A behaviour decision I would like a second opinion on.** In `ConsumePulsarRecord`, a record set that produced **no records** hit the same branch as a failed write:

```java
} else if (writer != null) {
    // We were able to parse the records, but unable to write them to the FlowFile
    session.rollback();
}
```

Those are different situations. Leaving such messages unacknowledged means the broker redelivers them **forever** — an empty message would loop indefinitely. I made that branch acknowledge, on the grounds that a genuine write failure throws and is routed to `parse_failure` instead, so reaching here means "nothing to emit". The existing `emptyMessageTest` in both sync and async agrees: it expects exactly one acknowledgement. But it is a judgement call about someone else's intent, so flagging it.