### PR TITLE
fix: start a new record set when the record schema changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ through *Mapped FlowFile Attributes*.
 > that comes from a message property has to be mapped through *Mapped FlowFile Attributes*
 > instead.
 
+### Record sets and the record schema
+
+`ConsumePulsarRecord` writes consecutive messages with the same mapped attributes (and topic)
+as one record set, using the schema the set was opened with. A message whose schema differs
+starts a new record set - and a new FlowFile - just as a change in the mapped attributes does.
+
+> **Behaviour change since `2.9.0`:** the record set used to be written with the schema of its
+> **first** message. With a Record Reader that infers the schema from each message (the default
+> of `JsonTreeReader`), every field that the first message of a batch did not have was silently
+> dropped from the rest of the batch, and a field whose type differed made the trigger fail. Such
+> batches are now split at every schema change instead, so a topic with payloads of several
+> shapes produces more, smaller FlowFiles than before. If that matters more than the optional
+> fields, give the reader an explicit schema (*Schema Text* or a schema registry): every message
+> then resolves to the same schema and the batch stays one FlowFile.
+
 ## Publisher message metadata
 
 `PublishPulsar` and `PublishPulsarRecord` set the message key and message properties from the

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -299,7 +299,10 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "default: 1000. If set to a value greater than 1, messages within the FlowFile will be seperated "
                     + "by the Message Demarcator. Consecutive messages are written to the same FlowFile as long as their "
                     + "Mapped FlowFile Attributes are identical; a change in those attributes starts a new FlowFile before "
