### PR TITLE
fix: acknowledge consumed messages only after their FlowFile is committed

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -630,6 +630,71 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         }
     }
 
+    /**
+     * Commits the session and, once the commit has succeeded, acknowledges {@code messages} to the broker.
+     * <p>
+     * An acknowledged message is gone from the subscription: the broker never redelivers it. So a message
+     * may only be acknowledged once the FlowFile that carries it has been committed. Acknowledging earlier
+     * - as each message was claimed, or on a path that then rolled the session back - told the broker the
+     * message was handled while its content could still be discarded, and a write error (a full content
+     * repository, a permissions problem, a disk fault) lost the message for good: it was neither in NiFi
+     * nor recoverable from Pulsar. The acknowledgement now runs in the commit callback, so a session that
+     * is never committed acknowledges nothing and the broker redelivers its messages instead.
+     * <p>
+     * Shared and Key_Shared subscriptions do not permit cumulative acknowledgements, so every message is
+     * acknowledged individually; the other subscription types acknowledge cumulatively up to the last
+     * message. In asynchronous mode the acknowledgements are submitted to the acknowledgement service and
+     * collected by {@link #drainAcknowledgments()}, as before. {@code messages} is emptied so the caller
+     * can keep collecting the messages of the next commit in the same list.
+     *
+     * @param session  the session holding the FlowFiles the messages were written to
+     * @param consumer the consumer the messages were received from
+     * @param messages the messages carried by the FlowFiles in the session; cleared on return
+     * @param shared   whether the subscription is Shared or Key_Shared
+     * @param async    whether to acknowledge through the asynchronous acknowledgement service
+     */
+    protected void commitAndAcknowledge(final ProcessSession session, final Consumer<GenericRecord> consumer,
+                                        final List<Message<GenericRecord>> messages, final boolean shared, final boolean async) {
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        final List<Message<GenericRecord>> committed = new ArrayList<>(messages);
+        messages.clear();
+
+        session.commitAsync(() -> acknowledge(consumer, committed, shared, async));
+    }
+
+    private void acknowledge(final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,
+                             final boolean shared, final boolean async) {
+        final ExecutorCompletionService<Object> service = async ? getAckService() : null;
+
+        try {
+            if (shared) {
+                for (final Message<GenericRecord> message : messages) {
+                    if (service != null) {
+                        service.submit(() -> consumer.acknowledgeAsync(message).get());
+                    } else {
+                        consumer.acknowledge(message);
+                    }
+                }
+            } else {
+                final Message<GenericRecord> last = messages.get(messages.size() - 1);
+
+                if (service != null) {
+                    service.submit(() -> consumer.acknowledgeCumulativeAsync(last).get());
+                } else {
+                    consumer.acknowledgeCumulative(last);
+                }
+            }
+        } catch (final PulsarClientException e) {
+            // The FlowFiles are already committed, so nothing is lost: the broker redelivers whatever was
+            // not acknowledged and the flow sees those messages again.
+            getLogger().error("Unable to acknowledge {} message(s) whose FlowFiles were committed; the broker will redeliver them",
+                    messages.size(), e);
+        }
+    }
+
     protected synchronized ExecutorCompletionService<Object> getAckService() {
        return ackService;
     }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -19,9 +19,9 @@ package org.apache.nifi.processors.pulsar.pubsub;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -108,9 +108,11 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     AtomicInteger msgCount = new AtomicInteger(0);
 
                     Map<String, String> lastAttributes = null;
-                    Message<GenericRecord> lastMessage = null;
                     Map<String, String> currentAttributes = null;
                     MessageBatchAttributes batchAttributes = null;
+                    // the messages written to the FlowFile that has not been committed yet: they are
+                    // acknowledged once it is, and not at all if it is rolled back
+                    final List<Message<GenericRecord>> uncommitted = new ArrayList<>();
 
                     for (Message<GenericRecord> msg : messages) {
                         currentAttributes = getMappedFlowFileAttributes(context, msg);
@@ -130,22 +132,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                                 session.transfer(flowFile, REL_SUCCESS);
                             }
 
