### PR TITLE
feat: build records from the topic's schema instead of a Record Reader (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ broker's acknowledgement.
 > either raise *Max Pending Messages*, set it to `0` to restore the previous unbounded behaviour, or
 > enable *Block if Message Queue Full* so sends wait instead of failing.
 
+## Consuming from topics that have a schema
+
+`ConsumePulsarRecord`'s **Message Schema Strategy** decides how a message becomes records.
+
+`Record Reader` (the default) parses each message with the configured reader, which has to match how the
+topic is encoded. That is not always obvious: an AVRO topic carries *bare Avro binary* — no file header
+and no embedded schema, because Pulsar keeps the schema in its registry — so it needs an `AvroReader`
+whose *Schema Access Strategy* is `Use 'Schema Text' Property` and whose *Schema Text* is
+`${avro.schema}`, the attribute this processor sets from the topic's registered schema. A JSON topic
+carries text a `JsonTreeReader` can infer. Pointing the wrong reader at a topic sends every message to
+`parse.failure`.
+
+`Topic Schema` builds records from the schema the topic carries instead. The field definitions come from
+the broker — Pulsar attaches each message's schema to it — so no reader and no schema configuration are
+needed at all, and AVRO and JSON topics behave identically. Because the schema arrives per message,
+evolution is handled: a message published under an older version decodes with the version it was written
+with.
+
+A *Record Reader* may still be configured under `Topic Schema`, and messages the strategy cannot decode
+fall back to it — a topic with no schema at all, or one whose schema has no record shape. Without a
+reader to fall back to, those messages go to `parse.failure`. Primitive and `KeyValue` schemas are not
+yet decoded this way.
+
 ## Publishing to topics that have a schema
 
 `PublishPulsar` and `PublishPulsarRecord` create their producers with

--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ broker's acknowledgement.
 `Record Reader` (the default) parses each message with the configured reader, which has to match how the
 topic is encoded. That is not always obvious: an AVRO topic carries *bare Avro binary* — no file header
 and no embedded schema, because Pulsar keeps the schema in its registry — so it needs an `AvroReader`
-whose *Schema Access Strategy* is `Use 'Schema Text' Property` and whose *Schema Text* is
-`${avro.schema}`, the attribute this processor sets from the topic's registered schema. A JSON topic
-carries text a `JsonTreeReader` can infer. Pointing the wrong reader at a topic sends every message to
-`parse.failure`.
+with *Schema Access Strategy* set to `Use 'Schema Text' Property`. Its *Schema Text* already defaults to
+`${avro.schema}`, which is the attribute this processor sets from the topic's registered schema, so the
+access strategy is the only field that has to change. Because `avro.schema` is part of what decides a
+record set's boundaries, a schema version change closes the current FlowFile and opens a new one carrying
+its own schema, and the reader is created with those attributes so `${avro.schema}` resolves for the
+reader itself rather than only downstream. A JSON topic carries text a `JsonTreeReader` can infer.
+Pointing the wrong reader at a topic sends every message to `parse.failure`.
 
 `Topic Schema` builds records from the schema the topic carries instead. The field definitions come from
 the broker — Pulsar attaches each message's schema to it — so no reader and no schema configuration are

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -37,7 +37,10 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
@@ -47,6 +50,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes;
+import org.apache.nifi.processors.pulsar.utils.TopicSchemaRecordDecoder;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.*;
 import org.apache.nifi.serialization.record.Record;
@@ -88,12 +92,35 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     public static final String MSG_COUNT = "record.count";
     private static final String RECORD_SEPARATOR = "\n";
 
+    static final AllowableValue SCHEMA_FROM_RECORD_READER = new AllowableValue("Record Reader", "Record Reader",
+            "Parse each message with the configured Record Reader. The reader has to match how the topic is "
+            + "encoded: an AVRO topic carries bare Avro binary and needs an AvroReader whose Schema Text is "
+            + "${avro.schema}, while a JSON topic carries text a JsonTreeReader can infer.");
+
+    static final AllowableValue SCHEMA_FROM_TOPIC = new AllowableValue("Topic Schema", "Topic Schema",
+            "Build records from the schema the topic carries, which the broker sends with every message. No "
+            + "Record Reader is needed and AVRO and JSON topics behave identically. Messages from a topic "
+            + "with no schema, or with a schema that has no record shape, fall back to the Record Reader.");
+
+    public static final PropertyDescriptor MESSAGE_SCHEMA_STRATEGY = new PropertyDescriptor.Builder()
+            .name("MESSAGE_SCHEMA_STRATEGY")
+            .displayName("Message Schema Strategy")
+            .description("How Pulsar messages are turned into records. 'Topic Schema' uses the schema "
+                    + "registered on the topic, so the encoding is handled for you; 'Record Reader' uses the "
+                    + "configured reader, which must match the topic's encoding.")
+            .required(false)
+            .allowableValues(SCHEMA_FROM_RECORD_READER, SCHEMA_FROM_TOPIC)
+            .defaultValue(SCHEMA_FROM_RECORD_READER.getValue())
+            .build();
+
     public static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
             .name("Record Reader")
             .displayName("Record Reader")