-                    + "the batch size is reached.")
+                    + "the batch size is reached. ConsumePulsarRecord also starts a new FlowFile when the record schema "
+                    + "changes: with a Record Reader that infers the schema from each message, a batch of messages of "
+                    + "different shapes is split into one FlowFile per shape change rather than losing the fields that "
+                    + "the first message of the batch does not have.")
             .required(false)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .defaultValue("1000")

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -19,7 +19,6 @@ package org.apache.nifi.processors.pulsar.pubsub;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
@@ -204,7 +203,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     /**
      * Perform the actual processing of the messages, by parsing the messages and writing them out to a FlowFile.
      * All of the messages passed in shall be routed to either SUCCESS or PARSE_FAILURE, allowing us to acknowledge
-     * the receipt of the messages to Pulsar, so they are not re-sent. The acknowledgement is issued once the
+     * the receipt of the messages to Pulsar, so they are not re-sent. Consecutive messages with the same mapped
+     * attributes and the same record schema share one record set; a change in either starts a new one. The acknowledgement is issued once the
      * session carrying the FlowFiles has been committed; if the batch cannot be written, the session is rolled
      * back and nothing is acknowledged, so the broker redelivers the messages instead of losing them.
      *
@@ -275,9 +275,28 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                     currentAttributes.put("avro.schema", new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()));
                 }
 
-                // if the current message's mapped attribute values differ from the previous set's,
-                // write out the active record set and clear various references so that we'll start a new one
-                if (lastAttributes != null && !lastAttributes.equals(currentAttributes)) {
+                // Parse the message before deciding which record set it joins. The reader's schema is the
+                // message's own - with an inferred schema, the shape of this payload - and a message whose
+                // schema differs from the open set's cannot go through the set's writer: a writer only emits
+                // the fields of the schema it was created with, so the fields the message does not share
+                // would be dropped silently, and a field of a different type would fail to coerce.
+                final byte[] data = msg.getData();
+                RecordReader reader = null;
+                RecordSchema currentSchema = null;
+
+                try {
+                    reader = readerFactory.createRecordReader(currentAttributes, new ByteArrayInputStream(data), data.length, getLogger());
+                    currentSchema = reader.getSchema();
+                } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
+                    IOUtils.closeQuietly(reader);
+                    reader = null;
+                }
+
+                // if the current message's mapped attribute values - or its schema - differ from the open
+                // record set's, write out the active record set and clear various references so that we'll
+                // start a new one. An unparseable message has no schema and leaves the open set as it is.
+                if (lastAttributes != null && (!lastAttributes.equals(currentAttributes)
+                        || (reader != null && !schema.equals(currentSchema)))) {
                     WriteResult result = writer.finishRecordSet();
                     IOUtils.closeQuietly(writer);
                     IOUtils.closeQuietly(rawOut);
@@ -308,25 +327,29 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 // purpose, so it is acknowledged with the commit of the FlowFiles it belongs to
                 uncommitted.add(msg);
 
+                if (reader == null) {
+                    // the message could not be parsed: it is routed to parse_failure with the rest of the set
+                    parseFailures.add(msg);
+                    continue;
+                }
+
                 // if there's no record set actively being written, begin one
-                byte[] data = msg.getData();
                 if (lastMessage == null) {
                     flowFile = session.create();
                     flowFile = session.putAllAttributes(flowFile, currentAttributes);
                     batchAttributes = new MessageBatchAttributes();
-                    schema = getSchema(flowFile, readerFactory, data);
+                    schema = currentSchema;
                     rawOut = session.write(flowFile);
                     writer = getRecordWriter(writerFactory, schema, rawOut, flowFile);
 
-                    if (schema == null || writer == null) {
+                    if (writer == null) {
                         parseFailures.add(msg);
+                        IOUtils.closeQuietly(reader);
                         // the OutputStream has to be closed before the FlowFile can be removed, otherwise
                         // the session rejects the removal with an IllegalStateException
-                        IOUtils.closeQuietly(writer);
                         IOUtils.closeQuietly(rawOut);
                         session.remove(flowFile);
                         // no record set is open now: keep the invariant that writer != null means "open"
-                        writer = null;
                         rawOut = null;
                         getLogger().error("Unable to create a record writer to consume from the Pulsar topic");
                         continue;
@@ -340,18 +363,17 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 batchAttributes.add(msg);
 
                 // write each of the records in the current message to the active record set. These will each
-                // have the same mapped flowfile attribute values, which means that it's ok that they are all placed
-                // in the same output flowfile.
-
-                final InputStream in = new ByteArrayInputStream(data);
+                // have the same mapped flowfile attribute values and the same schema, which means that it's ok
+                // that they are all placed in the same output flowfile.
                 try {
-                    RecordReader r = readerFactory.createRecordReader(flowFile, in, getLogger());
-                    for (Record record = r.nextRecord(); record != null; record = r.nextRecord()) {
+                    for (Record record = reader.nextRecord(); record != null; record = reader.nextRecord()) {
                         writer.write(record);
                         writtenRecords++;
                     }
-                } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
+                } catch (MalformedRecordException | IOException e) {
                     parseFailures.add(msg);
+                } finally {
+                    IOUtils.closeQuietly(reader);
                 }
             }
 
@@ -547,23 +569,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         } finally {
             drainAcknowledgments();
         }
-    }
-
-    private RecordSchema getSchema(FlowFile flowFile, RecordReaderFactory readerFactory, byte[] msgValue) {
-        RecordSchema schema = null;
-        InputStream in = null;
-
-        try {
-            in = new ByteArrayInputStream(msgValue);
-            schema = readerFactory.createRecordReader(flowFile, in, getLogger()).getSchema();
-        } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
-            getLogger().error("Unable to determine the schema", e);
-            return null;
-        } finally {
-            IOUtils.closeQuietly(in);
-        }
-
-        return schema;
     }
 
     private RecordSetWriter getRecordWriter(RecordSetWriterFactory writerFactory,

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaChangeTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaChangeTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A record set is written with the schema it was opened with, so a message whose schema differs has to
+ * start a new record set - the same rule that already applies to a change in the mapped attributes.
+ * <p>
+ * ConsumePulsarRecord used to create the set's writer from the schema of its first message and write every
+ * later message of the set through it. With a reader that infers the schema from the payload - the default
+ * of JsonTreeReader - any field the first message did not have was silently dropped, any field it had that
+ * a later message lacked came out as null, and a field whose type differed made the writer throw out of
+ * onTrigger. These tests run the real JsonTreeReader and JsonRecordSetWriter, because the mock parser has a
+ * fixed schema and cannot show any of this.
+ */
+public class ConsumePulsarRecordSchemaChangeTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/telemetry";
+
+    private static final String MESSAGE_1 = "{\"id\":1,\"a\":\"x\",\"nested\":{\"p\":1},\"tags\":[{\"k\":\"t1\"}]}";
+    private static final String MESSAGE_2 = "{\"id\":2,\"a\":\"y\",\"extra\":\"only-in-2\",\"nested\":{\"p\":2,\"q\":\"only-in-2\"},"
+            + "\"tags\":[{\"k\":\"t2\",\"m\":true}]}";
+    private static final String MESSAGE_3 = "{\"id\":3,\"b\":true}";
+
+    private JsonTreeReader reader;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        reader = new JsonTreeReader();
+        runner.addControllerService("record-reader", reader);
+
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+    }
+
+    /**
+     * The case from the issue: three messages, each with fields the others do not have. Each gets its own
+     * record set and keeps every field. Before the fix all three were written through the first message's
+     * schema as one FlowFile, and {@code extra}, {@code nested.q}, {@code tags[].m} and {@code b} were gone.
+     */
+    @Test
+    public void aMessageWithADifferentSchemaStartsANewRecordSet() {
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(MESSAGE_1, MESSAGE_2, MESSAGE_3));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        final List<MockFlowFile> flowFiles = successFlowFiles(3);
+        for (final MockFlowFile flowFile : flowFiles) {
+            assertEquals("1", flowFile.getAttribute("record.count"));
+        }
+
+        final String second = new String(flowFiles.get(1).toByteArray(), UTF_8);
+        assertTrue("a top-level field the first message lacks was dropped: " + second, second.contains("\"extra\":\"only-in-2\""));
+        assertTrue("a nested field the first message lacks was dropped: " + second, second.contains("\"q\":\"only-in-2\""));
+        assertTrue("an array element field the first message lacks was dropped: " + second, second.contains("\"m\":true"));
+        final String third = new String(flowFiles.get(2).toByteArray(), UTF_8);
+        assertTrue("a field only the last message has was dropped: " + third, third.contains("\"b\":true"));
+        assertFalse("a field the last message does not have was invented: " + third, third.contains("\"a\""));
+    }
+
+    /**
+     * A field whose type differs between messages is a schema change like any other. Before the fix the
+     * second value was coerced to the first message's type, and the writer threw NumberFormatException out
+     * of onTrigger - the trigger failed, nothing was acknowledged, and the batch came back to fail again.
+     */
+    @Test
+    public void aTypeConflictStartsANewRecordSetInsteadOfFailingTheTrigger() {
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages("{\"id\":1,\"v\":1}", "{\"id\":2,\"v\":\"text\"}"));
+
+        runner.run(1, true);
+
+        final List<MockFlowFile> flowFiles = successFlowFiles(2);
+        assertEquals("[{\"id\":1,\"v\":1}]", new String(flowFiles.get(0).toByteArray(), UTF_8));
+        assertEquals("[{\"id\":2,\"v\":\"text\"}]", new String(flowFiles.get(1).toByteArray(), UTF_8));
+    }
+
+    /** Messages with the same shape keep sharing one record set, exactly as before. */
+    @Test
+    public void messagesWithTheSameSchemaShareOneRecordSet() {
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(MESSAGE_1, MESSAGE_1.replace("\"id\":1", "\"id\":2"), MESSAGE_1.replace("\"id\":1", "\"id\":3")));
+
+        runner.run(1, true);
+
+        final MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertEquals("3", flowFile.getAttribute("record.count"));
+        assertEquals("3", flowFile.getAttribute(ConsumePulsarRecord.MSG_COUNT));
+    }
+
+    /**
+     * The trade-off, pinned so it is not a surprise: the set closes on every change, so messages that
+     * alternate between two shapes produce one FlowFile per message. Fragmentation is the price of not
+     * losing fields; a reader with an explicit schema avoids it.
+     */
+    @Test
+    public void alternatingSchemasProduceOneRecordSetPerChange() {
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(MESSAGE_1, MESSAGE_3, MESSAGE_1, MESSAGE_3));
+
+        runner.run(1, true);
+
+        successFlowFiles(4);
+    }
+
+    /** A change in the mapped attributes still starts a new record set, schema change or not. */
+    @Test
+    public void aMappedAttributeChangeStillStartsANewRecordSet() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "kind");
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(
+                message(MESSAGE_1, "kind", "first"),
+                message(MESSAGE_1.replace("\"id\":1", "\"id\":2"), "kind", "first"),
+                message(MESSAGE_1.replace("\"id\":1", "\"id\":3"), "kind", "second")));
+
+        runner.run(1, true);
+
+        final List<MockFlowFile> flowFiles = successFlowFiles(2);
+        assertEquals("first", flowFiles.get(0).getAttribute("kind"));
+        assertEquals("2", flowFiles.get(0).getAttribute("record.count"));
+        assertEquals("second", flowFiles.get(1).getAttribute("kind"));
+        assertEquals("1", flowFiles.get(1).getAttribute("record.count"));
+    }
+
+    /** An unparseable message goes to parse_failure and leaves the open record set as it is. */
+    @Test
+    public void anUnparseableMessageDoesNotCloseTheRecordSet() {
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(MESSAGE_1, "this is not json", MESSAGE_1.replace("\"id\":1", "\"id\":2")));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
+        assertEquals("this is not json", new String(runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_PARSE_FAILURE).get(0).toByteArray(), UTF_8));
+        final MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertEquals("2", flowFile.getAttribute("record.count"));
+    }
+
+    /**
+     * With an explicit schema nothing changes: every message resolves to the same schema, the set stays
+     * one FlowFile, and fields outside the schema are dropped by design.
+     */
+    @Test
+    public void anExplicitSchemaIsAppliedUnchanged() {
+        runner.setProperty(reader, "Schema Access Strategy", "schema-text-property");
+        runner.setProperty(reader, "Schema Text", "{\"type\":\"record\",\"name\":\"event\",\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"a\",\"type\":[\"null\",\"string\"]}]}");
+        runner.enableControllerService(reader);
+        mockClientService.setMockMessageQueue(messages(MESSAGE_1, MESSAGE_2, MESSAGE_3));
+
+        runner.run(1, true);
+
+        final MockFlowFile flowFile = successFlowFiles(1).get(0);
+        assertEquals("3", flowFile.getAttribute("record.count"));
+        // every record resolves to the explicit schema, so the writer emits each payload's own fields verbatim
+        assertEquals("[{\"id\":1,\"a\":\"x\"},{\"id\":2,\"a\":\"y\"},{\"id\":3}]", new String(flowFile.toByteArray(), UTF_8));
+    }
+
+    private List<MockFlowFile> successFlowFiles(final int expected) {
+        runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, expected);
+        return runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+    }
+
+    private static List<Message<GenericRecord>> messages(final String... payloads) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+        for (final String payload : payloads) {
+            msgs.add(message(payload, null, null));
+        }
+        return msgs;
+    }
+
+    @SafeVarargs
+    private static List<Message<GenericRecord>> messages(final Message<GenericRecord>... msgs) {
+        final List<Message<GenericRecord>> list = new ArrayList<>();
+        Collections.addAll(list, msgs);
+        return list;
+    }
+
+    private static int nextId = 1;
+
+    private static Message<GenericRecord> message(final String payload, final String propertyName, final String propertyValue) {
+        final Map<String, String> properties = propertyName == null ? null : Collections.singletonMap(propertyName, propertyValue);
+        return new MockPulsarMessage<GenericRecord>(TOPIC, payload.getBytes(UTF_8), "1234:" + (nextId++) + ":0", properties, null);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #174. Direction (1) from the issue discussion, as agreed there: a change in the record schema closes the record set, the way a change in the mapped attributes already does.

`ConsumePulsarRecord` created a record set's writer from the schema of the set's **first message** and wrote every other message of the set through it. With a reader that infers the schema from the payload — `JsonTreeReader`'s default — any field the first message did not have was silently dropped from the rest of the set, any field it had that a later message lacked came out as `null`, and a field whose type differed between messages made the writer throw `NumberFormatException` out of `onTrigger`. Nothing was logged and nothing reached `parse_failure`.

**Change**

- Each message is parsed **before** the processor decides which record set it joins: the reader is created at the top of the loop (it was created per message anyway, further down) and its schema is compared with the open set's. A different schema finishes the set and starts a new one, exactly like a change in the mapped attributes; an unparseable message has no schema, goes to `parse_failure` and leaves the open set alone.
- The set is opened with the schema of the message that opens it and every message that joins it has the same schema, so the writer never sees a record it cannot represent. `getSchema()` — the separate first-message reader whose schema was the only one consulted — is gone; each reader is closed once its records are written.
- With an explicit schema (Schema Text, a registry, …) every message resolves to the same schema and nothing changes; the explicit-schema test pins the previous output byte for byte.
- The trade-off is documented, as discussed on the issue: the *Consumer Message Batch Size* description now says that `ConsumePulsarRecord` also starts a new FlowFile on a schema change, and the README has a *Record sets and the record schema* section with a "Behaviour change since 2.9.0" callout — a topic with payloads of several shapes produces more, smaller FlowFiles than before, and an explicit schema is the way to keep one FlowFile per batch.

**Verification** — `ConsumePulsarRecordSchemaChangeTest`, running the real `JsonTreeReader` and `JsonRecordSetWriter` because the mock parser has a fixed schema and cannot show any of this:

- `aMessageWithADifferentSchemaStartsANewRecordSet` — the three payloads from #174 plus an array-element field: three FlowFiles, every field kept, nothing invented
- `aTypeConflictStartsANewRecordSetInsteadOfFailingTheTrigger` — `{"v":1}` then `{"v":"text"}`
- `alternatingSchemasProduceOneRecordSetPerChange` — pins the fragmentation trade-off
- `messagesWithTheSameSchemaShareOneRecordSet`, `aMappedAttributeChangeStillStartsANewRecordSet`, `anUnparseableMessageDoesNotCloseTheRecordSet`, `anExplicitSchemaIsAppliedUnchanged` — the behaviour that must not change

Against `main`, **three of the seven fail**:

```
aMessageWithADifferentSchemaStartsANewRecordSet:99->successFlowFiles:212 expected: <3> but was: <1>
aTypeConflictStartsANewRecordSetInsteadOfFailingTheTrigger:123 java.lang.NumberFormatException: For input string: "text"
alternatingSchemasProduceOneRecordSetPerChange:155->successFlowFiles:212 expected: <4> but was: <1>
```

The other four pass on both. No existing test needed a change: the FlowFile counts the suite asserts all come from `MockRecordParser`, whose schema is fixed — checked by running the suite rather than assuming.

Unit suite green: `mvn -B -ntp clean package -Dgpg.skip=true -pl '!docker-image'`, 296 tests. The Testcontainers integration tests were **not** run here (no Docker on this machine); the change does not depend on broker behaviour, so no IT was added.

**Not done here, on purpose:** direction (2) — inferring the set's schema from all of its messages so a heterogeneous batch stays one FlowFile. I have it working on a branch (`DataTypeUtils.merge`, which merges nested records and arrays and widens a type conflict to a choice type rather than picking a winner) and can send it as a follow-up once this lands, if the fragmentation turns out to matter.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Build / CI

## Checklist

- [x] Checked for an existing issue and any open PR already covering this
- [x] `mvn clean package` succeeds locally with Java 21
- [x] Added or updated tests where it makes sense, and confirmed they fail without the change
- [ ] Ran the integration tests (`mvn verify`, needs Docker) — could not: no Docker on this machine
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch
