### PR TITLE
fix: apply Message Routing Mode and Max Pending Messages to the producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,20 @@ broker's acknowledgement.
 > **Behaviour change since `2.9.0`:** neither property reached the producer since the publish
 > processors were refactored in 2023 — the producer always ran with the client defaults. A flow
 > that has *Message Routing Mode* set to `SinglePartition` will now really route its unkeyed
-> messages to a single partition, and *Max Pending Messages* now applies. A flow that had
-> `CustomPartition` selected becomes invalid and has to pick one of the other two modes.
+> messages to a single partition. A flow that had `CustomPartition` selected becomes invalid and
+> has to pick one of the other two modes.
+>
+> *Max Pending Messages* now applies **to every flow, including one that never configured it**.
+> The property has always shown a default of `1000`, but the value never reached the client, which
+> ran with the count-based bound disabled. With *Async Enabled*, messages are published through
+> `sendAsync()` and count against that bound; when it is reached and *Block if Message Queue Full*
+> is off — the default — a send fails with `ProducerQueueIsFullError` and its FlowFile is routed to
+> `failure` rather than waiting for room.
+>
+> Whether a flow reaches the bound depends on how fast the broker acknowledges, so it is likelier
+> against a remote or loaded broker than in testing. If you publish large FlowFiles asynchronously,
+> either raise *Max Pending Messages*, set it to `0` to restore the previous unbounded behaviour, or
+> enable *Block if Message Queue Full* so sends wait instead of failing.
 
 ## Publishing to topics that have a schema
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ FlowFile:
 > partition a message routes to, and it makes the topic compactable by that key. If you relied on
 > the previous unkeyed behaviour, clear the `msg.key` attribute before the publish processor.
 
+## Message routing on partitioned topics
+
+*Message Routing Mode* decides where an **unkeyed** message goes on a partitioned topic:
+`RoundRobinPartition` (the default) spreads them over the partitions, `SinglePartition` keeps
+them on one partition chosen per producer. A message with a key is hashed to a partition in
+either mode, so keyed messages keep their order per key regardless of the setting.
+`CustomPartition` needs a `MessageRouter` the processors cannot configure and is rejected at
+validation. *Max Pending Messages* bounds the producer's queue of messages awaiting the
+broker's acknowledgement.
+
+> **Behaviour change since `2.9.0`:** neither property reached the producer since the publish
+> processors were refactored in 2023 — the producer always ran with the client defaults. A flow
+> that has *Message Routing Mode* set to `SinglePartition` will now really route its unkeyed
+> messages to a single partition, and *Max Pending Messages* now applies. A flow that had
+> `CustomPartition` selected becomes invalid and has to pick one of the other two modes.
+
 ## Publishing to topics that have a schema
 
 `PublishPulsar` and `PublishPulsarRecord` create their producers with

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -27,6 +27,8 @@ import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
@@ -306,6 +308,26 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         return PROPERTIES;
     }
 
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+
+        // CustomPartition needs a MessageRouter implementation handed to the ProducerBuilder, and the
+        // processor offers no way to configure one: the client rejects the producer at creation time.
+        // Refusing it here fails the configuration with a reason instead of failing every trigger.
+        if (MESSAGE_ROUTING_MODE_CUSTOM_PARTITION.getValue().equals(validationContext.getProperty(MESSAGE_ROUTING_MODE).getValue())) {
+            results.add(new ValidationResult.Builder()
+                    .subject(MESSAGE_ROUTING_MODE.getDisplayName())
+                    .valid(false)
+                    .explanation("'" + MESSAGE_ROUTING_MODE_CUSTOM_PARTITION.getDisplayName() + "' needs a custom MessageRouter, "
+                            + "which this processor cannot configure; use '" + MESSAGE_ROUTING_MODE_ROUND_ROBIN_PARTITION.getDisplayName()
+                            + "' or '" + MESSAGE_ROUTING_MODE_SINGLE_PARTITION.getDisplayName() + "'")
+                    .build());
+        }
+
+        return results;
+    }
+
     private PulsarClientService pulsarClientService;
 
     private PublisherPool publisherPool;
