### PR TITLE
chore: add a security policy and scheduled vulnerability scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+# Static analysis of this repository's own Java source. Dependabot and the Trivy
+# scan both look at code we depend on; nothing looked at code we wrote until this.
+#
+# Free on public repositories. Runs on pull requests so a regression is caught
+# before it lands, and weekly so that newly published CodeQL queries get applied
+# to code that has not changed.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays at 08:00 UTC, an hour after the dependency scan.
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Java)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # Explicit build rather than autobuild: this is a multi-module NAR build and
+      # autobuild does not reliably pick the right goals. Mirrors the CI workflow -
+      # skip GPG signing (no keys here) and the docker-image module (nothing to
+      # analyze in it, and it would need a Docker daemon). Tests are skipped
+      # because CodeQL only needs the main sources compiled.
+      - name: Build
+        run: mvn -B -ntp clean package -DskipTests -Dgpg.skip=true -pl '!docker-image'
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:java-kotlin

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,115 @@
+name: Security Scan
+
+# Weekly vulnerability scan of both surfaces Dependabot cannot fully see:
+#
+#   1. the Maven dependency tree, including transitives Dependabot only reports
+#      on when an advisory names the direct dependency, and
+#   2. the built container image, whose base (apache/nifi) carries a full JRE and
+#      OS userland that no Maven scan will ever look at.
+#
+# Runs on a schedule rather than on push: the point is that this happens on a
+# cadence rather than when someone remembers to look. Results go to the Security
+# tab as SARIF, so findings accumulate somewhere reviewable instead of scrolling
+# past in a log.
+#
+# Accepted findings belong in .trivyignore with a reason and a review date - not
+# suppressed silently here.
+on:
+  schedule:
+    # Mondays at 07:00 UTC.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+# Least privilege: read the code, write scan results to the Security tab.
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: security-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependencies:
+    name: Dependency scan (Trivy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Two passes over the same cached database. The first records everything
+      # for the Security tab; the second decides whether the run goes red. They
+      # are split because the SARIF must upload even when the gate fails.
+      - name: Scan dependency tree (SARIF)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          format: sarif
+          output: trivy-deps.sarif
+          exit-code: '0'
+
+      - name: Upload dependency findings
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-deps.sarif
+          category: trivy-dependencies
+
+      # Fails the run on CVSS >= 7 equivalents, per issue #197.
+      - name: Fail on HIGH or CRITICAL
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+  image:
+    name: Container image scan (Trivy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # Full build including the docker-image module: the fabric8 plugin produces
+      # the local image `streamnative/nifi:latest` during the package phase. This
+      # is the same image the release workflow pushes to GHCR.
+      - name: Build image
+        run: mvn -B -ntp clean package -Dgpg.skip=true -DskipTests
+
+      - name: Scan image (SARIF)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: streamnative/nifi:latest
+          scanners: vuln
+          format: sarif
+          output: trivy-image.sarif
+          # REPORT-ONLY, deliberately. A NiFi base image carries a full JRE and OS
+          # userland, so the first scans will report a long tail of upstream CVEs
+          # that no change in this repository can fix. Gating on them now would
+          # leave the job permanently red, which just teaches everyone to ignore
+          # it. Triage the baseline into .trivyignore first, then set this to '1'
+          # so regressions actually stop the run.
+          exit-code: '0'
+
+      - name: Upload image findings
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,22 @@
+# Accepted Trivy findings.
+#
+# Every entry here is a decision, not a mute. An entry without a reason and a
+# review date should be deleted rather than trusted - if nobody remembers why a
+# finding was accepted, it has not been accepted, it has been forgotten.
+#
+# Format (one CVE per line, preceded by its justification):
+#
+#   # CVE-YYYY-NNNNN - <component>
+#   # Reason:  why this does not affect this bundle, or why we cannot act on it
+#   # Review:  YYYY-MM-DD
+#   CVE-YYYY-NNNNN
+#
+# Prefer fixing over ignoring. Reach for this file when the finding is in the
+# apache/nifi base image with no newer base available, or when the vulnerable
+# code path is provably unreachable from this bundle.
+#
+# The container image scan in .github/workflows/security-scan.yml is currently
+# report-only. Once its baseline has been triaged into this file, flip that job's
+# exit-code to '1' so new findings stop the run.
+
+# (no accepted findings yet)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the most recent release line only. The bundle version
+tracks the NiFi platform version it is built for (see the compatibility table in the
+[README](README.md)).
+
+| Bundle version | Supported |
+|---|---|
+| `2.10.x` | Yes |
+| `2.9.x` | No — upgrade to `2.10.x` |
+| `2.1.x` and earlier | No |
+
+If you are pinned to an older line because of a platform constraint, say so in your
+report; it helps to know that a backport matters to someone.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report privately through GitHub:
+
+1. Go to the [Security tab](../../security) of this repository.
+2. Click **Report a vulnerability**.
+3. Describe the issue, the affected version, and how to reproduce it.
+
+That opens a private advisory thread visible only to you and the maintainers. If you
+cannot use GitHub's private reporting for any reason, open a public issue containing
+only a request for a private contact channel — no details.
+
+Helpful things to include, when you have them:
+
+- The affected version, and whether you reproduced against the NARs or the container image
+- A minimal reproduction — a flow definition, processor configuration, or test case
+- What an attacker gains, and what access they need to get it
+
+## What to expect
+
+This is a small project maintained on a best-effort basis. Concretely:
+
+- **Acknowledgement within 5 business days.** If you have not heard back by then, assume
+  the notification was missed and ping the thread.
+- An initial assessment — whether it reproduces, and whether it is in scope — within
+  two weeks of acknowledgement.
+- Progress updates as the fix develops, rather than silence until release.
+
+Fixes ship in the next release of the supported line. If a problem is severe enough to
+warrant an out-of-band release, it will get one.
+
+## Scope
+
+**In scope** — anything this repository builds and publishes:
+
+- The processors (`PublishPulsar`, `ConsumePulsar`, `PublishPulsarRecord`, `ConsumePulsarRecord`)
+- The Pulsar client controller service, including credential handling and the client cache
+- The published NAR artifacts
+- The `ghcr.io/<owner>/nifi` container image, insofar as the problem is in what this
+  repository adds on top of the base image
+
+**Out of scope** — please report these upstream, where they can actually be fixed:
+
+- Apache NiFi itself → [security@apache.org](mailto:security@apache.org) and the
+  [NiFi security page](https://nifi.apache.org/security.html)
+- Apache Pulsar and its Java client → [security@apache.org](mailto:security@apache.org)
+- Vulnerabilities in the `apache/nifi` base image that originate upstream. Report them to
+  Apache. Telling us anyway is still useful — we may be able to move the base image pin.
+- Findings from an automated scanner with no demonstrated impact on this bundle. A CVE
+  identifier in a transitive dependency is a starting point for a report, not a report.
+
+## Disclosure
+
+We follow coordinated disclosure. Once a fix is available, the issue is published as a
+[GitHub Security Advisory](../../security/advisories) on this repository, and a CVE is
+requested where one is warranted. Reporters are credited by name unless they ask not to be.
+
+We will not take action against anyone who reports a vulnerability in good faith through
+the channel above, and we ask the same in return: no accessing data that is not yours, no
+degrading anyone's service, and no public disclosure before a fix is available.
+
+## Automated scanning
+
+This repository scans itself on a schedule, independently of anything reported:
+
+- **Dependabot** — weekly Maven, GitHub Actions, and base-image updates, grouped and
+  auto-merged on green CI for patch and minor bumps (`.github/dependabot.yml`)
+- **Trivy** — weekly scan of the dependency tree and the built container image
+  (`.github/workflows/security-scan.yml`)
+- **CodeQL** — static analysis of this repository's own Java source
+  (`.github/workflows/codeql.yml`)
+
+Accepted findings are recorded with a reason in [`.trivyignore`](.trivyignore) rather than
+suppressed silently.


### PR DESCRIPTION
Closes #197

## Context

Dependabot already covers known advisories in declared Maven and Actions dependencies, grouped and auto-merging on green CI. That is the largest part of the problem and it is already solved. Three gaps remained:

1. **No private reporting channel.** Someone finding a vulnerability had two options: a public issue, or nothing.
2. **Nothing scanned the container image.** Dependabot cannot see base-image OS packages, which is where CVE count actually accumulates — a NiFi base carries a full JRE and OS userland no Maven scan will ever look at.
3. **No static analysis of our own code.** Dependabot only looks at what we depend on.

## Changes

**`SECURITY.md`** — private reporting through GitHub Private Vulnerability Reporting, supported-version table, response expectations kept modest and truthful for a small project, and explicit scope boundaries that redirect Apache NiFi and Apache Pulsar findings upstream to `security@apache.org` rather than absorbing them here.

**`.github/workflows/security-scan.yml`** — weekly Trivy scan of both surfaces, SARIF to the Security tab. The dependency job fails on HIGH/CRITICAL per the issue's "fail on CVSS ≥ 7". The image job is **report-only for now**, deliberately: gating on a base image's upstream CVE tail before that baseline is triaged would leave the job permanently red, which teaches everyone to ignore it. The comment in the workflow says to flip `exit-code` to `'1'` once triaged.

**`.github/workflows/codeql.yml`** — CodeQL for Java on PRs and weekly. Uses an explicit Maven build rather than autobuild, which does not reliably handle a multi-module NAR build.

**`.trivyignore`** — checked in, with a documented format requiring a CVE id, a reason, and a review date per entry. This is the issue's "accepted findings recorded with a reason rather than muted silently".

## Deviations from the issue, and why

**Trivy instead of OWASP Dependency-Check.** Dependency-Check now requires an NVD API key or its database update is rate-limited into failure. Trivy covers both the dependency tree and the image, needs no secret provisioned, and emits SARIF natively. The issue's own framing — "scheduled runs matter more than the specific tools" — supports the substitution.

**The NiFi-parent watch is not here.** The issue's fifth item (report whether a newer `nifi-extension-bundles` parent carries security fixes) is bespoke scripting with no off-the-shelf action. That pin is the one where deferring carries open-ended risk *because the deferral is invisible*, so it deserves its own tracked issue rather than a bullet inside a scanning PR. Filed separately.

**The base-image fix shipped separately** as #200 — it was urgent enough to move on its own, since the `v2.10.0` image has already shipped on a NiFi 2.1.0 base.

## Required manual step

**Private Vulnerability Reporting must be enabled** in Settings → Code security before `SECURITY.md` is accurate — it is currently off, so the control the document tells reporters to use is not visible to them. Enabling secret scanning and push protection at the same time is free on a public repo and worth doing.

## Verification

- YAML validated for all three files.
- `aquasecurity/trivy-action@v0.36.0` and `github/codeql-action@v4` confirmed to resolve.
- Both workflows are `workflow_dispatch`-capable, so they can be exercised immediately after merge rather than waiting a week: `gh workflow run security-scan.yml` and `gh workflow run codeql.yml`, then check the Security tab for two distinct SARIF categories.