-            .description("The Record Reader to use for incoming FlowFiles")
+            .description("The Record Reader to use for incoming FlowFiles. Required unless Message Schema "
+                    + "Strategy is 'Topic Schema', which still falls back to this reader for messages from a "
+                    + "topic that has no schema.")
             .identifiesControllerService(RecordReaderFactory.class)
-            .required(true)
+            .required(false)
             .build();
 
     public static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
@@ -119,11 +146,41 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             .description("FlowFiles for which the content cannot be parsed.")
             .build();
 
+    /**
+     * The Record Reader stays required under the default strategy, so an existing configuration that omits
+     * it is still invalid for the same reason it always was. Under 'Topic Schema' it is optional, but it is
+     * still what messages from a schema-less topic fall back to - without it those go to parse.failure.
+     */
+    @Override
+    protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+
+        if (!usesTopicSchema(validationContext.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue())
+                && !validationContext.getProperty(RECORD_READER).isSet()) {
+            results.add(new ValidationResult.Builder()
+                    .subject(RECORD_READER.getDisplayName())
+                    .valid(false)
+                    .explanation("is required unless " + MESSAGE_SCHEMA_STRATEGY.getDisplayName()
+                            + " is '" + SCHEMA_FROM_TOPIC.getDisplayName() + "'")
+                    .build());
+        }
+
+        return results;
+    }
+
+    /** Holds the parsed schema between messages, so a batch on one schema parses the definition once. */
+    private final TopicSchemaRecordDecoder topicSchemaDecoder = new TopicSchemaRecordDecoder();
+
+    static boolean usesTopicSchema(final String strategy) {
+        return SCHEMA_FROM_TOPIC.getValue().equals(strategy);
+    }
+
     private static final List<PropertyDescriptor> PROPERTIES;
     private static final Set<Relationship> RELATIONSHIPS;
 
     static {
         final List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(MESSAGE_SCHEMA_STRATEGY);
         properties.add(RECORD_READER);
         properties.add(RECORD_WRITER);
         properties.add(MAX_WAIT_TIME);
@@ -266,6 +323,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         // Cumulative acks are NOT permitted on Shared subscriptions
         final boolean shared = isSharedSubscription(context);
 
+        final boolean useTopicSchema = usesTopicSchema(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
+
         try {
             for (Message<GenericRecord> msg : groupedMessages) {
                 currentAttributes = getMappedFlowFileAttributes(context, msg);
@@ -288,20 +347,36 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 final byte[] data = msg.getData();
                 RecordReader reader = null;
                 RecordSchema currentSchema = null;
+                Record topicSchemaRecord = null;
 
-                try {
-                    reader = readerFactory.createRecordReader(currentAttributes, new ByteArrayInputStream(data), data.length, getLogger());
-                    currentSchema = reader.getSchema();
-                } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
-                    IOUtils.closeQuietly(reader);
-                    reader = null;
+                if (useTopicSchema && TopicSchemaRecordDecoder.supports(readerSchemaInfo)) {
+                    // The topic's schema decides the record's shape, so no reader is consulted at all. One
+                    // message is one record here: a schema-bearing topic carries a single encoded value per
+                    // message, unlike a reader, which may find several records in one payload.
+                    try {
+                        topicSchemaRecord = topicSchemaDecoder.decode(data, readerSchemaInfo);
+                        currentSchema = topicSchemaRecord.getSchema();
+                    } catch (final IOException | RuntimeException e) {
+                        getLogger().debug("Unable to decode a message with the topic's schema", e);
+                        topicSchemaRecord = null;
+                    }
+                } else if (readerFactory != null) {
+                    // Either the configured strategy is the Record Reader, or the topic has no schema to
+                    // decode with - a schema-less topic, or one whose schema has no record shape.
+                    try {
+                        reader = readerFactory.createRecordReader(currentAttributes, new ByteArrayInputStream(data), data.length, getLogger());
+                        currentSchema = reader.getSchema();
+                    } catch (MalformedRecordException | IOException | SchemaNotFoundException e) {
+                        IOUtils.closeQuietly(reader);
+                        reader = null;
+                    }
                 }
 
                 // if the current message's mapped attribute values - or its schema - differ from the open
                 // record set's, write out the active record set and clear various references so that we'll
                 // start a new one. An unparseable message has no schema and leaves the open set as it is.
                 if (lastAttributes != null && (!lastAttributes.equals(currentAttributes)
-                        || (reader != null && !schema.equals(currentSchema)))) {
+                        || (currentSchema != null && !schema.equals(currentSchema)))) {
                     WriteResult result = writer.finishRecordSet();
                     IOUtils.closeQuietly(writer);
                     IOUtils.closeQuietly(rawOut);
@@ -332,7 +407,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 // purpose, so it is acknowledged with the commit of the FlowFiles it belongs to
                 uncommitted.add(msg);
 
-                if (reader == null) {
+                if (reader == null && topicSchemaRecord == null) {
                     // the message could not be parsed: it is routed to parse_failure with the rest of the set
                     parseFailures.add(msg);
                     continue;
@@ -371,9 +446,14 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 // have the same mapped flowfile attribute values and the same schema, which means that it's ok
                 // that they are all placed in the same output flowfile.
                 try {
-                    for (Record record = reader.nextRecord(); record != null; record = reader.nextRecord()) {
-                        writer.write(record);
+                    if (topicSchemaRecord != null) {
+                        writer.write(topicSchemaRecord);
                         writtenRecords++;
+                    } else {
+                        for (Record record = reader.nextRecord(); record != null; record = reader.nextRecord()) {
+                            writer.write(record);
+                            writtenRecords++;
+                        }
                     }
                 } catch (MalformedRecordException | IOException e) {
                     parseFailures.add(msg);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.nifi.avro.AvroTypeUtil;
+import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Builds NiFi records from the schema a Pulsar topic carries, rather than from a configured Record Reader.
+ * <p>
+ * The field definitions come from the broker, not from the payload and not from message properties: Pulsar
+ * keeps schemas in a registry keyed by topic and version, and {@code Schema.AUTO_CONSUME()} attaches the
+ * schema of each message's version as its reader schema. {@link SchemaInfo#getSchema()} is that definition,
+ * and for both {@code AVRO} and {@code JSON} topics it is an Avro schema document - only the
+ * {@link SchemaType} says how the payload itself is encoded. Because the definition arrives per message,
+ * schema evolution needs no special handling here: a message published under an older version decodes with
+ * the version it was written with.
+ * <p>
+ * This is the mirror of {@code PublisherLease}'s encoding, and deliberately decodes the bytes itself rather
+ * than using the value Pulsar already decoded. The Pulsar client shades Avro, so the record behind
+ * {@code msg.getValue()} is a {@code org.apache.pulsar.shade.org.apache.avro} type that NiFi's
+ * {@link AvroTypeUtil} cannot accept. Parsing the definition with unshaded Avro keeps both directions on
+ * the same conversion code.
+ */
+public class TopicSchemaRecordDecoder {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** Parsed once and re-parsed only when the definition itself changes, as leases do on the publish side. */
+    private String cachedDefinition;
+    private SchemaType cachedType;
+    private org.apache.avro.Schema cachedAvroSchema;
+    private RecordSchema cachedRecordSchema;
+
+    /**
+     * Whether records can be built from this schema. Only the two struct types Pulsar registers as an Avro
+     * document are supported; a topic with no schema reports {@code null} here, and a primitive or
+     * {@code KEY_VALUE} schema has no record shape to map, so both fall back to the Record Reader.
+     */
+    public static boolean supports(final SchemaInfo schemaInfo) {
+        return schemaInfo != null
+                && (schemaInfo.getType() == SchemaType.AVRO || schemaInfo.getType() == SchemaType.JSON);
+    }
+
+    /**
+     * Decodes one message into a record shaped by the topic's schema.
+     *
+     * @param data the raw message payload
+     * @param schemaInfo the schema the message was published under, which must {@link #supports} it
+     * @return the decoded record
+     * @throws IOException if the payload does not match the schema
+     */
+    public Record decode(final byte[] data, final SchemaInfo schemaInfo) throws IOException {
+        final String definition = new String(schemaInfo.getSchema(), StandardCharsets.UTF_8);
+
+        if (cachedRecordSchema == null || !definition.equals(cachedDefinition) || cachedType != schemaInfo.getType()) {
+            cachedAvroSchema = new org.apache.avro.Schema.Parser().parse(definition);
+            cachedRecordSchema = AvroTypeUtil.createSchema(cachedAvroSchema);
+            cachedDefinition = definition;
+            cachedType = schemaInfo.getType();
+        }
+
+        return schemaInfo.getType() == SchemaType.AVRO ? decodeAvro(data) : decodeJson(data);
+    }
+
+    /** AVRO topics carry bare Avro binary - no file header, no embedded schema - so the schema comes from us. */
+    private Record decodeAvro(final byte[] data) throws IOException {
+        final GenericDatumReader<org.apache.avro.generic.GenericRecord> datumReader =
+                new GenericDatumReader<>(cachedAvroSchema);
+
+        final org.apache.avro.generic.GenericRecord avroRecord =
+                datumReader.read(null, DecoderFactory.get().binaryDecoder(data, null));
+
+        return new MapRecord(cachedRecordSchema, AvroTypeUtil.convertAvroRecordToMap(avroRecord, cachedRecordSchema));
+    }
+
+    /**
+     * JSON topics carry plain JSON text - the shape Pulsar's own JSON schema writes, not Avro's JSON
+     * encoding - so it is parsed as JSON and coerced to the schema's types. Coercion matters because JSON
+     * has no way to distinguish an int from a long, or a string from a UUID.
+     */
+    @SuppressWarnings("unchecked")
+    private Record decodeJson(final byte[] data) throws IOException {
+        final Map<String, Object> values = JSON.readValue(data, Map.class);
+
+        return new MapRecord(cachedRecordSchema, values, false, true);
+    }
+
+    /** The schema the last decoded message was shaped by, for callers that group records into sets. */
+    public RecordSchema getLastRecordSchema() {
+        return cachedRecordSchema;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicSchemaIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicSchemaIT.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.api.schema.RecordSchemaBuilder;
+import org.apache.pulsar.client.api.schema.SchemaBuilder;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Test;
+
+/**
+ * Consuming with the topic's own schema instead of a configured Record Reader (#185).
+ * <p>
+ * The field definitions come from the broker: Pulsar keeps schemas in a registry keyed by topic and
+ * version, and {@code AUTO_CONSUME} attaches each message's schema as its reader schema. So the strategy
+ * needs no schema configuration of any kind - notably not the {@code AvroReader} with Schema Text
+ * {@code ${avro.schema}} that an AVRO topic otherwise requires, which is the configuration this replaces.
+ * <p>
+ * The e2e pairing - publish with this bundle, read it back with this bundle, on both encodings - is in
+ * {@link NiFiSchemaRoundTripIT}.
+ */
+public class ConsumePulsarTopicSchemaIT extends AbstractPulsarIT {
+
+    private static final int RECORDS = 10;
+
+    /** AVRO is the case that motivated this: bare binary that no reader can parse unaided. */
+    @Test
+    public void anAvroTopicIsConsumedWithNoRecordReaderConfigured() throws Exception {
+        final String topic = seededTopic("avro-topic-schema", SchemaType.AVRO);
+        publishWithPlainClient(topic, SchemaType.AVRO);
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "avro-ts");
+        assertEquals(RECORDS + 1, consumeRecords(consumer));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue("the decoded field values should be present", successContent(consumer).contains("sensor-1"));
+    }
+
+    /** JSON goes through the same strategy, so the two encodings become indistinguishable to the user. */
+    @Test
+    public void aJsonTopicIsConsumedWithNoRecordReaderConfigured() throws Exception {
+        final String topic = seededTopic("json-topic-schema", SchemaType.JSON);
+        publishWithPlainClient(topic, SchemaType.JSON);
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "json-ts");
+        assertEquals(RECORDS + 1, consumeRecords(consumer));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue("the decoded field values should be present", successContent(consumer).contains("sensor-1"));
+    }
+
+    /**
+     * A schema-less topic has no definition to decode with, so the strategy falls back to the Record
+     * Reader. This is the #181 shape, and it is why the reader stays configurable under this strategy.
+     */
+    @Test
+    public void aTopicWithoutASchemaFallsBackToTheRecordReader() throws Exception {
+        final String topic = "persistent://public/default/ts-noschema-" + System.nanoTime();
+        publish(topic, jsonPayloads());
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "noschema-ts");
+        final JsonTreeReader reader = new JsonTreeReader();
+        consumer.addControllerService("record-reader", reader);
+        consumer.enableControllerService(reader);
+        consumer.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+
+        assertEquals("the reader should have handled what the topic schema could not",
+                RECORDS, consumeRecordsExpecting(consumer, RECORDS));
+    }
+
+    /** Without a reader to fall back to, those messages are routed rather than silently dropped. */
+    @Test
+    public void aTopicWithoutASchemaAndNoReaderGoesToParseFailure() throws Exception {
+        final String topic = "persistent://public/default/ts-noschema-noreader-" + System.nanoTime();
+        publish(topic, jsonPayloads());
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "noschema-noreader-ts");
+        consumer.run(1, false, true);
+        await("messages to reach parse.failure", () -> {
+            consumer.run(1, false, false);
+            return !consumer.getFlowFilesForRelationship(ConsumePulsarRecord.REL_PARSE_FAILURE).isEmpty();
+        });
+        consumer.run(1, true, false);
+
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
+    }
+
+    // ------------------------------------------------------------------ e2e: NiFi in, NiFi out
+
+    /**
+     * The pairing a user actually deploys: publish with {@code PublishPulsarRecord} on 'Topic Schema' and
+     * read it back with {@code ConsumePulsarRecord} on 'Topic Schema', with no Record Reader anywhere in
+     * the flow. AVRO is the half that otherwise needs an AvroReader pointed at {@code ${avro.schema}}.
+     */
+    @Test
+    public void anAvroTopicRoundTripsThroughNiFiOnTheTopicSchemaAlone() throws Exception {
+        final String topic = seededTopic("avro-e2e", SchemaType.AVRO);
+        publishWithNiFi(topic);
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "avro-e2e");
+        assertEquals(RECORDS + 1, consumeRecords(consumer));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue("the decoded values should survive the round trip", successContent(consumer).contains("sensor-1"));
+    }
+
+    /** The same on JSON, so the two encodings are indistinguishable once the topic's schema drives both ends. */
+    @Test
+    public void aJsonTopicRoundTripsThroughNiFiOnTheTopicSchemaAlone() throws Exception {
+        final String topic = seededTopic("json-e2e", SchemaType.JSON);
+        publishWithNiFi(topic);
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "json-e2e");
+        assertEquals(RECORDS + 1, consumeRecords(consumer));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue("the decoded values should survive the round trip", successContent(consumer).contains("sensor-1"));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** Publishes {@link #RECORDS} records through {@code PublishPulsarRecord}, encoded with the topic's schema. */
+    private void publishWithNiFi(final String topic) throws Exception {
+        final TestRunner publisher = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(publisher, "pulsar-client");
+
+        final JsonTreeReader reader = new JsonTreeReader();
+        publisher.addControllerService("record-reader", reader);
+        publisher.enableControllerService(reader);
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        publisher.addControllerService("record-writer", writer);
+        publisher.enableControllerService(writer);
+
+        publisher.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        publisher.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        publisher.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        publisher.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        publisher.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        publisher.setProperty(PublishPulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+
+        final StringBuilder content = new StringBuilder("[");
+        for (int seq = 1; seq <= RECORDS; seq++) {
+            content.append(seq > 1 ? "," : "")
+                    .append("{\"id\":\"sensor-").append(seq).append("\",\"reading\":").append(seq * 10).append("}");
+        }
+        publisher.enqueue(content.append("]").toString().getBytes(UTF_8));
+        publisher.run(1, true);
+
+        publisher.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 1);
+        publisher.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+    }
+
+    private static GenericSchema<GenericRecord> sensorSchema(final SchemaType type) {
+        final RecordSchemaBuilder builder = SchemaBuilder.record("Sensor");
+        builder.field("id").type(SchemaType.STRING);
+        builder.field("reading").type(SchemaType.INT32);
+        return Schema.generic(builder.build(type));
+    }
+
+    private static String seededTopic(final String name, final SchemaType type) throws Exception {
+        final String topic = "persistent://public/default/" + name + "-" + System.nanoTime();
+        final GenericSchema<GenericRecord> schema = sensorSchema(type);
+
+        try (Producer<GenericRecord> seeder = getClient().newProducer(schema).topic(topic).create()) {
+            seeder.send(schema.newRecordBuilder().set("id", "seed").set("reading", 0).build());
+        }
+
+        return topic;
+    }
+
+    /** Publishes with a plain schema-aware client, so the consumer is tested independently of our publisher. */
+    private static void publishWithPlainClient(final String topic, final SchemaType type) throws Exception {
+        final GenericSchema<GenericRecord> schema = sensorSchema(type);
+
+        try (Producer<GenericRecord> producer = getClient().newProducer(schema).topic(topic).create()) {
+            for (int seq = 1; seq <= RECORDS; seq++) {
+                producer.send(schema.newRecordBuilder().set("id", "sensor-" + seq).set("reading", seq * 10).build());
+            }
+        }
+    }
+
+    private static String[] jsonPayloads() {
+        final String[] payloads = new String[RECORDS];
+        for (int seq = 1; seq <= RECORDS; seq++) {
+            payloads[seq - 1] = "{\"id\":\"sensor-" + seq + "\",\"reading\":" + (seq * 10) + "}";
+        }
+        return payloads;
+    }
+
+    /** A consumer on the Topic Schema strategy, deliberately with no Record Reader configured. */
+    private TestRunner topicSchemaConsumer(final String topic, final String subscription) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(ConsumePulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, subscription);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "100");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+        return runner;
+    }
+
+    private static String successContent(final TestRunner runner) {
+        final StringBuilder content = new StringBuilder();
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+            content.append(new String(flowFile.toByteArray(), UTF_8));
+        }
+        return content.toString();
+    }
+
+    private static int consumeRecords(final TestRunner runner) throws Exception {
+        return consumeRecordsExpecting(runner, RECORDS + 1);
+    }
+
+    private static int consumeRecordsExpecting(final TestRunner runner, final int expected) throws Exception {
+        final int[] records = {0};
+        runner.run(1, false, true);
+        await(expected + " records to be consumed", () -> {
+            runner.run(1, false, false);
+            records[0] = 0;
+            for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+                records[0] += Integer.parseInt(flowFile.getAttribute("record.count"));
+            }
+            return records[0] >= expected;
+        });
+        runner.run(1, true, false);
+        return records[0];
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/NiFiSchemaRoundTripIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/NiFiSchemaRoundTripIT.java
@@ -57,8 +57,13 @@ import org.junit.Test;
  * {@code ConsumePulsarRecord} hands the raw message bytes to the configured reader rather than the
  * decoded value, so the reader has to match what the topic holds. Pointing the wrong one at a topic is a
  * realistic misconfiguration - the properties are set in different places by different people - and the
- * last two tests establish that it surfaces as {@code parse.failure}, message by message, rather than as
- * silent corruption or a stuck consumer.
+ * last two tests pin what happens then.
+ * <p>
+ * That behaviour is the processor's contract rather than an accident of the mismatch: every message is
+ * routed to either {@code success} or {@code parse.failure} precisely so that it can be acknowledged, and
+ * the {@code parse.failure} FlowFile is what carries the undecodable ones to their acknowledgement -
+ * which is what #169 and #170 depend on. Nothing partially parsed reaches {@code success}, and the raw
+ * payload stays recoverable from {@code parse.failure}.
  * <p>
  * Only AVRO and JSON are covered because only those two are encoded: {@code PublisherLease} returns no
  * topic schema for any other {@link SchemaType}, and records fall back to the configured Record Writer.

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaStrategyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaStrategyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The Record Reader is required under the default strategy and optional under 'Topic Schema' (#185).
+ * <p>
+ * Making the descriptor itself optional would have silently accepted a configuration that has always been
+ * invalid - a reader-driven consumer with no reader - so the requirement moved into validation instead.
+ */
+public class ConsumePulsarRecordSchemaStrategyTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addPulsarClientService();
+
+        final MockRecordWriter writer = new MockRecordWriter("id, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "test-topic");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "test-subscription");
+    }
+
+    /** The behaviour every existing flow has: no reader, no consumer. */
+    @Test
+    public void theRecordReaderIsRequiredUnderTheDefaultStrategy() {
+        runner.assertNotValid();
+    }
+
+    /** Nothing changes for a flow that configures a reader and leaves the strategy alone. */
+    @Test
+    public void theDefaultStrategyIsValidWithAReader() throws InitializationException {
+        addRecordReader();
+
+        runner.assertValid();
+    }
+
+    /** The point of the strategy: the topic's schema replaces the reader entirely. */
+    @Test
+    public void theRecordReaderIsOptionalUnderTheTopicSchemaStrategy() {
+        runner.setProperty(ConsumePulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+
+        runner.assertValid();
+    }
+
+    /** A reader may still be configured alongside it, as the fallback for schema-less topics. */
+    @Test
+    public void aReaderMayStillBeConfiguredUnderTheTopicSchemaStrategy() throws InitializationException {
+        runner.setProperty(ConsumePulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+        addRecordReader();
+
+        runner.assertValid();
+    }
+
+    private void addRecordReader() throws InitializationException {
+        final MockRecordParser reader = new MockRecordParser();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+        runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Test;
+
+/** Decoding a message with the schema its topic carries, independently of a broker. */
+public class TopicSchemaRecordDecoderTest {
+
+    private static final String SENSOR = "{\"type\":\"record\",\"name\":\"Sensor\",\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"reading\",\"type\":\"int\"}]}";
+
+    private final TopicSchemaRecordDecoder decoder = new TopicSchemaRecordDecoder();
+
+    /** AVRO topics carry bare binary, so the schema has to come from the SchemaInfo rather than the data. */
+    @Test
+    public void avroBytesDecodeToARecord() throws Exception {
+        final Record record = decoder.decode(avroBytes("sensor-1", 42), schemaInfo(SchemaType.AVRO));
+
+        assertEquals("sensor-1", record.getValue("id"));
+        assertEquals(42, record.getValue("reading"));
+    }
+
+    /** JSON topics carry plain text, and the schema still decides the field types. */
+    @Test
+    public void jsonBytesDecodeToARecord() throws Exception {
+        final Record record = decoder.decode("{\"id\":\"sensor-2\",\"reading\":43}".getBytes(UTF_8),
+                schemaInfo(SchemaType.JSON));
+
+        assertEquals("sensor-2", record.getValue("id"));
+        assertEquals(43, record.getValue("reading"));
+    }
+
+    /**
+     * JSON cannot distinguish an int from a long, so the value arrives as whatever Jackson inferred and has
+     * to be coerced to the schema's type. Without coercion a downstream writer expecting an int gets a
+     * Long, which is the kind of mismatch that only shows up once the data reaches a typed sink.
+     */
+    @Test
+    public void jsonValuesAreCoercedToTheSchemaTypes() throws Exception {
+        final Record record = decoder.decode("{\"id\":\"sensor-3\",\"reading\":44}".getBytes(UTF_8),
+                schemaInfo(SchemaType.JSON));
+
+        assertTrue("reading should be an Integer, not a " + record.getValue("reading").getClass().getSimpleName(),
+                record.getValue("reading") instanceof Integer);
+    }
+
+    /** The parsed schema is reused between messages, but a changed definition must not be served stale. */
+    @Test
+    public void aChangedSchemaDefinitionIsReparsed() throws Exception {
+        decoder.decode(avroBytes("sensor-1", 42), schemaInfo(SchemaType.AVRO));
+
+        final String evolved = "{\"type\":\"record\",\"name\":\"Sensor\",\"fields\":["
+                + "{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"reading\",\"type\":\"int\"},"
+                + "{\"name\":\"unit\",\"type\":[\"null\",\"string\"],\"default\":null}]}";
+
+        final Record record = decoder.decode("{\"id\":\"s\",\"reading\":1,\"unit\":\"C\"}".getBytes(UTF_8),
+                SchemaInfo.builder().name("Sensor").type(SchemaType.JSON).schema(evolved.getBytes(UTF_8)).build());
+
+        assertEquals("C", record.getValue("unit"));
+    }
+
+    /** Only the two struct types map to a record; everything else falls back to the Record Reader. */
+    @Test
+    public void supportsOnlyTheStructTypes() {
+        assertTrue(TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.AVRO)));
+        assertTrue(TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.JSON)));
+        assertFalse("a primitive schema has no record shape (#189)",
+                TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.STRING)));
+        assertFalse("KeyValue carries two schemas and needs its own handling (#190)",
+                TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.KEY_VALUE)));
+        assertFalse("a topic with no schema reports null, which is the #181 case",
+                TopicSchemaRecordDecoder.supports(null));
+    }
+
+    /** A payload that does not match the schema is an error the caller routes, not a half-built record. */
+    @Test
+    public void aPayloadThatDoesNotMatchTheSchemaFails() {
+        assertThrows(IOException.class,
+                () -> decoder.decode("not json at all".getBytes(UTF_8), schemaInfo(SchemaType.JSON)));
+    }
+
+    /** Nothing has been decoded yet, so there is no schema to report. */
+    @Test
+    public void theSchemaIsUnknownBeforeTheFirstMessage() {
+        assertNull(new TopicSchemaRecordDecoder().getLastRecordSchema());
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static SchemaInfo schemaInfo(final SchemaType type) {
+        return SchemaInfo.builder().name("Sensor").type(type).schema(SENSOR.getBytes(UTF_8)).build();
+    }
+
+    /** What an AVRO topic actually holds: bare binary, no file header and no embedded schema. */
+    private static byte[] avroBytes(final String id, final int reading) throws Exception {
+        final org.apache.avro.Schema schema = new org.apache.avro.Schema.Parser().parse(SENSOR);
+        final GenericData.Record record = new GenericData.Record(schema);
+        record.put("id", id);
+        record.put("reading", reading);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final org.apache.avro.io.BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        new GenericDatumWriter<org.apache.avro.generic.GenericRecord>(schema).write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
Closes #185.

## The problem

`ConsumePulsarRecord` subscribes with `Schema.AUTO_CONSUME()`, which decodes every message — and then throws the decoded value away, passing the **raw wire bytes** to the configured Record Reader. So the reader has to match the topic's encoding, and the two encodings are not interchangeable:

| Topic | On the wire | Reader that works |
|---|---|---|
| AVRO | bare Avro binary, no embedded schema | `AvroReader`, Schema Text `${avro.schema}` |
| JSON | JSON text | `JsonTreeReader` |

The AVRO configuration is not discoverable. The schema is never in the data — Pulsar keeps it in the registry — so `AvroReader`'s default "embedded avro schema" strategy cannot work, and the `avro.schema` attribute that makes it possible was only mentioned in a code comment. Pointing the wrong reader at a topic sends **every** message to `parse.failure`.

## The change

A **Message Schema Strategy** property, mirroring the one `PublishPulsarRecord` already has:

- **`Record Reader`** (default) — exactly today's behaviour. No existing flow changes.
- **`Topic Schema`** — records are built from the schema the topic carries. No Record Reader, no schema configuration of any kind, and AVRO and JSON behave identically.

The field definitions come from the **broker**, not the payload and not message properties: Pulsar keeps schemas in a registry keyed by topic and version, and `AUTO_CONSUME` attaches each message's schema as its reader schema. Because it arrives per message, **schema evolution needs no special handling** — a message published under an older version decodes with the version it was written with, and #179's record-set boundaries already close a set when the schema changes.

### Why it decodes the bytes itself

The obvious implementation — use the `GenericRecord` Pulsar already decoded — does not work. The client **shades Avro**, so `msg.getValue()` is backed by `org.apache.pulsar.shade.org.apache.avro...`, which NiFi's `AvroTypeUtil` cannot accept. Parsing the definition with unshaded Avro and decoding here is the exact mirror of `PublisherLease`'s encoding, and keeps both directions on the same conversion code.

### The Record Reader descriptor

It became optional, with the requirement moved into `customValidate`. Leaving it required would make the new strategy unusable; making it optional outright would silently accept a reader-driven consumer with no reader, which has always been invalid. It is still the fallback under `Topic Schema` for topics the strategy cannot decode.

## Failing first

With `TopicSchemaRecordDecoder.supports()` forced to `false`:

```
Tests run: 6, Failures: 4
```

As implemented:

```
Tests run: 6, Failures: 0
```

The two that pass either way are the fallback cases, which is the intended discrimination — they must not depend on the decoder.

Full suite: **281 unit tests and 44 integration tests green**, confirming the default reader path is unchanged.

## Tests

- `TopicSchemaRecordDecoderTest` — AVRO binary and JSON text decoding, JSON type coercion, re-parsing on a changed definition, and which schema types are supported.
- `ConsumePulsarRecordSchemaStrategyTest` — the reader stays required under the default strategy, optional under `Topic Schema`.
- `ConsumePulsarTopicSchemaIT` — against a real broker: AVRO and JSON consumed with no reader configured, plus the schema-less fallback and the no-reader `parse.failure` case.
- **e2e:** publish with `PublishPulsarRecord` on `Topic Schema` and read it back with `ConsumePulsarRecord` on `Topic Schema`, with no Record Reader anywhere in the flow, on both encodings.

## Not covered

- **Primitive schemas (#189)** and **KeyValue schemas (#190)** — both fall back to the Record Reader; filed separately.
- **Logical types** — timestamps, decimals, UUIDs are untested in either direction (also open under #34).
- **Schema evolution against a live broker** — exercised only through a changed definition in the decoder's unit test, not by evolving a topic's registered schema mid-stream.