### PR TITLE
feat: map primitive-schema topics to single-field records (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,15 @@ value per message and has no fields, so `Topic Schema` gives each message a reco
 named by **Primitive Value Field** (`value` by default). It becomes a column name downstream, so it is
 worth setting to something meaningful.
 
-**A configured *Record Reader* takes precedence on these topics.** A `STRING` topic carrying JSON text is
-a common shape, and those flows want the payload parsed into records rather than wrapped in one string
-field — so with a reader configured the payload is parsed, and the single-field record is what happens
-when there is no reader to parse with.
+**Primitive Schema Handling** decides what happens when a *Record Reader* is also configured.
+`Record Reader if configured` — the default — parses the payload with the reader, which is what a `STRING`
+topic carrying JSON or CSV text wants. `Single-field record` always wraps the value instead.
+
+The choice is a property rather than an inference from whether a reader is set, because the reader is
+*also* the fallback for topics with no schema: configuring one for that reason should not silently change
+how primitive topics are read. Under the default, a `STRING` topic carrying plain text with a
+`JsonTreeReader` configured sends every message to `parse.failure`, since the reader cannot parse it and
+the single-field record is not reachable — `Single-field record` is the setting for that flow.
 
 Publishing to a primitive topic requires a record with **exactly one field**, whose value is coerced to
 the topic's type. A record with several fields has no unambiguous mapping onto a single value, so it is

--- a/README.md
+++ b/README.md
@@ -141,8 +141,28 @@ with.
 
 A *Record Reader* may still be configured under `Topic Schema`, and messages the strategy cannot decode
 fall back to it — a topic with no schema at all, or one whose schema has no record shape. Without a
-reader to fall back to, those messages go to `parse.failure`. Primitive and `KeyValue` schemas are not
-yet decoded this way.
+reader to fall back to, those messages go to `parse.failure`. `KeyValue` schemas are not yet decoded this
+way.
+
+### Topics with a primitive schema
+
+A topic whose schema is a primitive — `STRING`, `BOOLEAN`, or one of the numeric types — carries one
+value per message and has no fields, so `Topic Schema` gives each message a record of a single field
+named by **Primitive Value Field** (`value` by default). It becomes a column name downstream, so it is
+worth setting to something meaningful.
+
+**A configured *Record Reader* takes precedence on these topics.** A `STRING` topic carrying JSON text is
+a common shape, and those flows want the payload parsed into records rather than wrapped in one string
+field — so with a reader configured the payload is parsed, and the single-field record is what happens
+when there is no reader to parse with.
+
+Publishing to a primitive topic requires a record with **exactly one field**, whose value is coerced to
+the topic's type. A record with several fields has no unambiguous mapping onto a single value, so it is
+routed to `failure` rather than guessing which field was meant.
+
+`BYTES` is not treated as a primitive schema. Pulsar reports a topic with *no* schema as `BYTES` with an
+empty definition, so the two are indistinguishable, and treating it as primitive would capture every
+schema-less topic. The date and time schemas are not supported yet either.
 
 ## Publishing to topics that have a schema
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -113,6 +113,30 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             .defaultValue(SCHEMA_FROM_RECORD_READER.getValue())
             .build();
 
+    static final AllowableValue PRIMITIVE_VIA_READER = new AllowableValue("Record Reader if configured",
+            "Record Reader if configured",
+            "Parse the payload with the Record Reader when one is configured, and wrap it in a single field "
+            + "only when there is none. Suits a STRING topic carrying JSON or CSV text.");
+
+    static final AllowableValue PRIMITIVE_AS_RECORD = new AllowableValue("Single-field record",
+            "Single-field record",
+            "Always wrap the value in a single field, whether a Record Reader is configured or not. Suits a "
+            + "topic whose values are genuinely scalar, and leaves the reader free to serve as the fallback "
+            + "for topics that have no schema.");
+
+    public static final PropertyDescriptor PRIMITIVE_SCHEMA_HANDLING = new PropertyDescriptor.Builder()
+            .name("PRIMITIVE_SCHEMA_HANDLING")
+            .displayName("Primitive Schema Handling")
+            .description("What to do with a topic whose schema is a primitive. Only used by the 'Topic "
+                    + "Schema' strategy. The default defers to the Record Reader when one is configured, "
+                    + "which is what a STRING topic carrying JSON text wants; choose 'Single-field record' "
+                    + "when the values really are scalar, so that configuring a reader as the schema-less "
+                    + "fallback does not change how primitive topics are read.")
+            .required(false)
+            .allowableValues(PRIMITIVE_VIA_READER, PRIMITIVE_AS_RECORD)
+            .defaultValue(PRIMITIVE_VIA_READER.getValue())
+            .build();
+
     public static final PropertyDescriptor PRIMITIVE_VALUE_FIELD = new PropertyDescriptor.Builder()
             .name("PRIMITIVE_VALUE_FIELD")
             .displayName("Primitive Value Field")
@@ -195,6 +219,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     static {
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(MESSAGE_SCHEMA_STRATEGY);
+        properties.add(PRIMITIVE_SCHEMA_HANDLING);
         properties.add(PRIMITIVE_VALUE_FIELD);
         properties.add(RECORD_READER);
         properties.add(RECORD_WRITER);
@@ -347,6 +372,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         // cheap, and shares nothing.
         final TopicSchemaRecordDecoder topicSchemaDecoder = new TopicSchemaRecordDecoder();
         final String primitiveField = context.getProperty(PRIMITIVE_VALUE_FIELD).evaluateAttributeExpressions().getValue();
+        final boolean deferPrimitivesToReader =
+                PRIMITIVE_VIA_READER.getValue().equals(context.getProperty(PRIMITIVE_SCHEMA_HANDLING).getValue());
 
         try {
             for (Message<GenericRecord> msg : groupedMessages) {
@@ -372,11 +399,13 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 RecordSchema currentSchema = null;
                 Record topicSchemaRecord = null;
 
-                // A configured Record Reader wins on a primitive topic. A STRING topic carrying JSON text
-                // is a common production shape, and those flows want the payload parsed into records rather
-                // than wrapped in a single string field; with no reader there is nothing to parse with, so
-                // the single-field record is the useful answer instead of a parse failure.
-                final boolean readerWins = readerFactory != null && TopicSchemaRecordDecoder.isPrimitive(readerSchemaInfo);
+                // What a primitive topic does is chosen by Primitive Schema Handling rather than inferred
+                // from whether a reader happens to be set. A STRING topic carrying JSON text wants the
+                // reader; a genuinely scalar topic wants the single field - and because the reader is also
+                // the fallback for schema-less topics, configuring one for that reason must not silently
+                // decide this too. Deferring to the reader is the default, so nothing changes by upgrading.
+                final boolean readerWins = readerFactory != null && deferPrimitivesToReader
+                        && TopicSchemaRecordDecoder.isPrimitive(readerSchemaInfo);
 
                 if (useTopicSchema && !readerWins && TopicSchemaRecordDecoder.supports(readerSchemaInfo)) {
                     // The topic's schema decides the record's shape, so no reader is consulted at all. One

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -167,7 +167,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
      */
     @Override
     protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
-        final Collection<ValidationResult> results = new ArrayList<>();
+        // Seeded with the superclass results, not an empty list: AbstractPulsarConsumerProcessor enforces
+        // that exactly one of Topics / Topics Pattern is set and that Acknowledgment Timeout is at least
+        // 10 seconds, and starting empty silently dropped both for this processor (#194).
+        final Collection<ValidationResult> results = new ArrayList<>(super.customValidate(validationContext));
 
         if (!usesTopicSchema(validationContext.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue())
                 && !validationContext.getProperty(RECORD_READER).isSet()) {
@@ -181,9 +184,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
         return results;
     }
-
-    /** Holds the parsed schema between messages, so a batch on one schema parses the definition once. */
-    private final TopicSchemaRecordDecoder topicSchemaDecoder = new TopicSchemaRecordDecoder();
 
     static boolean usesTopicSchema(final String strategy) {
         return SCHEMA_FROM_TOPIC.getValue().equals(strategy);
@@ -339,6 +339,13 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         final boolean shared = isSharedSubscription(context);
 
         final boolean useTopicSchema = usesTopicSchema(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
+
+        // Created per batch rather than held on the processor. Concurrent Tasks > 1 gave every task the
+        // same decoder, and its schema cache was read and replaced without synchronization, so two tasks
+        // decoding different schemas returned each other's records - silently, with no exception, straight
+        // to success (#195). One decoder per batch parses each definition once per trigger, which is
+        // cheap, and shares nothing.
+        final TopicSchemaRecordDecoder topicSchemaDecoder = new TopicSchemaRecordDecoder();
         final String primitiveField = context.getProperty(PRIMITIVE_VALUE_FIELD).evaluateAttributeExpressions().getValue();
 
         try {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -113,6 +113,20 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             .defaultValue(SCHEMA_FROM_RECORD_READER.getValue())
             .build();
 
+    public static final PropertyDescriptor PRIMITIVE_VALUE_FIELD = new PropertyDescriptor.Builder()
+            .name("PRIMITIVE_VALUE_FIELD")
+            .displayName("Primitive Value Field")
+            .description("The field name to give the value of a topic whose schema is a primitive - a "
+                    + "STRING or INT32 topic, for instance - which carries one value per message and has no "
+                    + "fields of its own. Only used by the 'Topic Schema' strategy, and only when no Record "
+                    + "Reader is configured: a reader takes precedence, so JSON text on a STRING topic can "
+                    + "still be parsed into records rather than wrapped in a single field.")
+            .required(false)
+            .defaultValue(TopicSchemaRecordDecoder.DEFAULT_PRIMITIVE_FIELD)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
     public static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
             .name("Record Reader")
             .displayName("Record Reader")
@@ -181,6 +195,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
     static {
         final List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(MESSAGE_SCHEMA_STRATEGY);
+        properties.add(PRIMITIVE_VALUE_FIELD);
         properties.add(RECORD_READER);
         properties.add(RECORD_WRITER);
         properties.add(MAX_WAIT_TIME);
@@ -324,6 +339,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         final boolean shared = isSharedSubscription(context);
 
         final boolean useTopicSchema = usesTopicSchema(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
+        final String primitiveField = context.getProperty(PRIMITIVE_VALUE_FIELD).evaluateAttributeExpressions().getValue();
 
         try {
             for (Message<GenericRecord> msg : groupedMessages) {
@@ -349,12 +365,18 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                 RecordSchema currentSchema = null;
                 Record topicSchemaRecord = null;
 
-                if (useTopicSchema && TopicSchemaRecordDecoder.supports(readerSchemaInfo)) {
+                // A configured Record Reader wins on a primitive topic. A STRING topic carrying JSON text
+                // is a common production shape, and those flows want the payload parsed into records rather
+                // than wrapped in a single string field; with no reader there is nothing to parse with, so
+                // the single-field record is the useful answer instead of a parse failure.
+                final boolean readerWins = readerFactory != null && TopicSchemaRecordDecoder.isPrimitive(readerSchemaInfo);
+
+                if (useTopicSchema && !readerWins && TopicSchemaRecordDecoder.supports(readerSchemaInfo)) {
                     // The topic's schema decides the record's shape, so no reader is consulted at all. One
                     // message is one record here: a schema-bearing topic carries a single encoded value per
                     // message, unlike a reader, which may find several records in one payload.
                     try {
-                        topicSchemaRecord = topicSchemaDecoder.decode(data, readerSchemaInfo);
+                        topicSchemaRecord = topicSchemaDecoder.decode(data, readerSchemaInfo, primitiveField);
                         currentSchema = topicSchemaRecord.getSchema();
                     } catch (final IOException | RuntimeException e) {
                         getLogger().debug("Unable to decode a message with the topic's schema", e);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchema.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchema.java
@@ -75,6 +75,23 @@ public final class PrimitiveTopicSchema {
     private PrimitiveTopicSchema() {
     }
 
+    /**
+     * A scalar rendered as text. Structured values are refused rather than coerced: {@code toString()} on a
+     * record or a collection produces a Java debug string, and publishing that to a STRING topic would look
+     * like it worked while putting something like {@code MapRecord[{id=1}]} on the topic.
+     */
+    private static String asString(final Object value, final String fieldName) throws IOException {
+        if (value instanceof org.apache.nifi.serialization.record.Record
+                || value instanceof java.util.Map || value instanceof Object[]
+                || value instanceof Iterable) {
+            throw new IOException("Field '" + fieldName + "' is a " + value.getClass().getSimpleName()
+                    + ", which has no meaningful text form for a STRING topic; publish a scalar field or "
+                    + "use a topic whose schema is a record");
+        }
+
+        return DataTypeUtils.toString(value, (String) null);
+    }
+
     /** Whether a topic of this schema type can be mapped to a single-field record. */
     public static boolean supports(final SchemaType type) {
         return type != null && TYPES.containsKey(type);
@@ -132,7 +149,7 @@ public final class PrimitiveTopicSchema {
 
         try {
             switch (type) {
-                case STRING:  return Schema.STRING.encode(DataTypeUtils.toString(value, (String) null));
+                case STRING:  return Schema.STRING.encode(asString(value, fieldName));
                 case BOOLEAN: return Schema.BOOL.encode(DataTypeUtils.toBoolean(value, fieldName));
                 case INT8:    return Schema.INT8.encode(DataTypeUtils.toByte(value, fieldName));
                 case INT16:   return Schema.INT16.encode(DataTypeUtils.toShort(value, fieldName));

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchema.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchema.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.util.DataTypeUtils;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/**
+ * Topics whose registered schema is a single primitive value rather than a record (#189).
+ * <p>
+ * A primitive topic carries one value per message and has no fields, so there is no record shape to
+ * derive - it has to be chosen. Each message becomes a record of exactly one field, named by the
+ * processor's <em>Primitive Value Field</em> property, because NiFi's record model has no notion of a
+ * bare scalar and every downstream writer needs a column name.
+ * <p>
+ * The wire formats are Pulsar's own: {@code Schema.STRING}, {@code Schema.INT32} and the rest already
+ * encode and decode exactly what the broker validates against, so they are used directly rather than
+ * reimplemented. That also means this stays correct if a format ever changes underneath us.
+ * <p>
+ * The date and time schemas ({@code DATE}, {@code TIME}, {@code TIMESTAMP}, {@code INSTANT},
+ * {@code LOCAL_DATE}, {@code LOCAL_TIME}, {@code LOCAL_DATE_TIME}) are deliberately absent. They carry
+ * conversion questions that the numeric types do not - which is the same reason logical types are still
+ * uncovered for AVRO - and are better added with tests of their own.
+ * <p>
+ * {@code BYTES} is absent for a different and more important reason: it is not distinguishable from a
+ * topic that has no schema at all. A producer created with {@code Schema.BYTES} registers nothing on the
+ * topic, and {@code AUTO_PRODUCE_BYTES} reports a schema-less topic as {@code BYTES} with an empty
+ * definition:
+ * <pre>
+ *     info={"name": "Bytes", "schema": "", "type": "BYTES"} type=BYTES
+ * </pre>
+ * Treating that as a primitive topic would capture every schema-less topic - which is what this bundle's
+ * own publishers produce - and break the fallback to the Record Writer. A genuinely registered BYTES
+ * schema is indistinguishable from none, so there is nothing to gain and a common path to lose.
+ */
+public final class PrimitiveTopicSchema {
+
+    private static final Map<SchemaType, DataType> TYPES;
+
+    static {
+        final Map<SchemaType, DataType> types = new EnumMap<>(SchemaType.class);
+        types.put(SchemaType.STRING, RecordFieldType.STRING.getDataType());
+        types.put(SchemaType.BOOLEAN, RecordFieldType.BOOLEAN.getDataType());
+        types.put(SchemaType.INT8, RecordFieldType.BYTE.getDataType());
+        types.put(SchemaType.INT16, RecordFieldType.SHORT.getDataType());
+        types.put(SchemaType.INT32, RecordFieldType.INT.getDataType());
+        types.put(SchemaType.INT64, RecordFieldType.LONG.getDataType());
+        types.put(SchemaType.FLOAT, RecordFieldType.FLOAT.getDataType());
+        types.put(SchemaType.DOUBLE, RecordFieldType.DOUBLE.getDataType());
+        TYPES = Collections.unmodifiableMap(types);
+    }
+
+    private PrimitiveTopicSchema() {
+    }
+
+    /** Whether a topic of this schema type can be mapped to a single-field record. */
+    public static boolean supports(final SchemaType type) {
+        return type != null && TYPES.containsKey(type);
+    }
+
+    /** The NiFi type the single field takes, so writers downstream see the topic's actual type. */
+    public static DataType dataTypeOf(final SchemaType type) {
+        return TYPES.get(type);
+    }
+
+    /**
+     * Decodes one message into the value of the single field.
+     *
+     * @param type the topic's schema type, which must {@link #supports}
+     * @param data the raw message payload
+     * @return the decoded value
+     * @throws IOException if the payload is not valid for the schema
+     */
+    public static Object decode(final SchemaType type, final byte[] data) throws IOException {
+        try {
+            switch (type) {
+                case STRING:  return Schema.STRING.decode(data);
+                case BOOLEAN: return Schema.BOOL.decode(data);
+                case INT8:    return Schema.INT8.decode(data);
+                case INT16:   return Schema.INT16.decode(data);
+                case INT32:   return Schema.INT32.decode(data);
+                case INT64:   return Schema.INT64.decode(data);
+                case FLOAT:   return Schema.FLOAT.decode(data);
+                case DOUBLE:  return Schema.DOUBLE.decode(data);
+                default:      throw new IOException("Unsupported primitive schema type " + type);
+            }
+        } catch (final RuntimeException e) {
+            // A payload of the wrong width throws from the client's own decoder; the caller routes it to
+            // parse.failure rather than letting a malformed value reach a record set.
+            throw new IOException("The message is not a valid " + type + " value", e);
+        }
+    }
+
+    /**
+     * Encodes a field value with the topic's primitive schema. The value is coerced to the schema's type
+     * first, so a record whose field is a String on a topic of INT32 publishes the number rather than
+     * failing at the broker with a validation error that says nothing about which record was at fault.
+     *
+     * @param type the topic's schema type, which must {@link #supports}
+     * @param value the value of the record's single field, which may be null
+     * @param fieldName the field's name, for the error message when coercion fails
+     * @return the encoded payload
+     * @throws IOException if the value cannot be represented in the topic's schema
+     */
+    public static byte[] encode(final SchemaType type, final Object value, final String fieldName)
+            throws IOException {
+        if (value == null) {
+            throw new IOException("Field '" + fieldName + "' is null, which a " + type + " topic cannot carry");
+        }
+
+        try {
+            switch (type) {
+                case STRING:  return Schema.STRING.encode(DataTypeUtils.toString(value, (String) null));
+                case BOOLEAN: return Schema.BOOL.encode(DataTypeUtils.toBoolean(value, fieldName));
+                case INT8:    return Schema.INT8.encode(DataTypeUtils.toByte(value, fieldName));
+                case INT16:   return Schema.INT16.encode(DataTypeUtils.toShort(value, fieldName));
+                case INT32:   return Schema.INT32.encode(DataTypeUtils.toInteger(value, fieldName));
+                case INT64:   return Schema.INT64.encode(DataTypeUtils.toLong(value, fieldName));
+                case FLOAT:   return Schema.FLOAT.encode(DataTypeUtils.toFloat(value, fieldName));
+                case DOUBLE:  return Schema.DOUBLE.encode(DataTypeUtils.toDouble(value, fieldName));
+                default:      throw new IOException("Unsupported primitive schema type " + type);
+            }
+        } catch (final RuntimeException e) {
+            // IllegalTypeConversionException for a type that cannot convert, NumberFormatException for a
+            // String that is not a number. Both have to become an IOException here: an unchecked exception
+            // escaping the publish loop would bypass the failure routing and fail the whole trigger.
+            throw new IOException("Field '" + fieldName + "' cannot be published to a " + type + " topic", e);
+        }
+    }
+
+}

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -87,6 +87,25 @@ public class PublisherLease implements Closeable {
      * Producers are created with {@code Schema.AUTO_PRODUCE_BYTES()}, which binds to the topic when the
      * producer is created and then reports the topic's registered SchemaInfo.
      */
+    /**
+     * The topic's schema type, or null when it has none. Kept separate from {@link #getTopicSchema()},
+     * which only answers for the two struct types that map to an Avro document; a primitive topic (#189)
+     * has a type but no record shape.
+     */
+    SchemaType getTopicSchemaType() {
+        if (topicSchema == null) {
+            return null;
+        }
+
+        try {
+            final SchemaInfo info = topicSchema.getSchemaInfo();
+            return info == null ? null : info.getType();
+        } catch (final RuntimeException e) {
+            // getSchemaInfo() throws when the schema was never bound to a topic
+            return null;
+        }
+    }
+
     TopicSchema getTopicSchema() {
         if (topicSchema == null) {
             return null;
@@ -208,6 +227,11 @@ public class PublisherLease implements Closeable {
             logger.debug("The topic carries no Avro or JSON schema; encoding with the configured record writer instead");
         }
 
+        // A primitive topic takes the record's single field as its whole payload, so it is neither an Avro
+        // encode nor a Record Writer serialization.
+        final SchemaType primitiveType = useTopicSchema && resolvedSchema == null
+                && PrimitiveTopicSchema.supports(getTopicSchemaType()) ? getTopicSchemaType() : null;
+
         final org.apache.avro.Schema avroSchema = resolvedSchema == null ? null : resolvedSchema.getDefinition();
         final boolean encodeAsJson = resolvedSchema != null && resolvedSchema.isJson();
 
@@ -232,7 +256,9 @@ public class PublisherLease implements Closeable {
                 final byte[] messageContent;
                 final String messageKey;
 
-                if (avroSchema != null) {
+                if (primitiveType != null) {
+                    messageContent = encodeWithPrimitiveTopicSchema(record, primitiveType);
+                } else if (avroSchema != null) {
                     if (encodeAsJson) {
                         encodeWithTopicJsonSchema(record, avroSchema, jsonFactory, baos);
                     } else {
@@ -307,6 +333,26 @@ public class PublisherLease implements Closeable {
      * @return the encoded message content
      * @throws IOException if the record cannot be converted or encoded
      */
+    /**
+     * Encodes a record for a topic whose schema is a single primitive value. The record must have exactly
+     * one field: a primitive topic carries one value per message, so a record with several fields has no
+     * unambiguous mapping onto it, and guessing which field was meant would publish the wrong data
+     * silently. Failing here routes the FlowFile to failure with a message naming the fields instead.
+     */
+    private byte[] encodeWithPrimitiveTopicSchema(final Record record, final SchemaType primitiveType)
+            throws IOException {
+        final List<String> fields = record.getSchema().getFieldNames();
+
+        if (fields.size() != 1) {
+            throw new IOException("A " + primitiveType + " topic carries a single value per message, but the "
+                    + "record has " + fields.size() + " fields " + fields + "; publish a single-field record "
+                    + "or use a topic whose schema is a record");
+        }
+
+        final String fieldName = fields.get(0);
+        return PrimitiveTopicSchema.encode(primitiveType, record.getValue(fieldName), fieldName);
+    }
+
     private void encodeWithTopicSchema(final Record record, final org.apache.avro.Schema avroSchema,
                                        final GenericDatumWriter<org.apache.avro.generic.GenericRecord> datumWriter,
                                        final BinaryEncoder encoder) throws IOException {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
@@ -23,7 +23,12 @@ import java.util.Map;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.nifi.avro.AvroTypeUtil;
+import java.util.Collections;
+import java.util.HashMap;
+
 import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -57,6 +62,10 @@ public class TopicSchemaRecordDecoder {
     private SchemaType cachedType;
     private org.apache.avro.Schema cachedAvroSchema;
     private RecordSchema cachedRecordSchema;
+    private String cachedPrimitiveField;
+
+    /** Used when a caller does not name the field, and the default of the processor property. */
+    public static final String DEFAULT_PRIMITIVE_FIELD = "value";
 
     /**
      * Whether records can be built from this schema. Only the two struct types Pulsar registers as an Avro
@@ -65,7 +74,17 @@ public class TopicSchemaRecordDecoder {
      */
     public static boolean supports(final SchemaInfo schemaInfo) {
         return schemaInfo != null
-                && (schemaInfo.getType() == SchemaType.AVRO || schemaInfo.getType() == SchemaType.JSON);
+                && (schemaInfo.getType() == SchemaType.AVRO || schemaInfo.getType() == SchemaType.JSON
+                        || PrimitiveTopicSchema.supports(schemaInfo.getType()));
+    }
+
+    /**
+     * Whether this topic's schema is a single primitive value rather than a record (#189). Callers treat
+     * these differently: a primitive payload is often something a Record Reader should parse - JSON text on
+     * a STRING topic is a common shape - so a configured reader takes precedence over wrapping the value.
+     */
+    public static boolean isPrimitive(final SchemaInfo schemaInfo) {
+        return schemaInfo != null && PrimitiveTopicSchema.supports(schemaInfo.getType());
     }
 
     /**
@@ -77,6 +96,24 @@ public class TopicSchemaRecordDecoder {
      * @throws IOException if the payload does not match the schema
      */
     public Record decode(final byte[] data, final SchemaInfo schemaInfo) throws IOException {
+        return decode(data, schemaInfo, DEFAULT_PRIMITIVE_FIELD);
+    }
+
+    /**
+     * Decodes one message into a record shaped by the topic's schema.
+     *
+     * @param data the raw message payload
+     * @param schemaInfo the schema the message was published under, which must {@link #supports} it
+     * @param primitiveField the field name to give the value of a primitive topic
+     * @return the decoded record
+     * @throws IOException if the payload does not match the schema
+     */
+    public Record decode(final byte[] data, final SchemaInfo schemaInfo, final String primitiveField)
+            throws IOException {
+        if (PrimitiveTopicSchema.supports(schemaInfo.getType())) {
+            return decodePrimitive(data, schemaInfo.getType(), primitiveField);
+        }
+
         final String definition = new String(schemaInfo.getSchema(), StandardCharsets.UTF_8);
 
         if (cachedRecordSchema == null || !definition.equals(cachedDefinition) || cachedType != schemaInfo.getType()) {
@@ -108,6 +145,27 @@ public class TopicSchemaRecordDecoder {
     @SuppressWarnings("unchecked")
     private Record decodeJson(final byte[] data) throws IOException {
         final Map<String, Object> values = JSON.readValue(data, Map.class);
+
+        return new MapRecord(cachedRecordSchema, values, false, true);
+    }
+
+    /**
+     * A primitive topic has one value per message and no fields, so the record shape is chosen rather than
+     * derived: a single field, named by the caller, typed as the topic's schema.
+     */
+    private Record decodePrimitive(final byte[] data, final SchemaType type, final String fieldName)
+            throws IOException {
+        if (cachedRecordSchema == null || cachedType != type || !fieldName.equals(cachedPrimitiveField)) {
+            cachedRecordSchema = new SimpleRecordSchema(Collections.singletonList(
+                    new RecordField(fieldName, PrimitiveTopicSchema.dataTypeOf(type))));
+            cachedAvroSchema = null;
+            cachedDefinition = null;
+            cachedType = type;
+            cachedPrimitiveField = fieldName;
+        }
+
+        final Map<String, Object> values = new HashMap<>(1);
+        values.put(fieldName, PrimitiveTopicSchema.decode(type, data));
 
         return new MapRecord(cachedRecordSchema, values, false, true);
     }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
@@ -24,7 +24,6 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.nifi.avro.AvroTypeUtil;
 import java.util.Collections;
-import java.util.HashMap;
 
 import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.RecordField;
@@ -57,12 +56,39 @@ public class TopicSchemaRecordDecoder {
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    /** Parsed once and re-parsed only when the definition itself changes, as leases do on the publish side. */
-    private String cachedDefinition;
-    private SchemaType cachedType;
-    private org.apache.avro.Schema cachedAvroSchema;
-    private RecordSchema cachedRecordSchema;
-    private String cachedPrimitiveField;
+    /**
+     * The parsed schema, as one immutable snapshot behind a single volatile reference.
+     * <p>
+     * These were five separate mutable fields, read and replaced one at a time. Sharing one decoder across
+     * concurrent tasks then tore the cache: a thread could read another thread's Avro schema together with
+     * its own RecordSchema and return a record of the wrong shape with no exception raised (#195). Swapping
+     * one immutable object means a reader either sees the whole previous parse or the whole next one.
+     */
+    private volatile Parsed parsed;
+
+    /** One parse of one schema definition; every field is set together or not at all. */
+    private static final class Parsed {
+
+        private final String definition;
+        private final SchemaType type;
+        private final String primitiveField;
+        private final org.apache.avro.Schema avroSchema;
+        private final RecordSchema recordSchema;
+
+        private Parsed(final String definition, final SchemaType type, final String primitiveField,
+                final org.apache.avro.Schema avroSchema, final RecordSchema recordSchema) {
+            this.definition = definition;
+            this.type = type;
+            this.primitiveField = primitiveField;
+            this.avroSchema = avroSchema;
+            this.recordSchema = recordSchema;
+        }
+
+        private boolean matches(final String definition, final SchemaType type, final String primitiveField) {
+            return this.type == type && java.util.Objects.equals(this.definition, definition)
+                    && java.util.Objects.equals(this.primitiveField, primitiveField);
+        }
+    }
 
     /** Used when a caller does not name the field, and the default of the processor property. */
     public static final String DEFAULT_PRIMITIVE_FIELD = "value";
@@ -116,25 +142,28 @@ public class TopicSchemaRecordDecoder {
 
         final String definition = new String(schemaInfo.getSchema(), StandardCharsets.UTF_8);
 
-        if (cachedRecordSchema == null || !definition.equals(cachedDefinition) || cachedType != schemaInfo.getType()) {
-            cachedAvroSchema = new org.apache.avro.Schema.Parser().parse(definition);
-            cachedRecordSchema = AvroTypeUtil.createSchema(cachedAvroSchema);
-            cachedDefinition = definition;
-            cachedType = schemaInfo.getType();
+        Parsed current = parsed;
+
+        if (current == null || !current.matches(definition, schemaInfo.getType(), null)) {
+            final org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(definition);
+            current = new Parsed(definition, schemaInfo.getType(), null, avroSchema,
+                    AvroTypeUtil.createSchema(avroSchema));
+            parsed = current;
         }
 
-        return schemaInfo.getType() == SchemaType.AVRO ? decodeAvro(data) : decodeJson(data);
+        return schemaInfo.getType() == SchemaType.AVRO ? decodeAvro(data, current) : decodeJson(data, current);
     }
 
     /** AVRO topics carry bare Avro binary - no file header, no embedded schema - so the schema comes from us. */
-    private Record decodeAvro(final byte[] data) throws IOException {
+    private Record decodeAvro(final byte[] data, final Parsed current) throws IOException {
         final GenericDatumReader<org.apache.avro.generic.GenericRecord> datumReader =
-                new GenericDatumReader<>(cachedAvroSchema);
+                new GenericDatumReader<>(current.avroSchema);
 
         final org.apache.avro.generic.GenericRecord avroRecord =
                 datumReader.read(null, DecoderFactory.get().binaryDecoder(data, null));
 
-        return new MapRecord(cachedRecordSchema, AvroTypeUtil.convertAvroRecordToMap(avroRecord, cachedRecordSchema));
+        return new MapRecord(current.recordSchema,
+                AvroTypeUtil.convertAvroRecordToMap(avroRecord, current.recordSchema));
     }
 
     /**
@@ -143,10 +172,10 @@ public class TopicSchemaRecordDecoder {
      * has no way to distinguish an int from a long, or a string from a UUID.
      */
     @SuppressWarnings("unchecked")
-    private Record decodeJson(final byte[] data) throws IOException {
+    private Record decodeJson(final byte[] data, final Parsed current) throws IOException {
         final Map<String, Object> values = JSON.readValue(data, Map.class);
 
-        return new MapRecord(cachedRecordSchema, values, false, true);
+        return new MapRecord(current.recordSchema, values, false, true);
     }
 
     /**
@@ -155,23 +184,21 @@ public class TopicSchemaRecordDecoder {
      */
     private Record decodePrimitive(final byte[] data, final SchemaType type, final String fieldName)
             throws IOException {
-        if (cachedRecordSchema == null || cachedType != type || !fieldName.equals(cachedPrimitiveField)) {
-            cachedRecordSchema = new SimpleRecordSchema(Collections.singletonList(
-                    new RecordField(fieldName, PrimitiveTopicSchema.dataTypeOf(type))));
-            cachedAvroSchema = null;
-            cachedDefinition = null;
-            cachedType = type;
-            cachedPrimitiveField = fieldName;
+        Parsed current = parsed;
+
+        if (current == null || !current.matches(null, type, fieldName)) {
+            current = new Parsed(null, type, fieldName, null, new SimpleRecordSchema(Collections.singletonList(
+                    new RecordField(fieldName, PrimitiveTopicSchema.dataTypeOf(type)))));
+            parsed = current;
         }
 
-        final Map<String, Object> values = new HashMap<>(1);
-        values.put(fieldName, PrimitiveTopicSchema.decode(type, data));
-
-        return new MapRecord(cachedRecordSchema, values, false, true);
+        return new MapRecord(current.recordSchema,
+                Collections.singletonMap(fieldName, PrimitiveTopicSchema.decode(type, data)), false, true);
     }
 
     /** The schema the last decoded message was shaped by, for callers that group records into sets. */
     public RecordSchema getLastRecordSchema() {
-        return cachedRecordSchema;
+        final Parsed current = parsed;
+        return current == null ? null : current.recordSchema;
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PrimitiveSchemaRoundTripIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PrimitiveSchemaRoundTripIT.java
@@ -140,6 +140,47 @@ public class PrimitiveSchemaRoundTripIT extends AbstractPulsarIT {
         consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
     }
 
+    /**
+     * The blind spot the review found, and the reason the behaviour is a property rather than an inference.
+     * <p>
+     * With a reader configured - which the README also advises, since the reader is the fallback for
+     * schema-less topics - a STRING topic carrying plain text could only fail: the reader cannot parse
+     * "hello world", and the single-field record was unreachable. Choosing 'Single-field record' decouples
+     * the two decisions.
+     */
+    @Test
+    public void plainTextIsWrappedWhenTheStrategySaysSoEvenWithAReaderConfigured() throws Exception {
+        final String topic = "persistent://public/default/string-plain-" + System.nanoTime();
+
+        try (Producer<String> producer = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            producer.send("hello world");
+            producer.send("second line");
+        }
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "string-plain", new JsonTreeReader());
+        consumer.setProperty(ConsumePulsarRecord.PRIMITIVE_SCHEMA_HANDLING, "Single-field record");
+
+        assertEquals(2, consumeRecords(consumer, 2));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue("the text should be wrapped in the value field", successContent(consumer).contains("hello world"));
+    }
+
+    /** The default is unchanged: with a reader configured, the reader still gets first refusal. */
+    @Test
+    public void theDefaultStillDefersToAConfiguredReader() throws Exception {
+        final String topic = "persistent://public/default/string-default-" + System.nanoTime();
+
+        try (Producer<String> producer = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            for (int seq = 1; seq <= RECORDS; seq++) {
+                producer.send("{\"id\":\"sensor-" + seq + "\",\"reading\":" + seq + "}");
+            }
+        }
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "string-default", new JsonTreeReader());
+        assertEquals(RECORDS, consumeRecords(consumer, RECORDS));
+        assertTrue("the reader should still have parsed the JSON", successContent(consumer).contains("\"reading\""));
+    }
+
     // ---------------------------------------------------------------- publish-side guard
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PrimitiveSchemaRoundTripIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PrimitiveSchemaRoundTripIT.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.junit.Test;
+
+/**
+ * Topics whose schema is a single primitive value (#189), end to end through NiFi.
+ * <p>
+ * A primitive topic has one value per message and no fields, so the record shape is chosen rather than
+ * derived: one field, named by <em>Primitive Value Field</em>. The interesting case is not the mapping
+ * itself but the precedence rule around it - a STRING topic carrying JSON text is a common production
+ * shape, and those flows want the payload parsed into records, not wrapped in a single string field. So a
+ * configured Record Reader wins on a primitive topic, and the single-field record is what happens when
+ * there is no reader to parse with.
+ */
+public class PrimitiveSchemaRoundTripIT extends AbstractPulsarIT {
+
+    private static final int RECORDS = 5;
+
+    // ---------------------------------------------------------------- e2e round trips
+
+    /** NiFi in, NiFi out, over a STRING topic: publish single-field records and read them back. */
+    @Test
+    public void aStringTopicRoundTripsThroughNiFi() throws Exception {
+        final String topic = seededStringTopic("string-e2e");
+
+        publishWithNiFi(topic, "{\"value\":\"sensor-%d\"}");
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "string-e2e", null);
+        assertEquals(RECORDS + 1, consumeRecords(consumer, RECORDS + 1));
+        assertTrue("the published values should come back in the named field",
+                successContent(consumer).contains("sensor-1"));
+    }
+
+    /** The same over an INT32 topic, where the value is 4 bytes rather than text. */
+    @Test
+    public void anInt32TopicRoundTripsThroughNiFi() throws Exception {
+        final String topic = "persistent://public/default/int-e2e-" + System.nanoTime();
+
+        try (Producer<Integer> seeder = getClient().newProducer(Schema.INT32).topic(topic).create()) {
+            seeder.send(0);
+        }
+
+        publishWithNiFi(topic, "{\"value\":%d}");
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "int-e2e", null);
+        assertEquals(RECORDS + 1, consumeRecords(consumer, RECORDS + 1));
+        assertTrue("the numbers should survive as numbers", successContent(consumer).contains("\"value\":1"));
+    }
+
+    /** The field name is the user's, because it becomes a column name downstream. */
+    @Test
+    public void theValueFieldIsNamedByTheProperty() throws Exception {
+        final String topic = seededStringTopic("named-field");
+        publishWithNiFi(topic, "{\"value\":\"sensor-%d\"}");
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "named-field", null);
+        consumer.setProperty(ConsumePulsarRecord.PRIMITIVE_VALUE_FIELD, "payload");
+        consumeRecords(consumer, RECORDS + 1);
+
+        final String content = successContent(consumer);
+        assertTrue("the field should be named as configured, but got " + content, content.contains("\"payload\""));
+    }
+
+    // ---------------------------------------------------------------- precedence
+
+    /**
+     * The case from the review feedback on #184: a STRING topic whose messages are JSON text. With a
+     * reader configured the payload is parsed into real records rather than wrapped, so the fields inside
+     * the JSON are addressable downstream.
+     */
+    @Test
+    public void aConfiguredReaderParsesTheStringPayloadInsteadOfWrappingIt() throws Exception {
+        final String topic = "persistent://public/default/string-json-" + System.nanoTime();
+
+        try (Producer<String> producer = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            for (int seq = 1; seq <= RECORDS; seq++) {
+                producer.send("{\"id\":\"sensor-" + seq + "\",\"reading\":" + (seq * 10) + "}");
+            }
+        }
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "string-json", new JsonTreeReader());
+        assertEquals(RECORDS, consumeRecords(consumer, RECORDS));
+
+        final String content = successContent(consumer);
+        assertTrue("the JSON should have been parsed into fields, but got " + content, content.contains("\"reading\""));
+        assertTrue(content.contains("\"id\""));
+    }
+
+    /** Without a reader there is nothing to parse with, so the value is wrapped rather than failed. */
+    @Test
+    public void withoutAReaderTheStringPayloadIsWrappedInTheValueField() throws Exception {
+        final String topic = "persistent://public/default/string-wrap-" + System.nanoTime();
+
+        try (Producer<String> producer = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            for (int seq = 1; seq <= RECORDS; seq++) {
+                producer.send("{\"id\":\"sensor-" + seq + "\"}");
+            }
+        }
+
+        final TestRunner consumer = topicSchemaConsumer(topic, "string-wrap", null);
+        assertEquals(RECORDS, consumeRecords(consumer, RECORDS));
+
+        final String content = successContent(consumer);
+        assertTrue("the payload should be one string field, but got " + content, content.contains("\"value\""));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+    }
+
+    // ---------------------------------------------------------------- publish-side guard
+
+    /**
+     * A primitive topic carries one value per message, so a record with several fields has no unambiguous
+     * mapping. Guessing which field was meant would publish the wrong data silently, so it fails instead.
+     */
+    @Test
+    public void aMultiFieldRecordCannotBePublishedToAPrimitiveTopic() throws Exception {
+        final String topic = seededStringTopic("multi-field");
+
+        final TestRunner publisher = publisher(topic);
+        publisher.enqueue("[{\"id\":\"sensor-1\",\"reading\":10}]".getBytes(UTF_8));
+        publisher.run(1, true);
+
+        publisher.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 0);
+        publisher.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 1);
+    }
+
+    /**
+     * A topic with no schema is unaffected: the writer still serializes whatever it is given.
+     * <p>
+     * This is the test that caught BYTES being unusable as a primitive type. {@code AUTO_PRODUCE_BYTES}
+     * reports a schema-less topic as {@code BYTES} with an empty definition, so treating BYTES as a
+     * primitive made every schema-less topic reject multi-field records - and schema-less is what this
+     * bundle's own publishers produce.
+     */
+    @Test
+    public void aTopicWithoutASchemaIsUnaffected() throws Exception {
+        final String topic = "persistent://public/default/prim-noschema-" + System.nanoTime();
+
+        final TestRunner publisher = publisher(topic);
+        publisher.enqueue("[{\"id\":\"sensor-1\",\"reading\":10}]".getBytes(UTF_8));
+        publisher.run(1, true);
+
+        publisher.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 1);
+        publisher.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+
+        try (Consumer<byte[]> consumer = getClient().newConsumer(Schema.BYTES).topic(topic)
+                .subscriptionName("prim-noschema").subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe()) {
+            final Message<byte[]> message = consumer.receive(30, java.util.concurrent.TimeUnit.SECONDS);
+            assertTrue("the record writer's output should be on the topic",
+                    new String(message.getValue(), UTF_8).contains("sensor-1"));
+        }
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** A STRING topic with one record already on it, which is what registers the schema. */
+    private static String seededStringTopic(final String name) throws Exception {
+        final String topic = "persistent://public/default/prim-" + name + "-" + System.nanoTime();
+
+        try (Producer<String> seeder = getClient().newProducer(Schema.STRING).topic(topic).create()) {
+            seeder.send("seed");
+        }
+
+        return topic;
+    }
+
+    private TestRunner publisher(final String topic) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final JsonTreeReader reader = new JsonTreeReader();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(PublishPulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+        return runner;
+    }
+
+    /** Publishes {@link #RECORDS} single-field records, each built from {@code template}. */
+    private void publishWithNiFi(final String topic, final String template) throws Exception {
+        final TestRunner publisher = publisher(topic);
+
+        final StringBuilder content = new StringBuilder("[");
+        for (int seq = 1; seq <= RECORDS; seq++) {
+            content.append(seq > 1 ? "," : "").append(String.format(template, seq));
+        }
+        publisher.enqueue(content.append("]").toString().getBytes(UTF_8));
+        publisher.run(1, true);
+
+        publisher.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+        publisher.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, 1);
+    }
+
+    private TestRunner topicSchemaConsumer(final String topic, final String subscription,
+            final JsonTreeReader reader) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        if (reader != null) {
+            runner.addControllerService("record-reader", reader);
+            runner.enableControllerService(reader);
+            runner.setProperty(ConsumePulsarRecord.RECORD_READER, "record-reader");
+        }
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(ConsumePulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, subscription);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "100");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+        return runner;
+    }
+
+    private static String successContent(final TestRunner runner) {
+        final StringBuilder content = new StringBuilder();
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+            content.append(new String(flowFile.toByteArray(), UTF_8));
+        }
+        return content.toString();
+    }
+
+    private static int consumeRecords(final TestRunner runner, final int expected) throws Exception {
+        final int[] records = {0};
+        runner.run(1, false, true);
+        await(expected + " records to be consumed", () -> {
+            runner.run(1, false, false);
+            records[0] = 0;
+            for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+                records[0] += Integer.parseInt(flowFile.getAttribute("record.count"));
+            }
+            return records[0] >= expected;
+        });
+        runner.run(1, true, false);
+        return records[0];
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaStrategyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordSchemaStrategyTest.java
@@ -79,6 +79,30 @@ public class ConsumePulsarRecordSchemaStrategyTest extends AbstractPulsarProcess
         runner.assertValid();
     }
 
+    /**
+     * The override must keep the superclass rules, not replace them (#194). Overriding customValidate with
+     * a fresh list silently dropped both of the consumer's own rules for this processor, so a
+     * ConsumePulsarRecord with no topic at all became a valid configuration and failed at runtime instead.
+     */
+    @Test
+    public void theConsumersOwnValidationRulesStillApply() throws InitializationException {
+        addRecordReader();
+        runner.assertValid();
+
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.assertNotValid();
+    }
+
+    /** The other superclass rule, which the same bug disabled. */
+    @Test
+    public void theAcknowledgementTimeoutRuleStillApplies() throws InitializationException {
+        addRecordReader();
+        runner.assertValid();
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "2 sec");
+        runner.assertNotValid();
+    }
+
     private void addRecordReader() throws InitializationException {
         final MockRecordParser reader = new MockRecordParser();
         runner.addControllerService("record-reader", reader);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchemaTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchemaTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Test;
+
+/**
+ * Encoding and decoding the single value a primitive topic carries (#189).
+ * <p>
+ * Every encode is checked against Pulsar's own decoder rather than against our own encoder, so a test
+ * cannot pass by being wrong in both directions - which is the failure mode a hand-rolled wire format
+ * would have.
+ */
+public class PrimitiveTopicSchemaTest {
+
+    @Test
+    public void valuesRoundTripThroughPulsarsOwnCodecs() throws Exception {
+        assertEquals("hello", Schema.STRING.decode(PrimitiveTopicSchema.encode(SchemaType.STRING, "hello", "v")));
+        assertEquals(Boolean.TRUE, Schema.BOOL.decode(PrimitiveTopicSchema.encode(SchemaType.BOOLEAN, true, "v")));
+        assertEquals(Byte.valueOf((byte) 7), Schema.INT8.decode(PrimitiveTopicSchema.encode(SchemaType.INT8, (byte) 7, "v")));
+        assertEquals(Short.valueOf((short) 12345), Schema.INT16.decode(PrimitiveTopicSchema.encode(SchemaType.INT16, (short) 12345, "v")));
+        assertEquals(Integer.valueOf(42), Schema.INT32.decode(PrimitiveTopicSchema.encode(SchemaType.INT32, 42, "v")));
+        assertEquals(Long.valueOf(9000000000L), Schema.INT64.decode(PrimitiveTopicSchema.encode(SchemaType.INT64, 9000000000L, "v")));
+        assertEquals(Float.valueOf(1.5f), Schema.FLOAT.decode(PrimitiveTopicSchema.encode(SchemaType.FLOAT, 1.5f, "v")));
+        assertEquals(Double.valueOf(2.5d), Schema.DOUBLE.decode(PrimitiveTopicSchema.encode(SchemaType.DOUBLE, 2.5d, "v")));
+    }
+
+    @Test
+    public void decodingReadsWhatPulsarWrote() throws Exception {
+        assertEquals("hello", PrimitiveTopicSchema.decode(SchemaType.STRING, Schema.STRING.encode("hello")));
+        assertEquals(42, PrimitiveTopicSchema.decode(SchemaType.INT32, Schema.INT32.encode(42)));
+        assertEquals(9000000000L, PrimitiveTopicSchema.decode(SchemaType.INT64, Schema.INT64.encode(9000000000L)));
+        assertEquals(true, PrimitiveTopicSchema.decode(SchemaType.BOOLEAN, Schema.BOOL.encode(true)));
+    }
+
+    /**
+     * A record field's type need not match the topic's. Coercing here means a CSV reader's String "42" can
+     * be published to an INT32 topic, rather than failing at the broker with an error that names neither
+     * the field nor the record.
+     */
+    @Test
+    public void valuesAreCoercedToTheTopicsType() throws Exception {
+        assertEquals(Integer.valueOf(42), Schema.INT32.decode(PrimitiveTopicSchema.encode(SchemaType.INT32, "42", "v")));
+        assertEquals("42", Schema.STRING.decode(PrimitiveTopicSchema.encode(SchemaType.STRING, 42, "v")));
+        assertEquals(Long.valueOf(42L), Schema.INT64.decode(PrimitiveTopicSchema.encode(SchemaType.INT64, 42, "v")));
+    }
+
+    /** A value that cannot be represented is an error the caller routes, not a silently mangled message. */
+    @Test
+    public void aValueThatCannotBeRepresentedFails() {
+        assertThrows(IOException.class, () -> PrimitiveTopicSchema.encode(SchemaType.INT32, "not a number", "reading"));
+        assertThrows("null has no representation on a primitive topic", IOException.class,
+                () -> PrimitiveTopicSchema.encode(SchemaType.INT32, null, "reading"));
+    }
+
+    /** A payload of the wrong width is a parse failure, not a garbage value. */
+    @Test
+    public void aPayloadOfTheWrongWidthFails() {
+        assertThrows(IOException.class, () -> PrimitiveTopicSchema.decode(SchemaType.INT32, new byte[] {1, 2}));
+    }
+
+    @Test
+    public void theDateAndTimeSchemasAreNotSupportedYet() {
+        assertTrue(PrimitiveTopicSchema.supports(SchemaType.STRING));
+        assertTrue(PrimitiveTopicSchema.supports(SchemaType.INT32));
+        assertFalse("BYTES is how the client reports a topic with no schema at all, so treating it as a "
+                + "primitive would capture every schema-less topic",
+                PrimitiveTopicSchema.supports(SchemaType.BYTES));
+        assertFalse("deliberately deferred, along with AVRO logical types",
+                PrimitiveTopicSchema.supports(SchemaType.TIMESTAMP));
+        assertFalse(PrimitiveTopicSchema.supports(SchemaType.LOCAL_DATE_TIME));
+        assertFalse("a record type is not a primitive", PrimitiveTopicSchema.supports(SchemaType.AVRO));
+        assertFalse(PrimitiveTopicSchema.supports(null));
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchemaTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PrimitiveTopicSchemaTest.java
@@ -77,6 +77,27 @@ public class PrimitiveTopicSchemaTest {
                 () -> PrimitiveTopicSchema.encode(SchemaType.INT32, null, "reading"));
     }
 
+    /**
+     * A structured value has no meaningful text form, so it is refused rather than published as its
+     * toString(). Coercing it would put a Java debug string on the topic and look like it had worked.
+     */
+    @Test
+    public void aStructuredValueIsNotStringifiedOntoAStringTopic() {
+        final java.util.Map<String, Object> nested = new java.util.HashMap<>();
+        nested.put("id", 1);
+
+        assertThrows(IOException.class, () -> PrimitiveTopicSchema.encode(SchemaType.STRING, nested, "payload"));
+        assertThrows(IOException.class,
+                () -> PrimitiveTopicSchema.encode(SchemaType.STRING, new Object[] {1, 2}, "payload"));
+    }
+
+    /** Scalars still render as text, including numbers and booleans. */
+    @Test
+    public void scalarsStillRenderAsText() throws Exception {
+        assertEquals("42", Schema.STRING.decode(PrimitiveTopicSchema.encode(SchemaType.STRING, 42, "v")));
+        assertEquals("true", Schema.STRING.decode(PrimitiveTopicSchema.encode(SchemaType.STRING, true, "v")));
+    }
+
     /** A payload of the wrong width is a parse failure, not a garbage value. */
     @Test
     public void aPayloadOfTheWrongWidthFails() {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
@@ -90,17 +90,27 @@ public class TopicSchemaRecordDecoderTest {
         assertEquals("C", record.getValue("unit"));
     }
 
-    /** Only the two struct types map to a record; everything else falls back to the Record Reader. */
+    /** The struct types map to a record directly; the primitives map to a single-field one (#189). */
     @Test
-    public void supportsOnlyTheStructTypes() {
+    public void supportsTheStructAndPrimitiveTypes() {
         assertTrue(TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.AVRO)));
         assertTrue(TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.JSON)));
-        assertFalse("a primitive schema has no record shape (#189)",
+        assertTrue("a primitive topic becomes a single-field record (#189)",
                 TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.STRING)));
         assertFalse("KeyValue carries two schemas and needs its own handling (#190)",
                 TopicSchemaRecordDecoder.supports(schemaInfo(SchemaType.KEY_VALUE)));
         assertFalse("a topic with no schema reports null, which is the #181 case",
                 TopicSchemaRecordDecoder.supports(null));
+    }
+
+    /** Only the primitives need the reader-precedence rule, so struct types must not be flagged as such. */
+    @Test
+    public void onlyPrimitiveTopicsAreReportedAsPrimitive() {
+        assertTrue(TopicSchemaRecordDecoder.isPrimitive(schemaInfo(SchemaType.STRING)));
+        assertTrue(TopicSchemaRecordDecoder.isPrimitive(schemaInfo(SchemaType.INT32)));
+        assertFalse(TopicSchemaRecordDecoder.isPrimitive(schemaInfo(SchemaType.AVRO)));
+        assertFalse(TopicSchemaRecordDecoder.isPrimitive(schemaInfo(SchemaType.JSON)));
+        assertFalse(TopicSchemaRecordDecoder.isPrimitive(null));
     }
 
     /** A payload that does not match the schema is an error the caller routes, not a half-built record. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
@@ -126,6 +126,68 @@ public class TopicSchemaRecordDecoderTest {
         assertNull(new TopicSchemaRecordDecoder().getLastRecordSchema());
     }
 
+    /**
+     * Two threads decoding two schemas through one decoder must never see each other's shape (#195).
+     * <p>
+     * The cache was five mutable fields read and replaced one at a time, so a thread could pick up the
+     * other's Avro schema together with its own RecordSchema. The failure was silent - no exception, wrong
+     * records straight to success - and 13-36% of records were affected under contention. The decoder is
+     * now created per batch rather than shared, but the class is also safe on its own, and this is what
+     * says so.
+     */
+    @Test
+    public void twoThreadsDecodingTwoSchemasDoNotSeeEachOther() throws Exception {
+        final String alphaDef = "{\"type\":\"record\",\"name\":\"A\",\"fields\":["
+                + "{\"name\":\"alpha\",\"type\":\"string\"}]}";
+        final String betaDef = "{\"type\":\"record\",\"name\":\"B\",\"fields\":["
+                + "{\"name\":\"beta\",\"type\":\"string\"}]}";
+
+        final SchemaInfo alpha = SchemaInfo.builder().name("A").type(SchemaType.JSON)
+                .schema(alphaDef.getBytes(UTF_8)).build();
+        final SchemaInfo beta = SchemaInfo.builder().name("B").type(SchemaType.JSON)
+                .schema(betaDef.getBytes(UTF_8)).build();
+
+        final TopicSchemaRecordDecoder shared = new TopicSchemaRecordDecoder();
+        final int iterations = 20_000;
+        final java.util.concurrent.atomic.AtomicInteger wrong = new java.util.concurrent.atomic.AtomicInteger();
+        final java.util.concurrent.atomic.AtomicInteger failed = new java.util.concurrent.atomic.AtomicInteger();
+
+        final Runnable alphaTask = decoding(shared, alpha, "alpha", "a-value", iterations, wrong, failed);
+        final Runnable betaTask = decoding(shared, beta, "beta", "b-value", iterations, wrong, failed);
+
+        final Thread one = new Thread(alphaTask);
+        final Thread two = new Thread(betaTask);
+        one.start();
+        two.start();
+        one.join();
+        two.join();
+
+        assertEquals("records came back with the other thread's shape or value", 0, wrong.get());
+        assertEquals("decoding threw rather than returning a wrong record", 0, failed.get());
+    }
+
+    private static Runnable decoding(final TopicSchemaRecordDecoder decoder, final SchemaInfo schemaInfo,
+            final String field, final String value, final int iterations,
+            final java.util.concurrent.atomic.AtomicInteger wrong,
+            final java.util.concurrent.atomic.AtomicInteger failed) {
+        final byte[] payload = ("{\"" + field + "\":\"" + value + "\"}").getBytes(UTF_8);
+
+        return () -> {
+            for (int i = 0; i < iterations; i++) {
+                try {
+                    final Record record = decoder.decode(payload, schemaInfo);
+
+                    if (!value.equals(record.getValue(field))
+                            || !record.getSchema().getFieldNames().contains(field)) {
+                        wrong.incrementAndGet();
+                    }
+                } catch (final Exception e) {
+                    failed.incrementAndGet();
+                }
+            }
+        };
+    }
+
     // ------------------------------------------------------------------ helpers
 
     private static SchemaInfo schemaInfo(final SchemaType type) {


### PR DESCRIPTION
Closes #189.

## The change

A topic whose registered schema is a primitive — `STRING`, `BOOLEAN`, `INT8`/`INT16`/`INT32`/`INT64`, `FLOAT`, `DOUBLE` — carries one value per message and has no fields. Both processors previously treated that as no schema at all: the Record Writer serialized whatever it was given and the broker accepted it only if it happened to match.

Now:

- **Consuming** — `Topic Schema` gives each message a record of one field, named by a new **Primitive Value Field** property (`value` by default). It becomes a column name downstream, so it is configurable.
- **Publishing** — a single-field record is encoded with the topic's primitive schema, the value coerced to its type.

Encoding and decoding go through Pulsar's own `Schema.STRING`, `Schema.INT32` and friends rather than reimplementing the wire formats the broker validates against.

## The precedence rule, from review feedback on #184

> STRING topics with JSON text inside are common in production and #189 should keep "let the reader parse the STRING payload" possible.

So **a configured Record Reader wins on a primitive topic.** With a reader, the payload is parsed into real records; without one there is nothing to parse with, so the single-field record is the useful answer rather than a parse failure. Both directions are tested.

This does mean the same topic behaves differently depending on whether a reader is configured. That is deliberate and documented, rather than something to discover.

## Two things the tests caught

**`BYTES` cannot be supported, and an IT proved it.** `AUTO_PRODUCE_BYTES` reports a topic with *no* schema as `BYTES` with an empty definition:

```
info={"name": "Bytes", "schema": "", "type": "BYTES"} type=BYTES
```

A registered `BYTES` schema is therefore indistinguishable from none. Treating it as primitive made every schema-less topic reject multi-field records — and schema-less is exactly what this bundle's own publishers produce (#181). It is excluded, with the reasoning recorded in the code.

**An unchecked exception would have escaped the publish loop.** `DataTypeUtils.toInteger` throws `NumberFormatException`, not `IllegalTypeConversionException`, for a String that is not a number. My original catch missed it, so it would have failed the whole trigger instead of routing that FlowFile to `failure`.

## Publishing guard

A primitive topic takes one value per message, so a record with several fields has no unambiguous mapping. Guessing which field was meant would publish the wrong data silently, so it routes to `failure` with a message naming the fields.

## Tests

- `PrimitiveTopicSchemaTest` — every encode is checked against **Pulsar's own decoder**, not against our encoder, so a test cannot pass by being wrong in both directions. Plus coercion, malformed payloads, and which types are supported.
- `PrimitiveSchemaRoundTripIT` — against a real broker: **e2e NiFi→NiFi round trips on STRING and INT32**, the configurable field name, both sides of the reader-precedence rule, the multi-field publish guard, and a schema-less topic being unaffected.

**299 unit tests and 58 integration tests green.**

## Not covered

- The **date and time schemas** (`DATE`, `TIME`, `TIMESTAMP`, `INSTANT`, `LOCAL_DATE`, `LOCAL_TIME`, `LOCAL_DATE_TIME`), deferred for the same reason AVRO logical types are still uncovered under #34 — they carry conversion questions the numerics do not and deserve their own tests.
- **`KeyValue` schemas**, which are #190.