### PR TITLE
ci: make the Pulsar image pre-pull robust

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,8 +49,25 @@ jobs:
 
       # Pre-pulling makes the first container start predictable and keeps the pull time out
       # of the per-test startup timeout.
+      # Pulling ahead of time keeps the image download out of the per-test startup timeout. It is an
+      # optimisation, not a requirement - Testcontainers pulls the image itself if this does not - so a
+      # failure here must not fail the build.
+      #
+      # -q -DforceStdout does not guarantee that only the property value reaches stdout: a Maven warning
+      # (a cached dependency-resolution failure, say) lands there too and gets fed to `docker pull`, which
+      # then fails with "invalid reference format". Take the last line and check it looks like an image.
       - name: Pre-pull the Pulsar image
-        run: docker pull "$(mvn -B -ntp help:evaluate -Dexpression=pulsar.image -q -DforceStdout)"
+        continue-on-error: true
+        run: |
+          IMAGE="$(mvn -B -ntp help:evaluate -Dexpression=pulsar.image -q -DforceStdout 2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+          echo "Resolved Pulsar image: '$IMAGE'"
+
+          if [ -z "$IMAGE" ] || printf '%s' "$IMAGE" | grep -qv '^[a-z0-9._/-]\+:[A-Za-z0-9._-]\+$'; then
+            echo "Could not resolve a usable image reference; leaving the pull to Testcontainers."
+            exit 0
+          fi
+
+          docker pull "$IMAGE"
 
       # `verify` is what runs Failsafe; `package` (used by the CI workflow) stops short of it.
       - name: Run integration tests


### PR DESCRIPTION
The Integration Tests job is currently failing on #172 for a reason that has nothing to do with that PR — and it is a flaw in the workflow I added in #152.

The pre-pull step pipes Maven straight into `docker pull`:

```yaml
run: docker pull "$(mvn -B -ntp help:evaluate -Dexpression=pulsar.image -q -DforceStdout)"
```

`-q -DforceStdout` does **not** guarantee that only the property value reaches stdout. On #172, which adds a dependency, a cached resolution warning was emitted alongside the value:

```
invalid reference format: repository name (/repo.maven.apache.org/maven2 during a
previous attempt ... ) must be lowercase
```

The job died in **18 seconds** — before running a single test — on a branch whose tests are green. Any PR that perturbs dependency resolution can trigger this.

**Change:** take the last line of output, verify it looks like an image reference, and mark the step `continue-on-error`. Pre-pulling is an optimisation that keeps the image download out of the per-test startup timeout; Testcontainers pulls the image itself otherwise. It should never have been able to fail the build.

Verified against the exact polluted output from the failing run — it now extracts `apachepulsar/pulsar:4.2.4` correctly and would have passed.

Worth merging ahead of #172, which is blocked on it.