### PR TITLE
feat: encode records with a JSON topic schema (#34 phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,13 @@ Use `Topic Schema` when the topic carries an AVRO schema: the Record Writer's ou
 Avro-with-header — is not what the broker accepts, so it is rejected. On a topic with no Avro
 schema this strategy falls back to the Record Writer, so turning it on is safe either way.
 
-JSON-schema topics are not yet encoded; only AVRO. Those still need `Record Writer` output that
-happens to match.
+`Topic Schema` encodes for both **AVRO** and **JSON** topic schemas.
+
+> **Worth knowing about JSON-schema topics:** the broker validates payloads against an AVRO schema
+> and rejects content that does not match, but it does **not** do the same for a JSON schema. Before
+> this, publishing to a JSON-schema topic with the Record Writer put content on the topic that a
+> schema-aware consumer decoded as all-null fields, with nothing reported at either end. `Topic
+> Schema` is the only strategy that produces messages such a consumer can read.
 
 ## How to build
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
@@ -63,7 +63,7 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
 
     static final AllowableValue SCHEMA_FROM_TOPIC = new AllowableValue("Topic Schema", "Topic Schema",
             "Encode each record with the schema the topic currently carries, so a schema-aware consumer can "
-            + "decode it. Falls back to the Record Writer when the topic has no Avro schema.");
+            + "decode it. Falls back to the Record Writer when the topic has no Avro or JSON schema.");
 
     public static final PropertyDescriptor MESSAGE_SCHEMA_STRATEGY = new PropertyDescriptor.Builder()
             .name("MESSAGE_SCHEMA_STRATEGY")

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -16,9 +16,13 @@
  */
 package org.apache.nifi.processors.pulsar.utils;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.nifi.avro.AvroTypeUtil;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.nifi.flowfile.FlowFile;
