### PR TITLE
fix: keep the base image pinned to nifi.version, not ahead of it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,20 @@ updates:
       docker-all:
         patterns:
           - "*"
+    ignore:
+      # The base image must track `nifi.version`, not lead it: the image ships a
+      # NiFi runtime that loads NARs compiled against that exact NiFi version, and
+      # a mismatch in EITHER direction is an API gap between the platform and its
+      # extensions. Allow patch updates (2.10.x), which are security and bugfix
+      # releases within the same NiFi minor; block minor and major so the base
+      # image only moves when someone deliberately bumps `nifi.version` and the
+      # FROM line together.
+      #
+      # Without this, Dependabot proposed apache/nifi 2.10.0 -> 2.11.0 within
+      # minutes of the docker ecosystem being added, and the auto-merge workflow
+      # armed it - it only holds MAJOR bumps. Neither CI check builds the
+      # docker-image module, so nothing would have caught the desync.
+      - dependency-name: "apache/nifi"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
Follow-up to #200. Closes the gap that PR exposed.

## What happened

#200 added the `docker` ecosystem to Dependabot so the base image pin could not go stale again. It worked immediately — and surfaced the other half of the problem within minutes.

NiFi 2.11.0 exists, so Dependabot opened #202 proposing `apache/nifi 2.10.0 -> 2.11.0`. That is a **semver-minor** bump, and `dependabot-auto-merge.yml` holds only **major** bumps:

```yaml
if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
```

So #202 was auto-approved with auto-merge armed, waiting only on CI. Auto-merge on #202 has been disabled manually; this PR is the durable fix.

## Why a minor bump is wrong here

The published image ships a NiFi runtime that loads NARs compiled against `nifi.version`. A mismatch in **either** direction is an API gap between the platform and the extensions it loads:

- #200 fixed the base **trailing** `nifi.version` by nine minors — which is what shipped in `v2.10.0`.
- This would have started it **leading** by one minor, automatically, on a weekly cadence.

And nothing would have caught it: `ci.yml` builds with `-pl '!docker-image'` and the integration tests do not build the image either, so both required checks pass green regardless of whether the base image and the NARs can actually work together.

## Change

Ignore minor and major updates for `apache/nifi`, allowing patch. Mirrors the existing treatment of `org.apache.nifi:nifi-extension-bundles` in the same file.

- **Patch (2.10.0 → 2.10.1)** — security and bugfix releases within the same NiFi minor. Safe, and exactly what a base image most needs to receive automatically.
- **Minor and major** — held. The base image should move only when someone deliberately bumps `nifi.version` and the `FROM` line together, as a single decision.

This deliberately makes the base image a *trailing* indicator of `nifi.version` rather than an independent dependency, because that is what it actually is.

## Note on #202

#202 should be closed rather than merged. Once this lands, Dependabot will stop reopening it. If NiFi 2.11.0 is wanted, that is a `nifi.version` bump with the `FROM` line moving alongside it — not a base-image-only update.