@@ -349,6 +371,10 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
                 .asTimePeriod(TimeUnit.SECONDS).intValue());
         config.put("blockIfQueueFull", ctx.getProperty(BLOCK_IF_QUEUE_FULL).asBoolean());
         config.put("compressionType", CompressionType.valueOf(ctx.getProperty(COMPRESSION_TYPE).getValue()));
+        // Both were applied on the ProducerBuilder until producer creation moved to PublisherPool.loadConf();
+        // the properties stayed in the UI while the producer silently ran with the client defaults.
+        config.put("messageRoutingMode", MessageRoutingMode.valueOf(ctx.getProperty(MESSAGE_ROUTING_MODE).getValue()));
+        config.put("maxPendingMessages", ctx.getProperty(PENDING_MAX_MESSAGES).evaluateAttributeExpressions().asInteger());
 
         if (ctx.getProperty(BATCHING_ENABLED).asBoolean()) {
             config.put("batchingEnabled", Boolean.TRUE);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarRoutingModeIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarRoutingModeIT.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.junit.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * Where messages land on a partitioned topic is decided by the broker and the client's router, so the
+ * routing mode can only be verified against a real broker.
+ * <p>
+ * Every case publishes one FlowFile of 30 demarcated messages to a topic with three partitions and reads
+ * them back with a plain Pulsar consumer, which reports the partition each message came from.
+ */
+public class PublishPulsarRoutingModeIT extends AbstractPulsarIT {
+
+    private static final int PARTITIONS = 3;
+    private static final int MESSAGES = 30;
+
+    /** The case from the issue: SinglePartition has to keep unkeyed messages together. */
+    @Test
+    public void singlePartitionKeepsUnkeyedMessagesOnOnePartition() throws Exception {
+        final String topic = createPartitionedTopic();
+        final TestRunner runner = publisher(topic, "SinglePartition");
+
+        try (Consumer<byte[]> consumer = subscribe(topic)) {
+            runner.enqueue(unkeyedMessages());
+            runner.run(1, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+            final List<Message<byte[]>> received = receive(consumer, MESSAGES);
+            assertEquals(MESSAGES, received.size());
+            assertEquals("SinglePartition must route every unkeyed message to the same partition, but they arrived on "
+                    + partitionsOf(received), 1, partitionsOf(received).size());
+        }
+    }
+
+    /** The default, which the broken code applied by accident: unkeyed messages go round the partitions. */
+    @Test
+    public void roundRobinSpreadsUnkeyedMessagesOverEveryPartition() throws Exception {
+        final String topic = createPartitionedTopic();
+        final TestRunner runner = publisher(topic, "RoundRobinPartition");
+
+        try (Consumer<byte[]> consumer = subscribe(topic)) {
+            runner.enqueue(unkeyedMessages());
+            runner.run(1, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+            final List<Message<byte[]>> received = receive(consumer, MESSAGES);
+            assertEquals(MESSAGES, received.size());
+            assertEquals("round robin should use every partition, but used " + partitionsOf(received),
+                    PARTITIONS, partitionsOf(received).size());
+        }
+    }
+
+    /** A key is hashed to a partition in every mode, so keyed messages keep their partition and order. */
+    @Test
+    public void keyedMessagesStayOnOnePartitionPerKeyInEitherMode() throws Exception {
+        for (final String mode : new String[] {"RoundRobinPartition", "SinglePartition"}) {
+            final String topic = createPartitionedTopic();
+            final TestRunner runner = publisher(topic, mode);
+
+            try (Consumer<byte[]> consumer = subscribe(topic)) {
+                runner.enqueue(unkeyedMessages(), Collections.singletonMap(AbstractPulsarProducerProcessor.MSG_KEY, "device-7"));
+                runner.run(1, true);
+                runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+                final List<Message<byte[]>> received = receive(consumer, MESSAGES);
+                assertEquals(MESSAGES, received.size());
+                assertEquals(mode + ": one key must map to one partition, got " + partitionsOf(received), 1, partitionsOf(received).size());
+
+                int last = 0;
+                for (final Message<byte[]> message : received) {
+                    final int seq = Integer.parseInt(new String(message.getValue(), UTF_8).replaceAll("\\D", ""));
+                    assertTrue(mode + ": out of order, " + last + " then " + seq, seq > last);
+                    last = seq;
+                }
+            }
+        }
+    }
+
+    private static int topicCounter = 0;
+
+    private static String createPartitionedTopic() throws Exception {
+        final String topic = "persistent://public/default/routing-" + (topicCounter++) + "-" + System.nanoTime();
+        final Container.ExecResult result = PULSAR.execInContainer("bin/pulsar-admin", "topics", "create-partitioned-topic",
+                topic, "-p", String.valueOf(PARTITIONS));
+        assertEquals("pulsar-admin failed: " + result.getStderr(), 0, result.getExitCode());
+        return topic;
+    }
+
+    /** Batching is off so the round-robin router rotates per message rather than per batching window. */
+    private TestRunner publisher(final String topic, final String routingMode) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_ROUTING_MODE, routingMode);
+        return runner;
+    }
+
+    private static byte[] unkeyedMessages() {
+        final StringBuilder content = new StringBuilder();
+        for (int seq = 1; seq <= MESSAGES; seq++) {
+            content.append("m").append(seq).append('\n');
+        }
+        return content.toString().getBytes(UTF_8);
+    }
+
+    private static Consumer<byte[]> subscribe(final String topic) throws Exception {
+        return getClient().newConsumer(Schema.BYTES).topic(topic).subscriptionName("routing-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+    }
+
+    private static List<Message<byte[]>> receive(final Consumer<byte[]> consumer, final int expected) throws Exception {
+        final List<Message<byte[]>> messages = new ArrayList<>();
+        while (messages.size() < expected) {
+            final Message<byte[]> message = consumer.receive(15, TimeUnit.SECONDS);
+            if (message == null) {
+                break;
+            }
+            messages.add(message);
+            consumer.acknowledge(message);
+        }
+        return messages;
+    }
+
+    /** The partitions the messages arrived on, e.g. {@code [partition-0, partition-2]}. */
+    private static TreeSet<String> partitionsOf(final List<Message<byte[]>> messages) {
+        final TreeSet<String> partitions = new TreeSet<>();
+        for (final Message<byte[]> message : messages) {
+            final String topic = message.getTopicName();
+            partitions.add(topic.substring(topic.lastIndexOf("-partition-") + 1));
+        }
+        return partitions;
+    }
+
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRoutingConfigurationTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRoutingConfigurationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * The producer has to be configured with the routing mode and the pending-message bound the user picked.
+ * <p>
+ * Both properties were applied on the ProducerBuilder until producer creation moved to
+ * {@code PublisherPool.loadConf(map)}; they were not carried over into the map, so the producer ran with
+ * the client defaults whatever the processor was configured with. The map handed to {@code loadConf()} is
+ * what production actually applies, so that is what is asserted here.
+ */
+public class PublishPulsarRoutingConfigurationTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "test-topic");
+    }
+
+    @Test
+    public void theConfiguredRoutingModeAndPendingBoundReachTheProducer() {
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_ROUTING_MODE, "SinglePartition");
+        runner.setProperty(AbstractPulsarProducerProcessor.PENDING_MAX_MESSAGES, "250");
+
+        final Map<String, Object> config = producerConfiguration();
+
+        assertEquals(MessageRoutingMode.SinglePartition, config.get("messageRoutingMode"));
+        assertEquals(250, config.get("maxPendingMessages"));
+    }
+
+    @Test
+    public void theDefaultsAreAppliedExplicitly() {
+        final Map<String, Object> config = producerConfiguration();
+
+        assertEquals(MessageRoutingMode.RoundRobinPartition, config.get("messageRoutingMode"));
+        assertEquals(1000, config.get("maxPendingMessages"));
+    }
+
+    /** There is no way to hand the producer a MessageRouter, so the mode that needs one is refused up front. */
+    @Test
+    public void customPartitionIsRejectedAtValidation() {
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_ROUTING_MODE, "CustomPartition");
+
+        runner.assertNotValid();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> producerConfiguration() {
+        runner.enqueue("payload");
+        runner.run();
+
+        final ArgumentCaptor<Map<String, Object>> config = ArgumentCaptor.forClass(Map.class);
+        verify(mockClientService.getMockProducerBuilder(), times(1)).loadConf(config.capture());
+        return config.getValue();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #180.

`PublishPulsar` and `PublishPulsarRecord` expose **Message Routing Mode** and **Max Pending Messages**, but neither reached the producer. They were applied on the `ProducerBuilder` until producer creation moved into `PublisherPool.loadConf(map)` in 9f478c4 (2023-05-31); the map never carried them, so the producer ran with the client defaults whatever the processor was configured with. It went unnoticed because the property default, `RoundRobinPartition`, is also the client default.

**Change**

- `getPulsarProducerConfiguration()` puts `messageRoutingMode` and `maxPendingMessages` into the map — both are `ProducerConfigurationData` fields, so `loadConf()` takes them as they are.
- `CustomPartition` needs a `MessageRouter` handed to the builder, and the processors offer no way to configure one: the client refuses the producer at creation time, which would now turn every trigger into a failure. It is rejected at validation instead, with the reason and the two usable modes. If you would rather drop the option from the allowable values, say so — that is the other defensible fix.
- README: a *Message routing on partitioned topics* section with a "Behaviour change since 2.9.0" callout: a flow that has `SinglePartition` selected really routes unkeyed messages to one partition from now on, *Max Pending Messages* applies, and a flow with `CustomPartition` becomes invalid.

**Verification**

`PublishPulsarRoutingConfigurationTest` asserts the map handed to `loadConf()`, the way the existing chunking test does. Against `main`, all three fail:

```
theConfiguredRoutingModeAndPendingBoundReachTheProducer   expected:<SinglePartition> but was:<null>
theDefaultsAreAppliedExplicitly                           expected:<RoundRobinPartition> but was:<null>
customPartitionIsRejectedAtValidation                     Processor appears to be valid but expected it to be invalid
```

`PublishPulsarRoutingModeIT` publishes 30 demarcated messages to a three-partition topic on a real broker (`apachepulsar/pulsar:4.2.4`) and reads back which partition each one arrived on. Against `main`, `singlePartitionKeepsUnkeyedMessagesOnOnePartition` fails:

```
SinglePartition must route every unkeyed message to the same partition, but they arrived on [partition-0, partition-1, partition-2]
```

`roundRobinSpreadsUnkeyedMessagesOverEveryPartition` and `keyedMessagesStayOnOnePartitionPerKeyInEitherMode` pass on both and guard the behaviour that must not change — in particular that a key is hashed to a partition in either mode, so keyed flows are unaffected by this fix.

Integration tests **were run** this time: `mvn verify -Dgpg.skip=true -Ddocker.api.version=1.41` against a rootless podman socket (`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`, Ryuk disabled), which the Testcontainers setup from #152 handles without changes. Unit suite: 299 tests, green.

**Not done here:** actual `CustomPartition` support, which would need a way to name a `MessageRouter` implementation; filed nothing for it since the option has never worked and nobody has asked.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Build / CI

## Checklist

- [x] Checked for an existing issue and any open PR already covering this
- [x] `mvn clean package` succeeds locally with Java 21
- [x] Added or updated tests where it makes sense, and confirmed they fail without the change
- [x] Ran the integration tests (`mvn verify`, needs Docker) — via podman, see above
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch
