### PR TITLE
fix: build the image on the NiFi version the NARs target (2.10.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,19 @@ updates:
       github-actions-all:
         patterns:
           - "*"
+
+  # Base image updates for the published container. Dependabot reads the literal
+  # tag in the Dockerfile's FROM line, which is why that tag is pinned literally
+  # rather than templated from the `nifi.version` Maven property - a property
+  # reference here would be invisible to Dependabot and the pin would go stale
+  # again (it had drifted to 2.1.0 while the bundle targeted 2.10.0).
+  - package-ecosystem: docker
+    directory: "/docker-image/src/main/docker/nifi"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      docker-all:
+        patterns:
+          - "*"

--- a/docker-image/src/main/docker/nifi/Dockerfile
+++ b/docker-image/src/main/docker/nifi/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM apache/nifi:2.1.0
+FROM apache/nifi:2.10.0
 
 #############################################################################
 # Add the custom NAR files


### PR DESCRIPTION
## Problem

`docker-image/src/main/docker/nifi/Dockerfile` pinned `FROM apache/nifi:2.1.0` while `nifi.version` had moved to `2.10.0`. The published container therefore runs a **NiFi 2.1.0 runtime loading NARs compiled against NiFi 2.10.0** — nine minor versions of API drift between the platform and the extensions it loads.

This is not hypothetical: the `v2.10.0` release shipped an image in this state, and it is also tagged `:latest`.

```
$ git show v2.10.0:docker-image/src/main/docker/nifi/Dockerfile | grep ^FROM
FROM apache/nifi:2.1.0
$ git show v2.10.0:pom.xml | grep nifi.version
<nifi.version>2.10.0</nifi.version>
```

The GitHub release NAR assets are unaffected — they are built from the pom and are correct.

## Why nothing caught it

`.github/dependabot.yml` declared only the `maven` and `github-actions` ecosystems. The base image was the one dependency in the repository that nothing ever proposed an update for, so the pin sat at `2.1.0` through every subsequent NiFi bump without ever surfacing.

## Change

- Bump the base image to `apache/nifi:2.10.0` to match `nifi.version`.
- Add the `docker` ecosystem to Dependabot, pointed at the Dockerfile's directory, so the pin cannot go stale again.

The `FROM` tag stays a **literal** rather than being templated from the Maven property. Dependabot parses the literal and cannot resolve a property reference — writing it out is precisely what keeps the fix from regressing.

## Verification

- `apache/nifi:2.10.0` confirmed to exist on Docker Hub.
- Full local build including the `docker-image` module.

## Follow-up

This warrants a `v2.10.0.1` release once merged, so the published image matches the NARs it carries.

Refs #197 (found while scoping the container-scanning work; shipped separately so it can move faster)
