### PR TITLE
fix: validate published content against the topic's schema (#34 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,40 @@ FlowFile:
 > partition a message routes to, and it makes the topic compactable by that key. If you relied on
 > the previous unkeyed behaviour, clear the `msg.key` attribute before the publish processor.
 
+## Publishing to topics that have a schema
+
+`PublishPulsar` and `PublishPulsarRecord` create their producers with
+`Schema.AUTO_PRODUCE_BYTES()`, so the broker validates every payload against the schema the
+topic currently carries.
+
+| Topic | Behaviour |
+|---|---|
+| no schema | any content is accepted, exactly as before |
+| has a schema, content matches | published normally |
+| has a schema, content does not match | **routed to `failure`** with the broker's error |
+
+> **Breaking change.** Until now the processors published with `Schema.BYTES`, which the broker
+> does not validate. Content that did not match the topic's schema was accepted anyway: the
+> message landed on the topic looking valid, the registered schema was left untouched, and the
+> problem only appeared later, on the consumer side. A schema-aware consumer would fail to decode
+> that message — and, because it could not get past it, stop consuming the topic entirely:
+>
+> ```
+> read 1: id=sensor-1 reading=42
+> read 2 FAILED: AvroRuntimeException: Malformed data. Length is negative: -62
+> ```
+>
+> **Flows that publish content not matching their topic's schema will start routing those
+> FlowFiles to `failure`.** They were previously reported as successful while producing messages
+> no consumer could read, so this surfaces an existing problem rather than creating one — but it
+> is a visible change in behaviour, and it needs a `failure` connection to be handled.
+>
+> Only topics that carry a schema are affected. If your topics have no schema — the default, and
+> what every flow using these processors has relied on so far — nothing changes.
+>
+> Note that this validates the payload; it does not yet *encode* it. Producing records in the
+> topic's Avro or JSON schema from a NiFi record set is tracked separately.
+
 ## How to build
 
 To build the NAR files using Maven, just run the following commands. The first one makes sure that you are using Java 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -21,6 +21,7 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -100,7 +101,13 @@ public class PublisherPool implements Closeable {
     private PooledPublisherLease createLease(String topicName) throws PulsarClientException {
         final Map<String, Object> properties = new HashMap<>(pulsarProducerProperties);
 
-        final Producer producer = pulsarClient.newProducer()
+        // AUTO_PRODUCE_BYTES makes the broker validate the payload against whatever schema the topic
+        // currently carries, instead of writing it as opaque bytes. Producing with the default BYTES schema
+        // meant a topic with, say, an AVRO schema accepted arbitrary content without complaint: the message
+        // landed on the topic looking valid, the registered schema was untouched, and every schema-aware
+        // consumer then failed to decode it - and stayed stuck on it. On a topic with no schema this
+        // behaves exactly as before and any bytes are accepted.
+        final Producer producer = pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES())
                 .topic(topicName)
                 .loadConf(properties)
                 .create();

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarSchemaIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarSchemaIT.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Publishing to a topic that carries a schema (issue #34).
+ * <p>
+ * The publish processors created their producers with the default {@code Schema.BYTES}, which the broker
+ * does not validate against the topic's schema. Publishing arbitrary content to a topic with, say, an AVRO
+ * schema therefore succeeded, left the registered schema untouched, and put a message on the topic that
+ * looked valid but could not be decoded. The damage landed on the consumer, which failed on that message
+ * and could not get past it:
+ * <pre>
+ *     read 1: id=sensor-1 reading=42
+ *     read 2 FAILED: AvroRuntimeException: Malformed data. Length is negative: -62
+ * </pre>
+ * Producers now use {@code Schema.AUTO_PRODUCE_BYTES()}, so the broker checks the payload against the
+ * topic's current schema and rejects content that does not match, at publish time, where it can be routed
+ * to failure and seen.
+ */
+public class PublishPulsarSchemaIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    /** Content that does not match the topic's schema must be rejected rather than silently accepted. */
+    @Test
+    public void contentThatDoesNotMatchTheTopicSchemaIsRejected() throws Exception {
+        final String topic = seededTopic("mismatch");
+
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.enqueue("{\"id\":\"sensor-2\",\"reading\":43}".getBytes(UTF_8));
+        runner.run(1, true);
+
+        runner.assertTransferCount(PublishPulsar.REL_SUCCESS, 0);
+        runner.assertTransferCount(PublishPulsar.REL_FAILURE, 1);
+    }
+
+    /** A schema-aware consumer must still be able to read the topic afterwards. */
+    @Test
+    public void aRejectedPublishLeavesTheTopicReadable() throws Exception {
+        final String topic = seededTopic("readable");
+        final GenericSchema<GenericRecord> schema = sensorSchema();
+
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.enqueue("not an avro record at all".getBytes(UTF_8));
+        runner.run(1, true);
+        runner.assertTransferCount(PublishPulsar.REL_FAILURE, 1);
+
+        try (Consumer<GenericRecord> consumer = getClient().newConsumer(schema)
+                .topic(topic).subscriptionName("readable-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+
+            final Message<GenericRecord> first = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull("the seeded record should still be readable", first);
+            assertEquals("sensor-1", first.getValue().getField("id").toString());
+            consumer.acknowledge(first);
+
+            // nothing unreadable should have been written behind it
+            assertEquals("a rejected publish must not leave an undecodable message on the topic",
+                    null, consumer.receive(5, TimeUnit.SECONDS));
+        }
+    }
+
+    /** Properly encoded content is accepted and reads back correctly through a schema-aware consumer. */
+    @Test
+    public void contentMatchingTheTopicSchemaIsPublishedAndReadable() throws Exception {
+        final String topic = seededTopic("matching");
+        final GenericSchema<GenericRecord> schema = sensorSchema();
+
+        // encode a record with the topic's own schema, which is what a schema-aware writer would produce
+        final byte[] encoded = schema.encode(
+                schema.newRecordBuilder().set("id", "sensor-2").set("reading", 43).build());
+
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.enqueue(encoded);
+        runner.run(1, true);
+
+        runner.assertTransferCount(PublishPulsar.REL_SUCCESS, 1);
+        runner.assertTransferCount(PublishPulsar.REL_FAILURE, 0);
+
+        try (Consumer<GenericRecord> consumer = getClient().newConsumer(schema)
+                .topic(topic).subscriptionName("matching-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+
+            consumer.acknowledge(consumer.receive(30, TimeUnit.SECONDS));   // the seeded record
+
+            final Message<GenericRecord> published = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull("the published record should have arrived", published);
+            assertEquals("sensor-2", published.getValue().getField("id").toString());
+            assertEquals(43, published.getValue().getField("reading"));
+        }
+    }
+
+    /**
+     * The common case is unaffected: a topic with no schema still accepts arbitrary bytes. Almost every
+     * existing flow publishes to such a topic, so this is the guard against over-correcting.
+     */
+    @Test
+    public void aTopicWithoutASchemaStillAcceptsArbitraryBytes() throws Exception {
+        final String topic = "persistent://public/default/noschema-" + System.nanoTime();
+
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.enqueue("plain bytes, no schema anywhere".getBytes(UTF_8));
+        runner.run(1, true);
+
+        runner.assertTransferCount(PublishPulsar.REL_SUCCESS, 1);
+        runner.assertTransferCount(PublishPulsar.REL_FAILURE, 0);
+
+        try (Consumer<byte[]> consumer = getClient().newConsumer(Schema.BYTES)
+                .topic(topic).subscriptionName("bytes-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+
+            final Message<byte[]> message = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull(message);
+            assertEquals("plain bytes, no schema anywhere", new String(message.getValue(), UTF_8));
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** An AVRO schema, the way a schema-aware producer would leave the topic. */
+    private static GenericSchema<GenericRecord> sensorSchema() {
+        final RecordSchemaBuilder builder = SchemaBuilder.record("Sensor");
+        builder.field("id").type(SchemaType.STRING);
+        builder.field("reading").type(SchemaType.INT32);
+        return Schema.generic(builder.build(SchemaType.AVRO));
+    }
+
+    /** A topic carrying an AVRO schema and one valid record. */
+    private static String seededTopic(final String name) throws Exception {
+        final String topic = "persistent://public/default/schema-" + name + "-" + System.nanoTime();
+        final GenericSchema<GenericRecord> schema = sensorSchema();
+
+        try (Producer<GenericRecord> seeder = getClient().newProducer(schema).topic(topic).create()) {
+            seeder.send(schema.newRecordBuilder().set("id", "sensor-1").set("reading", 42).build());
+        }
+
+        return topic;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -99,6 +99,8 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
 
     public MockPulsarClientService() {
         when(mockClient.newProducer()).thenReturn((ProducerBuilder<byte[]>) mockProducerBuilder);
+        // producers are created with AUTO_PRODUCE_BYTES so the broker validates against the topic schema
+        when(mockClient.newProducer(any(Schema.class))).thenReturn((ProducerBuilder<byte[]>) mockProducerBuilder);
         when(mockClient.newConsumer(Schema.AUTO_CONSUME())).thenReturn((ConsumerBuilder<GenericRecord>) mockConsumerBuilder);
         when(mockClient.newConsumer(any(Schema.class))).thenReturn((ConsumerBuilder<GenericRecord>) mockConsumerBuilder);
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
@@ -18,6 +18,9 @@ package org.apache.nifi.processors.pulsar.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -40,9 +44,11 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Regression tests for the producer leak: the pool must hand out idle producers again, and closing the pool
@@ -61,7 +67,9 @@ public class PublisherPoolTest {
     public void setUp() throws PulsarClientException {
         client = mock(PulsarClient.class);
         builder = mock(ProducerBuilder.class, RETURNS_SELF);
-        when(client.newProducer()).thenReturn(builder);
+        // the pool creates producers with AUTO_PRODUCE_BYTES so the broker validates payloads against the
+        // topic's schema, so it is newProducer(Schema) that has to be stubbed
+        when(client.newProducer(any(Schema.class))).thenReturn(builder);
         // doAnswer(...).when(...) so that (re)stubbing never invokes a previous answer
         doAnswer(invocation -> {
             requestedTopics.add(invocation.getArgument(0));
@@ -75,6 +83,27 @@ public class PublisherPoolTest {
         }).when(builder).create();
 
         pool = new PublisherPool(mock(ComponentLog.class), Collections.emptyMap(), client);
+    }
+
+    /**
+     * Producers must be created with AUTO_PRODUCE_BYTES so the broker validates each payload against the
+     * schema the topic currently carries. With the default BYTES schema a topic with, say, an AVRO schema
+     * accepted arbitrary content: the message landed looking valid and every schema-aware consumer then
+     * failed to decode it. This pins the schema choice, which is otherwise invisible from the outside.
+     */
+    @Test
+    public void producersValidateAgainstTheTopicSchema() {
+        pool.obtainPublisher("persistent://public/default/schema-check");
+
+        final ArgumentCaptor<Schema> schema = ArgumentCaptor.forClass(Schema.class);
+        verify(client).newProducer(schema.capture());
+
+        // getSchemaInfo() throws until the schema is bound to a topic, so identify it by what it is
+        assertNotSame("producers must not write opaque bytes past the topic's schema",
+                Schema.BYTES, schema.getValue());
+        assertTrue("expected an AUTO_PRODUCE_BYTES schema so the broker validates the payload, but got "
+                        + schema.getValue().getClass().getName(),
+                schema.getValue().getClass().getSimpleName().contains("AutoProduceBytes"));
     }
 
     @Test


### PR DESCRIPTION
Phase one of #34. **Contains a breaking change — see below.**

### What was actually wrong

The issue says the publishers "use the Schema.BYTES schema" and need to match the topic. I expected publishing to a schema-bearing topic to fail or to clobber the schema. It does neither — I characterised it against a real broker first:

```
topic seeded with an AVRO schema
publish outcome: success=1 failure=0
topic schema after publishing: version 0, AVRO, Sensor{id,reading}   <- untouched
```

The publish **succeeds** and the schema is **intact**. The damage lands on the consumer:

```
read 1: id=sensor-1 reading=42
read 2 FAILED: AvroRuntimeException: Malformed data. Length is negative: -62
```

The message sits on the topic looking valid, and a schema-aware consumer not only fails to decode it but **cannot get past it** — the subscription is stuck. That is worse than a publish-time failure, because nothing upstream reports anything.

### Change

Producers are created with `Schema.AUTO_PRODUCE_BYTES()`, so the broker validates each payload against the topic's current schema and rejects mismatches at publish time, where they route to `failure` and are visible.

| Topic | Behaviour |
|---|---|
| no schema | any content accepted, exactly as before |
| has a schema, content matches | published normally |
| has a schema, content does not match | **routed to `failure`** |

### ⚠️ Breaking change

**Flows publishing content that does not match their topic's schema will start routing those FlowFiles to `failure`.** They were previously reported successful while producing messages no consumer could read, so this surfaces an existing problem rather than creating one — but it is a visible behaviour change and needs a `failure` connection wired up. Documented in the README with the failure output above.

Topics **without** a schema — the default, and what every existing flow relies on — are unaffected. That case has its own test precisely to guard against over-correcting.

### Tests

- **Unit**: `PublisherPoolTest.producersValidateAgainstTheTopicSchema` pins the schema the pool creates producers with, which is otherwise invisible from outside. (`getSchemaInfo()` throws until the schema binds to a topic, so it identifies the schema rather than inspecting it.)
- **Integration**: `PublishPulsarSchemaIT` — rejection, that a rejected publish leaves the topic readable, that properly encoded content publishes and reads back through a schema-aware consumer, and that a schema-less topic still accepts arbitrary bytes.

Against `main` the first two ITs fail (`expected: <0> but was: <1>` — mismatched content accepted); the other two pass and stand as regression guards.

Full build green: **268 unit + 27 integration**.

### What this does not do

It validates the payload; it does not **encode** one. Producing records in the topic's Avro or JSON schema from a NiFi record set — what @tspannhw asked for in the 2022 comment ("support Schema.JSON, Schema.AVRO") — is the larger half of #34 and wants its own change, now that this makes the silent-corruption path impossible.