@@ -44,6 +48,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,9 +66,9 @@ public class PublisherLease implements Closeable {
     /** The schema the producer was created with, used to discover what schema the topic carries. */
     private final Schema<byte[]> topicSchema;
 
-    /** The topic's Avro schema, parsed once and re-parsed only if the definition itself changes. */
+    /** The topic's schema, parsed once and re-parsed only if the definition itself changes. */
     private String cachedSchemaDefinition;
-    private org.apache.avro.Schema cachedAvroSchema;
+    private TopicSchema cachedTopicSchema;
 
     public PublisherLease(Producer producer, ComponentLog logger) {
         this(producer, logger, null);
@@ -76,13 +81,13 @@ public class PublisherLease implements Closeable {
     }
 
     /**
-     * The Avro schema the topic currently carries, or null when it has none, when the producer was not
-     * created with a schema-discovering one, or when the schema is not Avro.
+     * The schema the topic currently carries, or null when it has none, when the producer was not created
+     * with a schema-discovering one, or when the schema is of a type records cannot be encoded with.
      * <p>
      * Producers are created with {@code Schema.AUTO_PRODUCE_BYTES()}, which binds to the topic when the
      * producer is created and then reports the topic's registered SchemaInfo.
      */
-    org.apache.avro.Schema getTopicAvroSchema() {
+    TopicSchema getTopicSchema() {
         if (topicSchema == null) {
             return null;
         }
@@ -90,9 +95,9 @@ public class PublisherLease implements Closeable {
         try {
             final SchemaInfo info = topicSchema.getSchemaInfo();
 
-            if (info == null || info.getType() != SchemaType.AVRO) {
+            if (info == null || (info.getType() != SchemaType.AVRO && info.getType() != SchemaType.JSON)) {
                 cachedSchemaDefinition = null;
-                cachedAvroSchema = null;
+                cachedTopicSchema = null;
                 return null;
             }
 
@@ -101,16 +106,49 @@ public class PublisherLease implements Closeable {
             // Leases are pooled and serve many FlowFiles, so parsing this on every publish rebuilds the
             // same Avro type tree over and over. Keyed on the definition rather than cached outright, so a
             // schema that does change is still picked up rather than frozen at whatever was seen first.
-            if (!definition.equals(cachedSchemaDefinition)) {
-                cachedAvroSchema = new org.apache.avro.Schema.Parser().parse(definition);
+            if (cachedTopicSchema == null || !definition.equals(cachedSchemaDefinition)
+                    || cachedTopicSchema.getType() != info.getType()) {
+                cachedTopicSchema =
+                        new TopicSchema(new org.apache.avro.Schema.Parser().parse(definition), info.getType());
                 cachedSchemaDefinition = definition;
             }
 
-            return cachedAvroSchema;
+            return cachedTopicSchema;
         } catch (final RuntimeException e) {
             // getSchemaInfo() throws when the schema was never bound to a topic
             logger.debug("Unable to determine the topic's schema; falling back to the configured writer", e);
             return null;
+        }
+    }
+
+    /**
+     * A schema a topic carries, in the form records get encoded against.
+     * <p>
+     * Pulsar registers AVRO and JSON schemas the same way - the schema definition is an Avro schema
+     * document describing the record in both cases - and only the {@link SchemaType} says which encoding
+     * goes on the wire: Avro binary for one, plain JSON for the other. So the two travel together; the
+     * definition alone cannot say how to encode.
+     */
+    static final class TopicSchema {
+
+        private final org.apache.avro.Schema definition;
+        private final SchemaType type;
+
+        TopicSchema(final org.apache.avro.Schema definition, final SchemaType type) {
+            this.definition = definition;
+            this.type = type;
+        }
+
+        org.apache.avro.Schema getDefinition() {
+            return definition;
+        }
+
+        SchemaType getType() {
+            return type;
+        }
+
+        boolean isJson() {
+            return type == SchemaType.JSON;
         }
     }
 
@@ -158,22 +196,28 @@ public class PublisherLease implements Closeable {
     /**
      * @param useTopicSchema encode each record with the schema the topic carries rather than with the
      *                       configured record writer. Falls back to the writer when the topic has no Avro
-     *                       schema, so a topic without one behaves exactly as before.
+     *                       or JSON schema, so a topic without one behaves exactly as before.
      */
     public void publish(final FlowFile flowFile, final RecordSet recordSet, final RecordSetWriterFactory writerFactory,
                         final RecordSchema schema, final String messageKeyField, Map<String, String> messageProperties,
                         boolean async, boolean useTopicSchema) throws IOException {
 
-        final org.apache.avro.Schema avroSchema = useTopicSchema ? getTopicAvroSchema() : null;
+        final TopicSchema resolvedSchema = useTopicSchema ? getTopicSchema() : null;
 
-        if (useTopicSchema && avroSchema == null) {
-            logger.debug("The topic carries no Avro schema; encoding with the configured record writer instead");
+        if (useTopicSchema && resolvedSchema == null) {
+            logger.debug("The topic carries no Avro or JSON schema; encoding with the configured record writer instead");
         }
 
-        // Built once for the whole record set rather than per record: both are reusable across writes on
-        // the same schema, and the buffer below is already reset each iteration.
+        final org.apache.avro.Schema avroSchema = resolvedSchema == null ? null : resolvedSchema.getDefinition();
+        final boolean encodeAsJson = resolvedSchema != null && resolvedSchema.isJson();
+
+        // Built once for the whole record set rather than per record: all of these are reusable across
+        // writes on the same schema, and the buffer below is already reset each iteration.
         final GenericDatumWriter<org.apache.avro.generic.GenericRecord> datumWriter =
-                avroSchema == null ? null : new GenericDatumWriter<>(avroSchema);
+                (avroSchema == null || encodeAsJson) ? null : new GenericDatumWriter<>(avroSchema);
+        // AUTO_CLOSE_TARGET off: the stream below outlives each generator and is reused for every record.
+        final JsonFactory jsonFactory =
+                encodeAsJson ? new JsonFactory().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET) : null;
         BinaryEncoder encoder = null;
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
@@ -189,8 +233,12 @@ public class PublisherLease implements Closeable {
                 final String messageKey;
 
                 if (avroSchema != null) {
-                    encoder = EncoderFactory.get().binaryEncoder(baos, encoder);
-                    encodeWithTopicSchema(record, avroSchema, datumWriter, encoder);
+                    if (encodeAsJson) {
+                        encodeWithTopicJsonSchema(record, avroSchema, jsonFactory, baos);
+                    } else {
+                        encoder = EncoderFactory.get().binaryEncoder(baos, encoder);
+                        encodeWithTopicSchema(record, avroSchema, datumWriter, encoder);
+                    }
                     messageContent = baos.toByteArray();
                 } else {
                     try (final RecordSetWriter writer = writerFactory.createWriter(logger, schema, baos, flowFile)) {
@@ -273,6 +321,142 @@ public class PublisherLease implements Closeable {
 
         datumWriter.write(avroRecord, encoder);
         encoder.flush();
+    }
+
+    /**
+     * Encodes a NiFi record as plain JSON conforming to the topic's schema.
+     * <p>
+     * A Pulsar JSON schema is registered as an Avro schema document, but what it puts on the wire is
+     * ordinary JSON - Jackson's rendering of the message object - and not Avro's own JSON encoding, which
+     * wraps a union value in its branch name. So the record is converted to the topic's schema exactly as
+     * the Avro path converts it, and then written out as plain JSON.
+     * <p>
+     * Falling through to the configured record writer instead emitted whatever that writer emits - CSV,
+     * say - and, unlike an AVRO topic, a JSON one accepts it: the message landed on the topic looking
+     * valid and a schema-aware consumer decoded every one of its fields as null.
+     *
+     * @param record the record to encode
+     * @param avroSchema the schema document the topic carries
+     * @param jsonFactory the factory to build the generator from, shared across the record set
+     * @param out the buffer to encode into
+     * @throws IOException if the record cannot be converted or encoded
+     */
+    private void encodeWithTopicJsonSchema(final Record record, final org.apache.avro.Schema avroSchema,
+                                           final JsonFactory jsonFactory, final ByteArrayOutputStream out)
+            throws IOException {
+
+        final org.apache.avro.generic.GenericRecord avroRecord;
+
+        try {
+            avroRecord = AvroTypeUtil.createAvroRecord(record, avroSchema);
+        } catch (final Exception e) {
+            throw new IOException("Unable to convert the record to the topic's schema " + avroSchema.getFullName(), e);
+        }
+
+        try (JsonGenerator generator = jsonFactory.createGenerator(out)) {
+            writeAsJson(generator, avroSchema, avroRecord);
+        }
+    }
+
+    /**
+     * Writes one value as plain JSON, guided by the schema branch it was converted to.
+     * <p>
+     * Deliberately not Avro's {@code JsonEncoder}: that emits Avro's JSON encoding, in which a union value
+     * appears as {@code {"string": "x"}} and which a Pulsar consumer reading the same JSON schema cannot
+     * decode. Here a union writes the value it holds, and nothing else, which is what Pulsar's own JSON
+     * schema produces and reads back.
+     *
+     * @param generator the generator to write to
+     * @param schema the schema of this value
+     * @param value the value, already converted to the schema by {@link AvroTypeUtil}
+     */
+    private static void writeAsJson(final JsonGenerator generator, final org.apache.avro.Schema schema,
+                                    final Object value) throws IOException {
+
+        if (value == null) {
+            generator.writeNull();
+            return;
+        }
+
+        switch (schema.getType()) {
+            case UNION:
+                writeAsJson(generator, schema.getTypes().get(GenericData.get().resolveUnion(schema, value)), value);
+                break;
+
+            case RECORD:
+                final org.apache.avro.generic.GenericRecord nested = (org.apache.avro.generic.GenericRecord) value;
+                generator.writeStartObject();
+                for (final org.apache.avro.Schema.Field field : schema.getFields()) {
+                    generator.writeFieldName(field.name());
+                    writeAsJson(generator, field.schema(), nested.get(field.pos()));
+                }
+                generator.writeEndObject();
+                break;
+
+            case ARRAY:
+                generator.writeStartArray();
+                if (value instanceof Object[]) {
+                    for (final Object element : (Object[]) value) {
+                        writeAsJson(generator, schema.getElementType(), element);
+                    }
+                } else {
+                    for (final Object element : (Iterable<?>) value) {
+                        writeAsJson(generator, schema.getElementType(), element);
+                    }
+                }
+                generator.writeEndArray();
+                break;
+
+            case MAP:
+                generator.writeStartObject();
+                for (final Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                    generator.writeFieldName(String.valueOf(entry.getKey()));
+                    writeAsJson(generator, schema.getValueType(), entry.getValue());
+                }
+                generator.writeEndObject();
+                break;
+
+            case BYTES:
+                final ByteBuffer buffer = ((ByteBuffer) value).duplicate();
+                final byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                generator.writeBinary(bytes);
+                break;
+
+            case FIXED:
+                generator.writeBinary(((GenericFixed) value).bytes());
+                break;
+
+            case BOOLEAN:
+                generator.writeBoolean((Boolean) value);
+                break;
+
+            case INT:
+                generator.writeNumber(((Number) value).intValue());
+                break;
+
+            case LONG:
+                generator.writeNumber(((Number) value).longValue());
+                break;
+
+            case FLOAT:
+                generator.writeNumber(((Number) value).floatValue());
+                break;
+
+            case DOUBLE:
+                generator.writeNumber(((Number) value).doubleValue());
+                break;
+
+            case NULL:
+                generator.writeNull();
+                break;
+
+            // STRING and ENUM, plus anything a future Avro adds: Avro hands strings back as Utf8, so the
+            // value is rendered rather than cast.
+            default:
+                generator.writeString(value.toString());
+                break;
+        }
     }
 
     public long complete() {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarJsonSchemaIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarJsonSchemaIT.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Publishing NiFi records to a topic carrying a JSON schema (issue #34, phase three).
+ * <p>
+ * Phase two encodes records with the topic's schema when that schema is AVRO. A JSON-schema topic
+ * falls through to the Record Writer, whose output the broker then rejects, so such a topic cannot
+ * currently be written to at all with Message Schema Strategy = Topic Schema.
+ */
+public class PublishPulsarJsonSchemaIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final MockRecordParser reader = new MockRecordParser();
+        reader.addSchemaField("id", RecordFieldType.STRING);
+        reader.addSchemaField("reading", RecordFieldType.INT);
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("id, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    /** Records must reach a JSON-schema topic and decode through a schema-aware consumer. */
+    @Test
+    public void recordsAreEncodedWithAJsonTopicSchema() throws Exception {
+        final String topic = seededJsonTopic();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(PublishPulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+
+        runner.enqueue("sensor-2,43".getBytes(UTF_8));
+        runner.run(1, true);
+
+        runner.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 1);
+        runner.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+
+        try (Consumer<GenericRecord> consumer = getClient().newConsumer(jsonSchema())
+                .topic(topic).subscriptionName("json-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+
+            consumer.acknowledge(consumer.receive(30, TimeUnit.SECONDS));   // the seeded record
+
+            final Message<GenericRecord> published = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull("the published record should have arrived", published);
+            assertEquals("sensor-2", published.getValue().getField("id").toString());
+            assertEquals(43, published.getValue().getField("reading"));
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static GenericSchema<GenericRecord> jsonSchema() {
+        final RecordSchemaBuilder builder = SchemaBuilder.record("Sensor");
+        builder.field("id").type(SchemaType.STRING);
+        builder.field("reading").type(SchemaType.INT32);
+        return Schema.generic(builder.build(SchemaType.JSON));
+    }
+
+    private static String seededJsonTopic() throws Exception {
+        final String topic = "persistent://public/default/json-schema-" + System.nanoTime();
+        final GenericSchema<GenericRecord> schema = jsonSchema();
+
+        try (Producer<GenericRecord> seeder = getClient().newProducer(schema).topic(topic).create()) {
+            seeder.send(schema.newRecordBuilder().set("id", "sensor-1").set("reading", 42).build());
+        }
+
+        return topic;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarJsonUnionSchemaIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarJsonUnionSchemaIT.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Nullable fields on a JSON-schema topic.
+ * <p>
+ * The JSON encoding added for #34 phase three writes a union's resolved branch bare rather than in Avro's
+ * {@code {"string":"x"}} wrapper, on the reasoning that Pulsar's {@code GenericJsonRecord} reads ordinary
+ * Jackson JSON. That was inferred from reading the client rather than measured, and an optional field -
+ * {@code ["null","string"]} - is the most common shape in a real schema, so it is worth measuring: if the
+ * inference is wrong, this is silent corruption of exactly the kind #34 is about.
+ */
+public class PublishPulsarJsonUnionSchemaIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        // A real JSON reader, because the mock parser turns an empty CSV field into "" and can never
+        // produce a genuine null - which is the case that actually exercises the union encoding.
+        final JsonTreeReader reader = new JsonTreeReader();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("id, note, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(PublishPulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+    }
+
+    /** An optional field carrying a value, and the same field carrying null, must both round-trip. */
+    @Test
+    public void optionalFieldsRoundTripThroughAJsonSchemaTopic() throws Exception {
+        final String topic = seededTopic();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+
+        // record 1 has the optional field set; record 2 omits it entirely, so it is genuinely null
+        runner.enqueue(("[{\"id\":\"sensor-2\",\"note\":\"hello\",\"reading\":43},"
+                + "{\"id\":\"sensor-3\",\"reading\":44}]").getBytes(UTF_8));
+        runner.run(1, true);
+
+        runner.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 1);
+        runner.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+
+        try (Consumer<GenericRecord> consumer = getClient().newConsumer(sensorSchema())
+                .topic(topic).subscriptionName("union-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+
+            consumer.acknowledge(consumer.receive(30, TimeUnit.SECONDS));   // the seeded record
+
+            final Message<GenericRecord> withValue = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull("the record with an optional value should have arrived", withValue);
+            assertEquals("sensor-2", withValue.getValue().getField("id").toString());
+            assertEquals("an optional field carrying a value decoded wrongly - the union encoding is off",
+                    "hello", String.valueOf(withValue.getValue().getField("note")));
+            assertEquals(43, withValue.getValue().getField("reading"));
+            consumer.acknowledge(withValue);
+
+            final Message<GenericRecord> withNull = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull("the record with a null optional should have arrived", withNull);
+            assertEquals("sensor-3", withNull.getValue().getField("id").toString());
+            assertNull("an absent optional field should decode as null", withNull.getValue().getField("note"));
+            assertEquals(44, withNull.getValue().getField("reading"));
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** id required; note optional, i.e. a ["null","string"] union; reading required. */
+    private static GenericSchema<GenericRecord> sensorSchema() {
+        final RecordSchemaBuilder builder = SchemaBuilder.record("Sensor");
+        builder.field("id").type(SchemaType.STRING);
+        builder.field("note").type(SchemaType.STRING).optional();
+        builder.field("reading").type(SchemaType.INT32);
+        return Schema.generic(builder.build(SchemaType.JSON));
+    }
+
+    private static String seededTopic() throws Exception {
+        final String topic = "persistent://public/default/json-union-" + System.nanoTime();
+        final GenericSchema<GenericRecord> schema = sensorSchema();
+
+        try (Producer<GenericRecord> seeder = getClient().newProducer(schema).topic(topic).create()) {
+            seeder.send(schema.newRecordBuilder()
+                    .set("id", "sensor-1").set("note", "seeded").set("reading", 42).build());
+        }
+
+        return topic;
+    }
+}


### PR DESCRIPTION
Completes #34. **Contains a finding that was not in the issue.**

### JSON-schema topics were never protected

Phase one made the broker validate published content, and phase two encoded records for AVRO topics. I assumed phase three was simply "add JSON encoding". Characterising it first showed something worse — the broker does **not** validate against a JSON schema the way it does against AVRO, so the Record Writer's output was accepted without complaint:

```
raw bytes on topic: "sensor-2","43"
decoded id=null reading=null
```

The message sits on the topic looking valid; a schema-aware consumer reads **every field as null**; nothing is reported at either end. The silent corruption #34 is about was still live for JSON-schema topics on `main`, and phase one did not close it.

### Change

- `getTopicAvroSchema()` → `getTopicSchema()`, returning the parsed definition with its `SchemaType`, accepting JSON as well as AVRO. The parse cache key now includes the type.
- Records convert through the **same** `AvroTypeUtil.createAvroRecord()` call the Avro path uses, so coercion is identical, then are written as plain JSON by a schema-guided walk.
- Avro's `JsonEncoder` is deliberately **not** used — it wraps unions as `{"string":"x"}`, which Pulsar's `GenericJsonReader` cannot decode. A union writes its resolved branch bare.

### On verification

Union encoding was the one part reasoned about rather than measured, and optional fields are the commonest shape in any real schema — so I measured it. `PublishPulsarJsonUnionSchemaIT` round-trips a `["null","string"]` field both carrying a value and genuinely null. **The reasoning held**, and it is now a regression test rather than an argument.

That test was wrong on its first attempt in an instructive way: it asserted `null` but got `""`, because `MockRecordParser` turns an empty CSV field into an empty string and can never produce a null. The encoder was faithfully round-tripping an empty string. Switching to `JsonTreeReader` made the null real.

**What is still not verified:** nested records, arrays, maps, enums, binary and logical types are implemented but exercised only through the flat and nullable cases. Logical types pass through as their underlying Avro representation, which may not match what a POJO-based `JSONSchema` producer emits — worth its own issue if anyone hits it.

Full build green: **270 unit + 32 integration**.

Stacked on nothing; #171 and #172 are already merged.