### PR TITLE
docs: add 2.10.0 release notes and compatibility row

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 | Bundle version | NiFi | Pulsar client | Java |
 |---|---|---|---|
+| `2.10.0` | 2.10.0 | 4.2.4 | 21 |
 | `2.9.0` | 2.9.0 | 4.2.2 | 21 |
 | `2.1.0` | 2.1.0 | 3.3.7 | 21 |
 
@@ -14,6 +15,9 @@
 The bundle version tracks the NiFi platform version it is built for; each release
 line targets one Pulsar client major. See [VERSIONING.md](VERSIONING.md) for the
 full scheme, branching model, and release process.
+
+Release notes live in [`docs/release-notes/`](docs/release-notes/). `2.10.0` carries
+several behaviour changes — see [its notes](docs/release-notes/2.10.0.md) before upgrading.
 
 ## Consumer FlowFile attributes
 

--- a/docs/release-notes/2.10.0.md
+++ b/docs/release-notes/2.10.0.md
@@ -1,0 +1,90 @@
+# 2.10.0
+
+Built for **NiFi 2.10.0** against the **Pulsar 4.2.4** client. Java 21.
+
+This is a large release: 48 commits since `2.9.0`, most of them correctness fixes found by
+running the processors against a real broker for the first time. **Read the behaviour changes
+below before upgrading** — several fix bugs by changing what a flow does.
+
+## Behaviour changes
+
+These alter what existing flows do. None requires a configuration change to keep working, except
+where stated.
+
+**Messages are acknowledged only after their FlowFile is committed.** Previously a message could be
+acknowledged while its content could still be discarded, so a write error lost it for good — neither
+in NiFi nor recoverable from Pulsar. Acknowledgement now runs in the commit callback, so a session
+that is never committed acknowledges nothing and the broker redelivers. Flows may now see redelivery
+where messages were previously lost silently.
+
+**A FlowFile's messages are published in order.** Sends were issued in a way that let the broker
+receive them out of order within a single FlowFile.
+
+**Every send is awaited.** Send futures were created and discarded without being awaited, so a
+failed send could go unreported and the message was lost. A strict test caught this as `999 of 1000`.
+
+**Published content is validated against the topic's schema.** Producers now use
+`Schema.AUTO_PRODUCE_BYTES()`, so the broker checks each payload against the topic's registered
+schema. Content that does not match is now routed to `failure` at publish time instead of landing on
+the topic as an undecodable message that no schema-aware consumer could read past. **Publishing
+arbitrary bytes to a schema-bearing topic now fails where it previously appeared to succeed.**
+Topics with no schema are unaffected.
+
+**Message Routing Mode and Max Pending Messages now reach the producer.** Neither had since the 2023
+publish refactor. *Max Pending Messages* applies **to every flow, including one that never
+configured it**: the property has always shown a default of `1000`, but the client ran with the
+count-based bound disabled. With *Async Enabled*, exceeding it fails a send with
+`ProducerQueueIsFullError` when *Block if Message Queue Full* is off, which is the default. If you
+publish large FlowFiles asynchronously, either raise the bound, set it to `0` to restore the previous
+behaviour, or enable blocking. **`CustomPartition` is now rejected at validation** — it needs a
+`MessageRouter` the processors cannot supply, and the client refused it at producer creation anyway.
+
+**`Consumer Message Batch Size` is honoured**, and **partitioned-topic messages are batched by
+logical topic**, so a partitioned topic is read as one topic rather than one FlowFile per partition.
+
+**The `msg.key` attribute fallback is honoured as documented.** A keyed message routes to a partition
+by its key and makes the topic compactable by it; if you relied on the previous unkeyed behaviour,
+clear `msg.key` before the publish processor.
+
+## New
+
+**Schema-aware publishing (#34).** `PublishPulsarRecord` gains a *Message Schema Strategy*. Under
+`Topic Schema`, records are encoded with the schema the topic carries — AVRO and JSON — so a
+schema-aware consumer can decode them.
+
+**Schema-aware consuming (#185).** `ConsumePulsarRecord` gains the same property. Under `Topic
+Schema`, records are built from the schema the broker sends with each message: no Record Reader and
+no schema configuration at all, and AVRO and JSON topics behave identically. Because the schema
+arrives per message, schema evolution needs no special handling. `Record Reader` remains the default,
+so existing flows are unchanged.
+
+**Primitive-schema topics (#189).** A topic whose schema is `STRING`, `BOOLEAN` or a numeric type maps
+to a record of one field, named by *Primitive Value Field*. *Primitive Schema Handling* decides
+whether a configured Record Reader parses the payload instead — a `STRING` topic carrying JSON text
+usually wants that.
+
+**KeyValue-schema topics (#190).** `INLINE` and `SEPARATED` both map to a record with `key` and
+`value` fields, each keeping the shape its own schema describes.
+
+**Configurable consumer cache size**, and **`Concurrent Tasks` is safe** for the record consumer.
+
+## Fixes
+
+Producer leak on rescheduling; acknowledgement `Future`s retained without bound in async mode;
+unbounded FlowFile claiming per trigger; empty FlowFiles in async mode; parse-failure FlowFiles
+stranded when routing could not write; a failed `parse_failure` write redelivering a whole batch
+rather than only the affected messages; `NullPointerException` on every message from a topic with no
+schema; a record set not closed when the schema changes mid-stream.
+
+## Testing
+
+Integration tests now run against a real Pulsar broker via Testcontainers (`mvn verify`), including
+NiFi-to-NiFi round trips — publish with this bundle, read it back with it — across bytes, records,
+AVRO, JSON, primitive and KeyValue topics. Several of the fixes above were found only by those tests;
+the unit suite passed throughout, because the mocked client returned `null` message ids and a fixed
+schema where a real broker does not.
+
+## Upgrading
+
+Drop in the new NARs. No configuration change is required unless you use `CustomPartition`, which is
+now invalid, or publish large FlowFiles asynchronously — see *Max Pending Messages* above.


### PR DESCRIPTION
Release prep for **2.10.0**. Docs only — no code, and deliberately **no version bump**.

## Why there is no version bump

VERSIONING.md is explicit:

> The **git tag is authoritative** for a release. The pom `<version>` on `main` stays at the NiFi base version… you do **not** hand-edit it or commit a bump before tagging.

And `release.yml` does exactly that:

```yaml
- name: Stamp version from tag
  if: github.ref_type == 'tag'
  run: mvn -B -ntp versions:set -DnewVersion="${GITHUB_REF_NAME#v}" ...
```

I had started a bump commit before reading this and discarded it. Cutting the release is a single action: **push `v2.10.0`**.

## Why 2.10.0

Under the documented rule the NiFi version owns the Maven version, and `nifi.version` is `2.10.0` — so this is *"first release built for NiFi 2.10.0"*. The Pulsar client moved 4.2.2 → 4.2.4 within the same major, which the scheme treats as a property of the release line, recorded in the matrix rather than the coordinate.

## What is here

- The `2.10.0` row in the README compatibility table.
- `docs/release-notes/2.10.0.md`, written out rather than left to `generate_release_notes`.

Auto-generated notes list PR titles, which cannot say *"this fixes a bug by changing what your flow does."* This release has several of those:

- **acknowledgement now happens after commit** — flows may see redelivery where messages were previously lost silently;
- **published content is validated against the topic's schema** — publishing arbitrary bytes to a schema-bearing topic now fails where it appeared to succeed;
- **Max Pending Messages now applies to flows that never configured it**, and can fail sends with `ProducerQueueIsFullError` under async;
- **`CustomPartition` is now invalid.**

The notes lead with those, since they are what a reader upgrading needs, and cover the new schema support and fixes after.

## Note for later

VERSIONING.md rests on *"one Pulsar client major per release line"*. #188 is precisely about supporting several at once, so the scheme needs revisiting as part of that work — including what a `3.0.0` would then mean, given the current rule makes it "built for NiFi 3.0.0". Raised on #188 rather than resolved here.