### PR TITLE
fix: consume from a topic without a schema instead of throwing NullPointerException

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -57,6 +57,8 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
 @CapabilityDescription("Consumes messages from Apache Pulsar. "
@@ -271,8 +273,11 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 // particularly when the message originates from a different topic.
                 currentAttributes.put("topicName", getLogicalTopicName(msg.getTopicName()));
                 // add the schema to the attributes in-case the schema is updated on the topic
-                if (msg.getReaderSchema().isPresent() && msg.getReaderSchema().get().getSchemaInfo().getType() == SchemaType.AVRO) {
-                    currentAttributes.put("avro.schema", new String(msg.getReaderSchema().get().getSchemaInfo().getSchema()));
+                // With AUTO_CONSUME the reader schema is present even for a topic that has no schema at all -
+                // it is the AutoConsumeSchema itself - but its SchemaInfo is null. Treat that like no schema.
+                final SchemaInfo readerSchemaInfo = msg.getReaderSchema().map(Schema::getSchemaInfo).orElse(null);
+                if (readerSchemaInfo != null && readerSchemaInfo.getType() == SchemaType.AVRO) {
+                    currentAttributes.put("avro.schema", new String(readerSchemaInfo.getSchema()));
                 }
 
                 // Parse the message before deciding which record set it joins. The reader's schema is the

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarRecordIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarRecordIT.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * ConsumePulsarRecord against a real broker. What a message carries as its reader schema - and whether
+ * that schema has any schema info at all - is decided by the broker, so this cannot be shown with the mock
+ * client, whose messages report no reader schema.
+ */
+public class ConsumePulsarRecordIT extends AbstractPulsarIT {
+
+    private static final int MESSAGES = 30;
+    private static int topicCounter = 0;
+
+    /**
+     * The case from the issue. A topic never given a schema yields a reader schema whose SchemaInfo is
+     * null; before the fix every trigger threw NullPointerException out of onTrigger and nothing was ever
+     * consumed from such a topic.
+     */
+    @Test
+    public void aTopicWithoutASchemaIsConsumed() throws Exception {
+        final String topic = topic("schemaless");
+        publish(topic, messages());
+
+        final TestRunner runner = consumer(topic);
+        final int records = consumeUntil(runner, MESSAGES);
+
+        assertEquals(MESSAGES, records);
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+            flowFile.assertAttributeNotExists("avro.schema");
+        }
+    }
+
+    /** The common production shape - a topic carrying a STRING schema - keeps working as before. */
+    @Test
+    public void aTopicWithAStringSchemaIsConsumed() throws Exception {
+        final String topic = topic("string-schema");
+        try (Producer<String> producer = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            for (final String message : messages()) {
+                producer.send(message);
+            }
+        }
+
+        final TestRunner runner = consumer(topic);
+        final int records = consumeUntil(runner, MESSAGES);
+
+        assertEquals(MESSAGES, records);
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+    }
+
+    /** The partitions of a partitioned topic are read as one logical topic (#141), on a real broker too. */
+    @Test
+    public void aPartitionedTopicIsReadAsOneLogicalTopic() throws Exception {
+        final String topic = topic("partitioned");
+        final Container.ExecResult result = PULSAR.execInContainer("bin/pulsar-admin", "topics", "create-partitioned-topic", topic, "-p", "3");
+        assertEquals("pulsar-admin failed: " + result.getStderr(), 0, result.getExitCode());
+        publish(topic, messages());
+
+        final TestRunner runner = consumer(topic);
+        final int records = consumeUntil(runner, MESSAGES);
+
+        assertEquals(MESSAGES, records);
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+            assertEquals("a partition must be reported as its logical topic", topic, flowFile.getAttribute("topicName"));
+        }
+    }
+
+    private static String topic(final String name) {
+        return "persistent://public/default/consume-" + name + "-" + (topicCounter++) + "-" + System.nanoTime();
+    }
+
+    /** {@code MESSAGES} JSON payloads of the same shape, so they share one record set. */
+    private static String[] messages() {
+        final String[] messages = new String[MESSAGES];
+        for (int seq = 1; seq <= MESSAGES; seq++) {
+            messages[seq - 1] = "{\"device\":\"d" + (seq % 3) + "\",\"seq\":" + seq + "}";
+        }
+        return messages;
+    }
+
+    private TestRunner consumer(final String topic) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final JsonTreeReader reader = new JsonTreeReader();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "100");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+        return runner;
+    }
+
+    /**
+     * Triggers the processor until {@code expected} records have reached success, then stops it. The
+     * processor polls with {@code receive(0, SECONDS)}, so the first triggers after the consumer connects
+     * can legitimately return nothing while the broker is still delivering - a fixed trigger count would
+     * "lose" a tail of messages that simply had not arrived yet.
+     */
+    private static int consumeUntil(final TestRunner runner, final int expected) throws Exception {
+        final int[] records = {0};
+        runner.run(1, false, true);
+        await(expected + " records to be consumed", () -> {
+            runner.run(1, false, false);
+            records[0] = 0;
+            final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS);
+            for (final MockFlowFile flowFile : flowFiles) {
+                records[0] += Integer.parseInt(flowFile.getAttribute("record.count"));
+            }
+            return records[0] >= expected;
+        });
+        runner.run(1, true, false);
+        return records[0];
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemalessTopicTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemalessTopicTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A message from a topic that has no schema must be consumed like any other.
+ * <p>
+ * The consumer subscribes with {@code Schema.AUTO_CONSUME()}. For such a message the reader schema is
+ * present - it is the {@code AutoConsumeSchema} itself - but its {@code SchemaInfo} is {@code null}, and
+ * the attribute code dereferenced it: every trigger threw {@code NullPointerException} out of
+ * {@code onTrigger}, nothing was acknowledged, and the batch came back to fail again. The mock message
+ * used everywhere else returns an empty reader schema, which is why no unit test could show it.
+ */
+public class ConsumePulsarRecordSchemalessTopicTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/schemaless";
+
+    /** What a real message from a schema-less topic looks like: a reader schema without schema info. */
+    private static final class SchemalessMessage extends MockPulsarMessage<GenericRecord> {
+        private SchemalessMessage(final String payload, final int id) {
+            super(TOPIC, payload.getBytes(UTF_8), "1234:" + id + ":0", null, null);
+        }
+
+        @Override
+        public Optional<Schema<?>> getReaderSchema() {
+            final Schema<?> autoConsumeWithoutSchema = mock(Schema.class);   // getSchemaInfo() returns null
+            return Optional.of(autoConsumeWithoutSchema);
+        }
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockRecordParser readerService = new MockRecordParser();
+        readerService.addSchemaField("name", RecordFieldType.STRING);
+        readerService.addSchemaField("age", RecordFieldType.INT);
+        runner.addControllerService("record-reader", readerService);
+        runner.enableControllerService(readerService);
+
+        final MockRecordWriter writerService = new MockRecordWriter("name, age");
+        runner.addControllerService("record-writer", writerService);
+        runner.enableControllerService(writerService);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+    }
+
+    @Test
+    public void messagesFromATopicWithoutASchemaAreConsumed() {
+        mockClientService.setMockMessageQueue(Arrays.asList(
+                new SchemalessMessage("Name1,1", 1), new SchemalessMessage("Name2,2", 2), new SchemalessMessage("Name3,3", 3)));
+
+        // Before the fix this threw NullPointerException out of onTrigger.
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS).get(0);
+        assertEquals("3", flowFile.getAttribute("record.count"));
+        flowFile.assertAttributeNotExists("avro.schema");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #181.

`ConsumePulsarRecord` threw `NullPointerException` out of `onTrigger` for every message from a topic that has no schema. The consumer subscribes with `Schema.AUTO_CONSUME()`; for such a message the reader schema **is** present — it is the `AutoConsumeSchema` itself — but its `SchemaInfo` is `null`, and the code that decides whether to attach `avro.schema` dereferenced it. The trigger failed, nothing was acknowledged (#169), and the batch came back to fail again: the processor could not consume a schema-less topic at all. The `isPresent()` guard from #74 covered "no reader schema" but not "reader schema without schema info".

**Change**

- A `null` `SchemaInfo` is treated like an absent schema: `msg.getReaderSchema().map(Schema::getSchemaInfo)` and the `AVRO` check on the result. No `avro.schema` attribute for such a message; nothing else changes. Three lines in `consumeMessages()`.

**Verification**

`ConsumePulsarRecordSchemalessTopicTest` — a mock message whose reader schema is present but has no schema info, which is what the shared mock could not produce (it reports an empty reader schema, which is why no unit test ever hit this). Against `main`:

```
messagesFromATopicWithoutASchemaAreConsumed
    java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.common.schema.SchemaInfo.getType()"
    because the return value of "org.apache.pulsar.client.api.Schema.getSchemaInfo()" is null
```

`ConsumePulsarRecordIT` — the first integration test that exercises `ConsumePulsarRecord` against a real broker (`apachepulsar/pulsar:4.2.4`), with the real `JsonTreeReader`/`JsonRecordSetWriter`:

- `aTopicWithoutASchemaIsConsumed` — the case from the issue; **fails on `main`** with the same `NullPointerException`
- `aTopicWithAStringSchemaIsConsumed` — the common production shape, passes on both
- `aPartitionedTopicIsReadAsOneLogicalTopic` — #141 on a real partitioned topic: every FlowFile reports the logical topic in `topicName`; passes on both

The consume helper triggers until the expected record count arrives rather than a fixed number of times, for the reason noted on #166: the processor polls with `receive(0, SECONDS)`, so the first triggers after the consumer connects can legitimately return nothing.

Integration tests **were run**: `mvn verify -Dgpg.skip=true -Ddocker.api.version=1.41` against a rootless podman socket (`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`, Ryuk disabled). Unit suite: 297 tests, green.

**Not done here:** nothing else was changed in the attribute logic — a topic with an AVRO schema still gets `avro.schema`, and other schema types still get nothing, exactly as #74 left it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI

## Checklist

- [x] Checked for an existing issue and any open PR already covering this
- [x] `mvn clean package` succeeds locally with Java 21
- [x] Added or updated tests where it makes sense, and confirmed they fail without the change
- [x] Ran the integration tests (`mvn verify`, needs Docker) — via podman, see above
- [x] No secrets, credentials, or generated artifacts committed
- [x] PR targets the `main` branch