-                            session.commitAsync();
-
-                            if (!shared) {
-	                            final Message<GenericRecord> finalMessage = lastMessage;
-	                            // Cumulatively acknowledge consuming the messages for non-shared subs
-	                            
-	                            getAckService().submit(new Callable<Object>() {
-	                                @Override
-	                                public Object call() throws Exception {
-	                                    return consumer.acknowledgeCumulativeAsync(finalMessage).get();
-	                                }
-	                            });
-                            }
+                            commitAndAcknowledge(session, consumer, uncommitted, shared, true);
 
                             lastAttributes = null;
-                            lastMessage = null;
                         }
 
                         if (lastAttributes == null) {
@@ -158,19 +147,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         }
 
                         lastAttributes = currentAttributes;
-                        lastMessage = msg;
                         batchAttributes.add(msg);
- 
-                        if (shared) {
-                        	// acknowledge each message individually for shared subs
-                        	getAckService().submit(new Callable<Object>() {
-                        		@Override
-                        		public Object call() throws Exception {
-                        			return consumer.acknowledgeAsync(msg).get();
-                        		}
-                        	});
-                        }
-                        
+                        uncommitted.add(msg);
+
                         try {
                             byte[] data = msg.getData();
 
@@ -187,6 +166,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             }
                              
                         } catch (final IOException ioEx) {
+                            // nothing has been acknowledged, so the broker redelivers the whole batch
+                            getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", ioEx);
+                            IOUtils.closeQuietly(out);
                             session.rollback();
                             return;
                         }
@@ -203,19 +185,10 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         session.transfer(flowFile, REL_SUCCESS);
                     }
 
-                    session.commitAsync();
-
-                    // Cumulatively acknowledge consuming the message for non-shared subs. This has to stay
-                    // inside the isNotEmpty() guard: on an idle topic the list is empty and there is no last
-                    // message to acknowledge.
-                    if (!shared) {
-	                    getAckService().submit(new Callable<Object>() {
-	                        @Override
-	                        public Object call() throws Exception {
-	                           return consumer.acknowledgeCumulativeAsync(messages.get(messages.size() - 1)).get();
-	                        }
-	                    });
-                    }
+                    // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a
+                    // time otherwise. This has to stay inside the isNotEmpty() guard: on an idle topic the
+                    // list is empty and there is nothing to commit or acknowledge.
+                    commitAndAcknowledge(session, consumer, uncommitted, shared, true);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
@@ -247,6 +220,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             Map<String, String> lastAttributes = null;
             Map<String, String> currentAttributes = null;
             MessageBatchAttributes batchAttributes = null;
+            // the messages written to the FlowFile that has not been committed yet: they are acknowledged
+            // once it is, and not at all if it is rolled back
+            final List<Message<GenericRecord>> uncommitted = new ArrayList<>();
 
             while (loopCounter.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
@@ -254,13 +230,8 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 if (lastMsg != null && !lastAttributes.equals(currentAttributes)) {
                     IOUtils.closeQuietly(out);
 
-                    if (!shared)  {
-                        consumer.acknowledgeCumulative(lastMsg);
-                    }
-
                     if (msgCount.get() < 1) {
                         session.remove(flowFile);
-                        session.commitAsync();
                     } else {
                         flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
                         flowFile = session.putAttribute(flowFile, MSG_COUNT, msgCount.toString());
@@ -269,6 +240,8 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         getLogger().debug("Created {} from {} messages received from Pulsar Server and transferred to 'success'",
                             new Object[]{flowFile, msgCount.toString()});
                     }
+
+                    commitAndAcknowledge(session, consumer, uncommitted, shared, false);
 
                     lastAttributes = null;
                     lastMsg = null;
@@ -288,10 +261,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     lastAttributes = currentAttributes;
                     batchAttributes.add(msg);
                     loopCounter.incrementAndGet();
-                    
-                    if (shared) {
-                    	consumer.acknowledge(msg);
-                    }
+                    uncommitted.add(msg);
                     
                     byte[] data = msg.getData();
 
@@ -306,26 +276,19 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     }
                     
                 } catch (final IOException ioEx) {
-                    getLogger().error("Unable to create flow file ", ioEx);
+                    // nothing has been acknowledged, so the broker redelivers the whole batch
+                    getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", ioEx);
+                    IOUtils.closeQuietly(out);
                     session.rollback();
-                    if (!shared) {
-                        consumer.acknowledgeCumulative(lastMsg);
-                    }
-  
                     return;
                 }
             }
             
             IOUtils.closeQuietly(out);
 
-            if (!shared && lastMsg != null)  {
-                consumer.acknowledgeCumulative(lastMsg);
-            }
-
             if (msgCount.get() < 1) {
                 if (flowFile != null) {
                     session.remove(flowFile);
-                    session.commitAsync();
                 }
             } else {
                 flowFile = session.putAllAttributes(flowFile, batchAttributes.toAttributes());
@@ -335,6 +298,10 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 getLogger().debug("Created {} from {} messages received from Pulsar Server and transferred to 'success'",
                    new Object[]{flowFile, msgCount.toString()});
             }
+
+            // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time
+            // otherwise. Nothing is committed or acknowledged when no message was received.
+            commitAndAcknowledge(session, consumer, uncommitted, shared, false);
 
         } catch (PulsarClientException e) {
             getLogger().error("Error communicating with Apache Pulsar", e);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -205,7 +204,9 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     /**
      * Perform the actual processing of the messages, by parsing the messages and writing them out to a FlowFile.
      * All of the messages passed in shall be routed to either SUCCESS or PARSE_FAILURE, allowing us to acknowledge
-     * the receipt of the messages to Pulsar, so they are not re-sent.
+     * the receipt of the messages to Pulsar, so they are not re-sent. The acknowledgement is issued once the
+     * session carrying the FlowFiles has been committed; if the batch cannot be written, the session is rolled
+     * back and nothing is acknowledged, so the broker redelivers the messages instead of losing them.
      *
      * @param context       - The current ProcessContext
      * @param session       - The current ProcessSession.
@@ -250,6 +251,9 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         Message<GenericRecord> lastMessage = null;
         Map<String, String> currentAttributes = null;
         MessageBatchAttributes batchAttributes = null;
+        // the messages carried - on success or on parse_failure - by the FlowFiles that have not been
+        // committed yet: they are acknowledged once those are, and not at all if they are rolled back
+        final List<Message<GenericRecord>> uncommitted = new ArrayList<>();
 
         // Cumulative acks are NOT permitted on Shared subscriptions
         final boolean shared = isSharedSubscription(context);
@@ -281,19 +285,22 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                         session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                         session.transfer(flowFile, REL_SUCCESS);
                     } else {
-                        session.rollback();
+                        // the record set holds no records: discard its FlowFile. Rolling the session back
+                        // here would also discard everything routed before it in this session.
+                        session.remove(flowFile);
                     }
 
                     handleFailures(session, parseFailures, demarcator);
                     parseFailures.clear();
-
-                    if (!shared) {
-                        acknowledgeCumulative(consumer, lastMessage, async);
-                    }
+                    commitAndAcknowledge(session, consumer, uncommitted, shared, async);
 
                     lastAttributes = null;
                     lastMessage = null;
                 }
+
+                // every message ends up in a FlowFile - on success or on parse_failure - or is discarded on
+                // purpose, so it is acknowledged with the commit of the FlowFiles it belongs to
+                uncommitted.add(msg);
 
                 // if there's no record set actively being written, begin one
                 byte[] data = msg.getData();
@@ -326,10 +333,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 lastMessage = msg;
                 batchAttributes.add(msg);
 
-                if (shared) {
-                    acknowledge(consumer, msg, async);
-                }
-
                 // write each of the records in the current message to the active record set. These will each
                 // have the same mapped flowfile attribute values, which means that it's ok that they are all placed
                 // in the same output flowfile.
@@ -360,18 +363,22 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 session.getProvenanceReporter().receive(flowFile, getPulsarClientService().getPulsarBrokerRootURL() + "/" + consumer.getTopic());
                 session.transfer(flowFile, REL_SUCCESS);
             } else if (writer != null) {
-                // We were able to parse the records, but unable to write them to the FlowFile
-                session.rollback();
+                // the record set holds no records: discard its FlowFile rather than roll the session back
+                session.remove(flowFile);
             }
+
+            handleFailures(session, parseFailures, demarcator);
         } catch (IOException e) {
-            getLogger().error("Unable to consume from Pulsar topic ", e);
+            // nothing has been acknowledged, so the broker redelivers the whole batch
+            getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", e);
+            IOUtils.closeQuietly(writer);
+            IOUtils.closeQuietly(rawOut);
+            session.rollback();
+            return;
         }
 
-        handleFailures(session, parseFailures, demarcator);
-
-        if (!shared) {
-            acknowledgeCumulative(consumer, messages.get(messages.size() - 1), async);
-        }
+        // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time otherwise.
+        commitAndAcknowledge(session, consumer, uncommitted, shared, async);
     }
 
     /**
@@ -403,34 +410,15 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         }
     }
 
-    private void acknowledge(final Consumer<GenericRecord> consumer, final Message<GenericRecord> msg, final boolean async) throws PulsarClientException {
-        if (async) {
-            getAckService().submit(new Callable<Object>() {
-                @Override
-                public Object call() throws Exception {
-                    return consumer.acknowledgeAsync(msg).get();
-                }
-            });
-        } else {
-            consumer.acknowledge(msg);
-        }
-    }
-
-    private void acknowledgeCumulative(final Consumer<GenericRecord> consumer, final Message<GenericRecord> msg, final boolean async) throws PulsarClientException {
-        if (async) {
-            getAckService().submit(new Callable<Object>() {
-                @Override
-                public Object call() throws Exception {
-                    return consumer.acknowledgeCumulativeAsync(msg).get();
-                }
-            });
-        } else {
-            consumer.acknowledgeCumulative(msg);
-        }
-    }
-
+    /**
+     * Routes the messages that could not be parsed to {@link #REL_PARSE_FAILURE}.
+     *
+     * @throws IOException if their content cannot be written. The FlowFile is discarded first, so nothing
+     *                     is left dangling in the session; the caller rolls the session back without
+     *                     acknowledging the messages, and the broker redelivers them.
+     */
     private void handleFailures(ProcessSession session,
-                                BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) {
+                                BlockingQueue<Message<GenericRecord>> parseFailures, byte[] demarcator) throws IOException {
 
         if (CollectionUtils.isEmpty(parseFailures)) {
             return;
@@ -438,25 +426,20 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
         FlowFile flowFile = session.create();
         final OutputStream rawOut = session.write(flowFile);
-        boolean written = false;
 
         try {
             writeParseFailures(rawOut, parseFailures, demarcator);
-            written = true;
         } catch (final IOException e) {
-            getLogger().error("Unable to write the messages that could not be parsed", e);
-        } finally {
-            // The stream has to be closed before the FlowFile can be transferred or removed. Leaving it
-            // open - as the error path used to - leaves a FlowFile dangling in the session that is neither
-            // routed nor discarded, so the parse failures are lost and the session cannot be committed.
+            // The stream has to be closed before the FlowFile can be removed. Leaving it open - as the
+            // error path used to - leaves a FlowFile dangling in the session that is neither routed nor
+            // discarded, so the session cannot be committed.
             IOUtils.closeQuietly(rawOut);
+            session.remove(flowFile);
+            throw e;
         }
 
-        if (written) {
-            session.transfer(flowFile, REL_PARSE_FAILURE);
-        } else {
-            session.remove(flowFile);
-        }
+        IOUtils.closeQuietly(rawOut);
+        session.transfer(flowFile, REL_PARSE_FAILURE);
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.MockSessionFactory;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * A message may be acknowledged to the broker only once the FlowFile that carries it has been committed.
+ * <p>
+ * An acknowledged message is gone from the subscription: the broker never redelivers it. ConsumePulsar
+ * acknowledged Shared-subscription messages before writing them, and non-shared ones right after rolling
+ * the session back on a write error, so any failure to write the content - a full content repository, a
+ * permissions problem, a disk fault - lost the batch silently: it was neither in NiFi nor recoverable from
+ * Pulsar. Every scenario runs in synchronous and asynchronous mode on a Shared and on an Exclusive
+ * subscription, because each combination acknowledges through a different path.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/acknowledgement";
+
+    @Parameters(name = "async={0}, subscription={1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+            {false, "Exclusive"}, {false, "Shared"}, {true, "Exclusive"}, {true, "Shared"}});
+    }
+
+    private final boolean async;
+    private final String subscriptionType;
+    private final boolean shared;
+
+    public ConsumePulsarAcknowledgementTest(final boolean async, final String subscriptionType) {
+        this.async = async;
+        this.subscriptionType = subscriptionType;
+        this.shared = isSharedSubType(subscriptionType);
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, subscriptionType);
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+    }
+
+    /**
+     * The healthy case, with the order that matters: by the time the broker is told a message is handled,
+     * the FlowFile carrying it is already committed. Before the fix a Shared subscription acknowledged
+     * every message before it was even written, and the committed count recorded here was 0.
+     */
+    @Test
+    public void messagesAreAcknowledgedOnlyAfterTheirFlowFileIsCommitted() throws PulsarClientException {
+        final List<String> statesAtAcknowledgement = recordSessionStateAtAcknowledgement(ConsumePulsar.REL_SUCCESS);
+        mockClientService.setMockMessageQueue(messages(3, "payload"));
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
+        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
+                shared ? 3 : 1, statesAtAcknowledgement.size());
+        for (final String state : statesAtAcknowledgement) {
+            assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
+        }
+    }
+
+    /**
+     * The failure from the issue: the content repository rejects the write. Nothing may be acknowledged,
+     * so that the broker redelivers the batch. Before the fix a Shared subscription had already acknowledged
+     * every message, and an Exclusive one acknowledged cumulatively right after rolling the session back.
+     */
+    @Test
+    public void nothingIsAcknowledgedWhenTheContentCannotBeWritten() throws PulsarClientException {
+        // schedule the processor against the still-empty topic
+        runner.run(1, false, true);
+        mockClientService.setMockMessageQueue(messages(3, "payload"));
+        final MockProcessSession session = sessionWhoseContentCannotBeWritten();
+
+        ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), session);
+        // what the framework does once onTrigger returns: it has to find a clean, rolled-back session
+        session.commitAsync();
+        // unschedule the processor, which waits for the acknowledgement pool to finish whatever was
+        // submitted. (Running another trigger instead would consume what the failed one left in the
+        // receiver queue - in synchronous mode the write fails on the first message - and acknowledge it.)
+        ((AbstractPulsarConsumerProcessor<?>) runner.getProcessor()).shutDown(runner.getProcessContext());
+
+        session.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        verifyNothingAcknowledged();
+    }
+
+    /** Messages with an empty payload are discarded on purpose, and they still have to be acknowledged. */
+    @Test
+    public void discardedEmptyMessagesAreStillAcknowledged() throws PulsarClientException {
+        mockClientService.setMockMessageQueue(messages(3, null));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        verifyAcknowledged(3);
+    }
+
+    /**
+     * Stubs every acknowledgement method of the consumer to record the state of the session at the moment
+     * the broker is told a message is handled: how many FlowFiles the relationship holds, and whether the
+     * session has been committed. The expected value is {@link #ONE_COMMITTED_FLOWFILE}.
+     */
+    private List<String> recordSessionStateAtAcknowledgement(final Relationship relationship) throws PulsarClientException {
+        final List<String> states = new CopyOnWriteArrayList<>();
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return null;
+        }).when(consumer).acknowledge(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return null;
+        }).when(consumer).acknowledgeCumulative(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return CompletableFuture.completedFuture(null);
+        }).when(consumer).acknowledgeAsync(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return CompletableFuture.completedFuture(null);
+        }).when(consumer).acknowledgeCumulativeAsync(any(Message.class));
+
+        return states;
+    }
+
+    private static final String ONE_COMMITTED_FLOWFILE = "1 transferred, committed";
+
+    private String sessionState(final Relationship relationship) {
+        final int transferred = runner.getFlowFilesForRelationship(relationship).size();
+        final boolean committed = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions()
+                .stream().allMatch(ConsumePulsarAcknowledgementTest::isCommitted);
+
+        return transferred + " transferred, " + (committed ? "committed" : "not committed");
+    }
+
+    private static boolean isCommitted(final MockProcessSession session) {
+        try {
+            session.assertCommitted();
+            return true;
+        } catch (final AssertionError notCommitted) {
+            return false;
+        }
+    }
+
+    private void verifyAcknowledged(final int messages) throws PulsarClientException {
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        if (shared) {
+            verify(consumer, times(async ? 0 : messages)).acknowledge(any(Message.class));
+            verify(consumer, times(async ? messages : 0)).acknowledgeAsync(any(Message.class));
+        } else {
+            verify(consumer, times(async ? 0 : 1)).acknowledgeCumulative(any(Message.class));
+            verify(consumer, times(async ? 1 : 0)).acknowledgeCumulativeAsync(any(Message.class));
+        }
+    }
+
+    private void verifyNothingAcknowledged() throws PulsarClientException {
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        verify(consumer, never()).acknowledge(any(Message.class));
+        verify(consumer, never()).acknowledgeAsync(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
+    }
+
+    /**
+     * A session whose FlowFile content cannot be written - what a full or read-only content repository
+     * looks like to the processor. Everything else behaves like the runner's own session.
+     */
+    private MockProcessSession sessionWhoseContentCannotBeWritten() {
+        final Processor processor = runner.getProcessor();
+
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("Intentional Unit Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+
+    /** {@code count} messages with distinct ids; a {@code null} payload produces empty messages. */
+    private static List<Message<GenericRecord>> messages(final int count, final String payload) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+
+        for (int n = 1; n <= count; n++) {
+            final byte[] data = payload == null ? new byte[0] : (payload + "-" + n).getBytes(UTF_8);
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, data, "1234:" + n + ":0", null, null));
+        }
+
+        return msgs;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockFailingRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.MockSessionFactory;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * The record processor has the same contract as {@link ConsumePulsarAcknowledgementTest}: a message is
+ * acknowledged only once the FlowFile carrying it - on success or on parse_failure - has been committed,
+ * and never when the session is rolled back.
+ * <p>
+ * ConsumePulsarRecord acknowledged Shared-subscription messages before parsing them, acknowledged
+ * cumulatively after a failed write, and on a Shared subscription never acknowledged a message that could
+ * not be parsed at all, so the broker redelivered it - and the flow received it again on parse_failure -
+ * forever.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/record-acknowledgement";
+
+    @Parameters(name = "async={0}, subscription={1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+            {false, "Exclusive"}, {false, "Shared"}, {true, "Exclusive"}, {true, "Shared"}});
+    }
+
+    private final boolean async;
+    private final String subscriptionType;
+    private final boolean shared;
+
+    public ConsumePulsarRecordAcknowledgementTest(final boolean async, final String subscriptionType) {
+        this.async = async;
+        this.subscriptionType = subscriptionType;
+        this.shared = isSharedSubType(subscriptionType);
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, subscriptionType);
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        // in async mode the processor keeps polling its completion service for this long after the last batch
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, async ? "1 sec" : "0 sec");
+    }
+
+    /** The healthy case: records reach success, and the acknowledgement follows the commit. */
+    @Test
+    public void messagesAreAcknowledgedOnlyAfterTheirFlowFileIsCommitted() throws Exception {
+        useReader(parser());
+        final List<String> statesAtAcknowledgement = recordSessionStateAtAcknowledgement(ConsumePulsarRecord.REL_SUCCESS);
+        mockClientService.setMockMessageQueue(messages(3));
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 1);
+        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
+                shared ? 3 : 1, statesAtAcknowledgement.size());
+        for (final String state : statesAtAcknowledgement) {
+            assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
+        }
+    }
+
+    /**
+     * Messages that cannot be parsed are routed to parse_failure and acknowledged with that FlowFile.
+     * Before the fix a Shared subscription skipped the acknowledgement for them entirely, so the broker
+     * redelivered them on every acknowledgement timeout.
+     */
+    @Test
+    public void unparseableMessagesAreAcknowledgedOnlyAfterTheirParseFailureFlowFileIsCommitted() throws Exception {
+        useReader(new MockFailingRecordParser());
+        final List<String> statesAtAcknowledgement = recordSessionStateAtAcknowledgement(ConsumePulsarRecord.REL_PARSE_FAILURE);
+        mockClientService.setMockMessageQueue(messages(3));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
+        assertEquals("every unparseable message is acknowledged once its parse_failure FlowFile is committed",
+                shared ? 3 : 1, statesAtAcknowledgement.size());
+        for (final String state : statesAtAcknowledgement) {
+            assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
+        }
+    }
+
+    /**
+     * The content repository rejects every write: neither the records nor the parse failures can be
+     * persisted. Nothing may be acknowledged, so that the broker redelivers the batch. Before the fix the
+     * messages were acknowledged anyway - before the write on a Shared subscription, after the failure on
+     * an Exclusive one.
+     */
+    @Test
+    public void nothingIsAcknowledgedWhenTheContentCannotBeWritten() throws Exception {
+        useReader(parser());
+        // schedule the processor against the still-empty topic
+        runner.run(1, false, true);
+        mockClientService.setMockMessageQueue(messages(3));
+        final MockProcessSession session = sessionWhoseContentCannotBeWritten();
+
+        ((ConsumePulsarRecord) runner.getProcessor()).onTrigger(runner.getProcessContext(), session);
+        // what the framework does once onTrigger returns: it has to find a clean, rolled-back session
+        session.commitAsync();
+        // unschedule the processor, which waits for the acknowledgement pool to finish whatever was
+        // submitted. (Running another trigger instead would consume what the failed one left in the
+        // receiver queue - in synchronous mode the write fails on the first message - and acknowledge it.)
+        ((AbstractPulsarConsumerProcessor<?>) runner.getProcessor()).shutDown(runner.getProcessContext());
+
+        session.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
+        session.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        verifyNothingAcknowledged();
+    }
+
+    private static MockRecordParser parser() {
+        final MockRecordParser readerService = new MockRecordParser();
+        readerService.addSchemaField("name", RecordFieldType.STRING);
+        readerService.addSchemaField("age", RecordFieldType.INT);
+        return readerService;
+    }
+
+    private void useReader(final ControllerService readerService) throws InitializationException {
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+    }
+
+    /**
+     * Stubs every acknowledgement method of the consumer to record the state of the session at the moment
+     * the broker is told a message is handled: how many FlowFiles the relationship holds, and whether the
+     * session has been committed. The expected value is {@link #ONE_COMMITTED_FLOWFILE}.
+     */
+    private List<String> recordSessionStateAtAcknowledgement(final Relationship relationship) throws PulsarClientException {
+        final List<String> states = new CopyOnWriteArrayList<>();
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return null;
+        }).when(consumer).acknowledge(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return null;
+        }).when(consumer).acknowledgeCumulative(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return CompletableFuture.completedFuture(null);
+        }).when(consumer).acknowledgeAsync(any(Message.class));
+        doAnswer(invocation -> {
+            states.add(sessionState(relationship));
+            return CompletableFuture.completedFuture(null);
+        }).when(consumer).acknowledgeCumulativeAsync(any(Message.class));
+
+        return states;
+    }
+
+    private static final String ONE_COMMITTED_FLOWFILE = "1 transferred, committed";
+
+    private String sessionState(final Relationship relationship) {
+        final int transferred = runner.getFlowFilesForRelationship(relationship).size();
+        final boolean committed = ((MockSessionFactory) runner.getProcessSessionFactory()).getCreatedSessions()
+                .stream().allMatch(ConsumePulsarRecordAcknowledgementTest::isCommitted);
+
+        return transferred + " transferred, " + (committed ? "committed" : "not committed");
+    }
+
+    private static boolean isCommitted(final MockProcessSession session) {
+        try {
+            session.assertCommitted();
+            return true;
+        } catch (final AssertionError notCommitted) {
+            return false;
+        }
+    }
+
+    private void verifyNothingAcknowledged() throws PulsarClientException {
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        verify(consumer, never()).acknowledge(any(Message.class));
+        verify(consumer, never()).acknowledgeAsync(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
+    }
+
+    /**
+     * A session whose FlowFile content cannot be written - what a full or read-only content repository
+     * looks like to the processor. Everything else behaves like the runner's own session.
+     */
+    private MockProcessSession sessionWhoseContentCannotBeWritten() {
+        final Processor processor = runner.getProcessor();
+
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("Intentional Unit Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+
+    /** One CSV record per message, parsed by MockRecordParser as (name, age). */
+    private static List<Message<GenericRecord>> messages(final int count) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+
+        for (int n = 1; n <= count; n++) {
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, ("Name" + n + "," + n).getBytes(UTF_8), "1234:" + n + ":0", null, null));
+        }
+
+        return msgs;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #167.

`ConsumePulsar` and `ConsumePulsarRecord` told the broker a message was handled either **before** its content was written (Shared/Key_Shared subscriptions acknowledged each message as it was claimed) or **after** rolling the session back on a write error (the cumulative acknowledgement on the other subscription types). An acknowledged message is never redelivered, so any failure to write the FlowFile — a full content repository, a permissions problem, a disk fault — lost the batch for good: neither in NiFi nor recoverable from Pulsar.

**Change**

- New `AbstractPulsarConsumerProcessor.commitAndAcknowledge()`: the acknowledgement runs in the `session.commitAsync()` success callback — the pattern NiFi's own Kafka consumers use — once per committed FlowFile: one acknowledgement per message on Shared/Key_Shared, one cumulative acknowledgement otherwise. A session that is rolled back acknowledges nothing, so the broker redelivers its messages. In asynchronous mode the acknowledgements still go through the acknowledgement service and are drained as before (#150), and the async write error is now logged instead of swallowed.
- Both processors collect the messages of the FlowFile being built in an `uncommitted` list and hand it to `commitAndAcknowledge()` at every point where they used to acknowledge; the acknowledgements on the rollback paths are gone.
- `ConsumePulsarRecord`, which the issue asked to check, had the same ordering plus two more variants:
  - on a Shared subscription a message that failed to resolve a schema was **never** acknowledged (the `continue` skipped the acknowledgement), so the broker redelivered it on every acknowledgement timeout and the flow received it on `parse_failure` again and again. Every message is now acknowledged with the commit of the FlowFile it belongs to, `success` or `parse_failure`;
  - parse failures whose FlowFile could not be written were discarded and acknowledged (#163 left the session clean, but the messages were still lost). `handleFailures()` now removes the FlowFile and rethrows, and the caller rolls the batch back unacknowledged — same outcome as any other write error;
  - an empty record set (`WriteResult.EMPTY`) is discarded with `session.remove()` instead of `session.rollback()`, which also discarded everything routed before it in the session.

Behaviour is otherwise unchanged: same acknowledgement counts, same FlowFiles, same attributes. Under the standard engine `commitAsync()` commits synchronously, so the acknowledgement happens at the same point in the trigger it did before, just after the commit instead of before the write; under the stateless engine it is deferred until the flow completes, which is the correct place for it.

**Verification** — `ConsumePulsarAcknowledgementTest` and `ConsumePulsarRecordAcknowledgementTest`, each parameterised over sync/async × Shared/Exclusive because the four combinations acknowledge through different paths:

- `messagesAreAcknowledgedOnlyAfterTheirFlowFileIsCommitted` — every acknowledgement call records the session state at that moment; the expected value is "1 transferred, committed"
- `nothingIsAcknowledgedWhenTheContentCannotBeWritten` — a `MockProcessSession` whose content streams throw `IOException`, driven through `onTrigger` directly; nothing may be acknowledged and the session has to be clean afterwards
- `discardedEmptyMessagesAreStillAcknowledged` (ConsumePulsar) and `unparseableMessagesAreAcknowledgedOnlyAfterTheirParseFailureFlowFileIsCommitted` (ConsumePulsarRecord) guard the two paths where a message produces no `success` content but still has to be acknowledged

Against `main`, **17 of the 24 cases fail**; the 7 that pass are the combinations the issue already lists as correct (async + non-shared) plus the count-only checks. One caveat: the async Shared ordering case is racy on `main` (the acknowledgement is submitted before the write, and the executor may run it before or after the commit), so it can pass there by chance; with the fix it is deterministic.

Unit suite green: `mvn -B -ntp clean package -Dgpg.skip=true -pl '!docker-image'`, 286 tests. The Testcontainers integration tests were not run here (no Docker on this machine).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] `mvn clean package` succeeds locally with Java 21
- [x] Added or updated tests where it makes sense
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch
