### PR TITLE
fix: give the mapped msg.key attribute the decoded key, never base64

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -43,6 +43,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.pulsar.utils.KeyValueTopicSchema;
 import org.apache.nifi.processors.pulsar.utils.PropertyMappingUtils;
 import org.apache.nifi.pulsar.PulsarClientService;
 import org.apache.nifi.pulsar.cache.PulsarConsumerLRUCache;
@@ -52,6 +53,7 @@ import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -320,7 +322,13 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + " identical mapped values are batched together (up to the Consumer Message Batch Size), while a change"
                     + " in any mapped value starts a new FlowFile. Message metadata that is not mapped here (message id,"
                     + " message properties) is added to the FlowFile as 'pulsar.message.id*' / 'pulsar.property.*' attributes"
-                    + " but never splits a batch.")
+                    + " but never splits a batch."
+                    + " Because the mapped values decide batching, mapping __KEY__ puts every distinct key in its own"
+                    + " FlowFile - inexpensive on a low-cardinality key such as a device or tenant id, and expensive on"
+                    + " a high-cardinality one such as an order id."
+                    + " On a topic whose schema is a KeyValue schema with SEPARATED encoding, the key is decoded with the"
+                    + " topic's key schema rather than reported as the base64 that Pulsar's message key metadata holds:"
+                    + " a primitive key becomes its string form and a structured key its JSON rendering.")
             .required(false)
             .addValidator(Validator.VALID)
             .defaultValue("")
@@ -747,10 +755,45 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
      * @return the mapped attribute values of the message (never null, possibly empty)
      */
     protected Map<String, String> getMappedFlowFileAttributes(ProcessContext context, final Message<GenericRecord> msg) {
+        return getMappedFlowFileAttributes(context, msg, null);
+    }
+
+    /**
+     * As {@link #getMappedFlowFileAttributes(ProcessContext, Message)}, decoding the message key against
+     * the topic's schema when one is given.
+     *
+     * @param keyDecoder decodes the key of a KeyValue SEPARATED topic; null to take the key as Pulsar
+     *                   reports it. Must be an instance used for nothing else, and created per batch
+     *                   rather than held on the processor - a decoder shared across concurrent tasks is
+     *                   what caused the silent cross-talk fixed in #195.
+     */
+    protected Map<String, String> getMappedFlowFileAttributes(ProcessContext context,
+            final Message<GenericRecord> msg, final KeyValueTopicSchema keyDecoder) {
         String mappings = context.getProperty(MAPPED_FLOWFILE_ATTRIBUTES).getValue();
 
         return PropertyMappingUtils.getMappedValues(mappings,
-        		(p) -> PULSAR_MESSAGE_KEY.equals(p) ? msg.getKey() : msg.getProperty(p));
+        		(p) -> PULSAR_MESSAGE_KEY.equals(p) ? messageKey(msg, keyDecoder) : msg.getProperty(p));
+    }
+
+    /**
+     * The message key as something a flow can use.
+     * <p>
+     * On a KeyValue SEPARATED topic the key is set through {@code keyBytes()}, and {@code getKey()}
+     * returns its base64 text - so a STRING key of {@code device-1} arrives as {@code ZGV2aWNlLTE=},
+     * which nothing downstream can route or filter on (#198). Where the topic's schema tells us how the
+     * key was written, decode it; otherwise report it exactly as Pulsar does.
+     */
+    private String messageKey(final Message<GenericRecord> msg, final KeyValueTopicSchema keyDecoder) {
+        if (keyDecoder != null && msg.hasKey()) {
+            final SchemaInfo readerSchema = msg.getReaderSchema().map(Schema::getSchemaInfo).orElse(null);
+            final String decoded = keyDecoder.decodeKeyAsText(msg.getKeyBytes(), readerSchema);
+
+            if (decoded != null) {
+                return decoded;
+            }
+        }
+
+        return msg.getKey();
     }
     
     protected boolean isSharedSubscription(ProcessContext context) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.utils.KeyValueTopicSchema;
 import org.apache.nifi.processors.pulsar.utils.MessageBatchAttributes;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -114,8 +115,14 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     // acknowledged once it is, and not at all if it is rolled back
                     final List<Message<GenericRecord>> uncommitted = new ArrayList<>();
 
+                    // One per batch, outside the loop so the schema is parsed once rather than per message,
+                    // and never held on the processor: a decoder shared across concurrent tasks is what
+                    // caused the silent cross-talk fixed in #195. Used only to decode the message key for
+                    // a mapped attribute (#198); this processor does no record shaping of its own.
+                    final KeyValueTopicSchema keyAttributeDecoder = new KeyValueTopicSchema();
+
                     for (Message<GenericRecord> msg : messages) {
-                        currentAttributes = getMappedFlowFileAttributes(context, msg);
+                        currentAttributes = getMappedFlowFileAttributes(context, msg, keyAttributeDecoder);
 
                        if (lastAttributes != null && !lastAttributes.equals(currentAttributes)) {
                             // mapped attributes changed, write the current flowfile and start a new one
@@ -224,8 +231,14 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             // once it is, and not at all if it is rolled back
             final List<Message<GenericRecord>> uncommitted = new ArrayList<>();
 
+            // One per batch, outside the loop so the schema is parsed once rather than per message,
+            // and never held on the processor: a decoder shared across concurrent tasks is what
+            // caused the silent cross-talk fixed in #195. Used only to decode the message key for
+            // a mapped attribute (#198); this processor does no record shaping of its own.
+            final KeyValueTopicSchema keyAttributeDecoder = new KeyValueTopicSchema();
+
             while (loopCounter.get() < maxMessages && (msg = consumer.receive(0, TimeUnit.SECONDS)) != null) {
-                currentAttributes = getMappedFlowFileAttributes(context, msg);
+                currentAttributes = getMappedFlowFileAttributes(context, msg, keyAttributeDecoder);
 
                 if (lastMsg != null && !lastAttributes.equals(currentAttributes)) {
                     IOUtils.closeQuietly(out);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -397,6 +397,10 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         // cheap, and shares nothing.
         final TopicSchemaRecordDecoder topicSchemaDecoder = new TopicSchemaRecordDecoder();
         final KeyValueTopicSchema keyValueDecoder = new KeyValueTopicSchema();
+        // Its own instance, not the one above: this parses under the default field names while the
+        // record decoder parses under the configured ones, and a single decoder alternating between
+        // the two would re-parse the schema on every message.
+        final KeyValueTopicSchema keyAttributeDecoder = new KeyValueTopicSchema();
         final String primitiveField = context.getProperty(PRIMITIVE_VALUE_FIELD).evaluateAttributeExpressions().getValue();
         final String kvKeyField = context.getProperty(KEY_VALUE_KEY_FIELD).evaluateAttributeExpressions().getValue();
         final String kvValueField = context.getProperty(KEY_VALUE_VALUE_FIELD).evaluateAttributeExpressions().getValue();
@@ -405,7 +409,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
         try {
             for (Message<GenericRecord> msg : groupedMessages) {
-                currentAttributes = getMappedFlowFileAttributes(context, msg);
+                currentAttributes = getMappedFlowFileAttributes(context, msg, keyAttributeDecoder);
                 // Introduce an attribute to distinguish between current and previously captured attributes,
                 // particularly when the message originates from a different topic.
                 currentAttributes.put("topicName", getLogicalTopicName(msg.getTopicName()));

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchema.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchema.java
@@ -128,6 +128,56 @@ public class KeyValueTopicSchema {
     }
 
     /**
+     * Decodes only the key of a SEPARATED message, as text for a FlowFile attribute (#198).
+     * <p>
+     * {@code Message.getKey()} returns base64 for a key set through {@code keyBytes()}, so a STRING key
+     * of {@code device-1} surfaces as {@code ZGV2aWNlLTE=} - not wrong so much as unusable, since nothing
+     * downstream can route or filter on it. This gives the decoded key instead: the value's string form
+     * for a primitive key, its JSON rendering for a struct key. Never base64.
+     * <p>
+     * Parses under the default field names, so callers should give this its own instance rather than
+     * sharing the one used for record decoding: a decoder alternating between two sets of field names
+     * would re-parse the schema on every message.
+     * <p>
+     * Never throws. A mapped attribute is not worth failing a message over, so anything undecodable
+     * yields null and leaves the attribute absent - which is also what a key we cannot render as text
+     * (a BYTES key) produces, rather than swapping base64 for some other unusable encoding.
+     *
+     * @param messageKey the message's key bytes; may be null
+     * @param schemaInfo the topic's schema, which need not be a KeyValue schema
+     * @return the decoded key as text, or null if there is none to give
+     */
+    public String decodeKeyAsText(final byte[] messageKey, final SchemaInfo schemaInfo) {
+        if (messageKey == null || !supports(schemaInfo)) {
+            return null;
+        }
+
+        try {
+            parse(schemaInfo, DEFAULT_KEY_FIELD, DEFAULT_VALUE_FIELD);
+
+            // INLINE keeps the key in the payload, so the message's key metadata is not the topic's key
+            // and decoding it against the key schema would be meaningless.
+            if (cachedEncoding != KeyValueEncodingType.SEPARATED) {
+                return null;
+            }
+
+            final Object key = decodeSide(messageKey, cachedKeySchema, cachedKeyType, cachedKeyAvro);
+
+            if (key instanceof Record) {
+                return TopicSchemaRecordDecoder.toJsonText((Record) key, cachedKeyAvro);
+            }
+
+            if (key == null || key instanceof byte[]) {
+                return null;
+            }
+
+            return String.valueOf(key);
+        } catch (final IOException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    /**
      * Encodes a record's key and value fields for this topic.
      *
      * @return the payload, and the message key when the encoding is SEPARATED; the key is null otherwise

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
@@ -227,12 +227,7 @@ public class TopicSchemaRecordDecoder {
             // MapRecord, which Jackson cannot serialize, so any JSON side with a nested record failed to
             // publish. Converting to an Avro record first and writing that gives nesting, unions and
             // logical types the same treatment they get at the top level.
-            final java.io.ByteArrayOutputStream json = new java.io.ByteArrayOutputStream();
-            try (com.fasterxml.jackson.core.JsonGenerator generator =
-                         new com.fasterxml.jackson.core.JsonFactory().createGenerator(json)) {
-                PublisherLease.writeAsJson(generator, avroSchema, avroRecord);
-            }
-            return json.toByteArray();
+            return writeAsJsonBytes(avroSchema, avroRecord);
         }
 
         final java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
@@ -242,6 +237,47 @@ public class TopicSchemaRecordDecoder {
                 .write(avroRecord, encoder);
         encoder.flush();
         return out.toByteArray();
+    }
+
+    /**
+     * Renders a record as JSON text, through the same writer the publish path uses.
+     * <p>
+     * Takes the already-parsed Avro schema rather than a {@link SchemaInfo} so that a caller holding a
+     * cached schema does not re-parse it per message - {@code Schema.Parser().parse} is the expensive
+     * part of handling a small record.
+     *
+     * @param record the record to render
+     * @param avroSchema the parsed Avro schema describing it
+     * @return the record as JSON text
+     * @throws IOException if the record cannot be represented in the schema
+     */
+    public static String toJsonText(final Record record, final org.apache.avro.Schema avroSchema)
+            throws IOException {
+        final org.apache.avro.generic.GenericRecord avroRecord;
+
+        try {
+            avroRecord = AvroTypeUtil.createAvroRecord(record, avroSchema);
+        } catch (final Exception e) {
+            throw new IOException("Unable to convert the record to " + avroSchema.getFullName(), e);
+        }
+
+        return new String(writeAsJsonBytes(avroSchema, avroRecord), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * The one place a record becomes JSON. Shared by {@link #encodeStruct}, which needs the bytes to
+     * publish, and {@link #toJsonText}, which needs the text for a FlowFile attribute.
+     */
+    private static byte[] writeAsJsonBytes(final org.apache.avro.Schema avroSchema,
+            final org.apache.avro.generic.GenericRecord avroRecord) throws IOException {
+        final java.io.ByteArrayOutputStream json = new java.io.ByteArrayOutputStream();
+
+        try (com.fasterxml.jackson.core.JsonGenerator generator =
+                     new com.fasterxml.jackson.core.JsonFactory().createGenerator(json)) {
+            PublisherLease.writeAsJson(generator, avroSchema, avroRecord);
+        }
+
+        return json.toByteArray();
     }
 
     /** The schema the last decoded message was shaped by, for callers that group records into sets. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessorMessageAttributesTest.java
@@ -161,6 +161,60 @@ public class AbstractPulsarConsumerProcessorMessageAttributesTest {
         assertEquals("B", thirdAttributes.get("tenant"));
     }
 
+    // ------------------------------------------------- decoded message key (#198)
+
+    /**
+     * On a KeyValue SEPARATED topic the key is set through keyBytes(), so getKey() reports base64. The
+     * mapped attribute must carry the decoded key instead - a flow cannot route on ZGV2aWNlLTE=.
+     */
+    @Test
+    public void aMappedKeyOnASeparatedTopicIsDecodedNotBase64() {
+        givenMessageProperties(new HashMap<>());
+        testRunner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "msg.key=__KEY__");
+
+        final byte[] keyBytes = org.apache.pulsar.client.api.Schema.STRING.encode("device-1");
+        givenSeparatedKeyValueMessage(keyBytes);
+
+        final Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(
+                testRunner.getProcessContext(), mockMessage,
+                new org.apache.nifi.processors.pulsar.utils.KeyValueTopicSchema());
+
+        assertEquals("device-1", attributes.get("msg.key"));
+    }
+
+    /** Without a decoder - and on any non-KeyValue topic - the key is reported exactly as Pulsar gives it. */
+    @Test
+    public void aMappedKeyIsUnchangedWithoutADecoder() {
+        givenMessageProperties(new HashMap<>());
+        testRunner.setProperty(AbstractPulsarConsumerProcessor.MAPPED_FLOWFILE_ATTRIBUTES, "msg.key=__KEY__");
+        when(mockMessage.getKey()).thenReturn("plain-key");
+
+        final Map<String, String> attributes = processor.testGetMappedFlowFileAttributes(
+                testRunner.getProcessContext(), mockMessage);
+
+        assertEquals("plain-key", attributes.get("msg.key"));
+    }
+
+    private void givenSeparatedKeyValueMessage(final byte[] keyBytes) {
+        final org.apache.pulsar.common.schema.SchemaInfo value =
+                org.apache.pulsar.common.schema.SchemaInfo.builder().name("V")
+                        .type(org.apache.pulsar.common.schema.SchemaType.STRING)
+                        .schema(new byte[0]).build();
+
+        final org.apache.pulsar.common.schema.SchemaInfo kv =
+                org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.encodeKeyValueSchemaInfo("kv",
+                        org.apache.pulsar.client.api.Schema.STRING.getSchemaInfo(), value,
+                        org.apache.pulsar.common.schema.KeyValueEncodingType.SEPARATED);
+
+        final org.apache.pulsar.client.api.Schema<?> schema =
+                org.mockito.Mockito.mock(org.apache.pulsar.client.api.Schema.class);
+        when(schema.getSchemaInfo()).thenReturn(kv);
+
+        when(mockMessage.hasKey()).thenReturn(true);
+        when(mockMessage.getKeyBytes()).thenReturn(keyBytes);
+        when(mockMessage.getReaderSchema()).thenAnswer(i -> java.util.Optional.of(schema));
+    }
+
     // Test processor that extends AbstractPulsarConsumerProcessor for testing purposes
     private static class TestConsumerProcessor extends AbstractPulsarConsumerProcessor<byte[]> {
         @Override
@@ -171,6 +225,11 @@ public class AbstractPulsarConsumerProcessorMessageAttributesTest {
         // Expose protected method for testing
         public Map<String, String> testGetMappedFlowFileAttributes(ProcessContext context, Message<GenericRecord> msg) {
             return getMappedFlowFileAttributes(context, msg);
+        }
+
+        public Map<String, String> testGetMappedFlowFileAttributes(ProcessContext context,
+                Message<GenericRecord> msg, org.apache.nifi.processors.pulsar.utils.KeyValueTopicSchema keyDecoder) {
+            return getMappedFlowFileAttributes(context, msg, keyDecoder);
         }
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchemaTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchemaTest.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.pulsar.utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -194,7 +195,97 @@ public class KeyValueTopicSchemaTest {
         assertTrue(!KeyValueTopicSchema.supports(null));
     }
 
+    // ------------------------------------------------- decodeKeyAsText (#198)
+
+    /**
+     * The issue's own example. Message.getKey() returns base64 for a key set through keyBytes(), so a
+     * STRING key of device-1 surfaced as ZGV2aWNlLTE= and nothing downstream could route on it.
+     */
+    @Test
+    public void aSeparatedStringKeyDecodesToTextRatherThanBase64() {
+        final SchemaInfo info = keyValueSchema(READING, org.apache.pulsar.common.schema.SchemaType.AVRO,
+                KeyValueEncodingType.SEPARATED);
+
+        final String key = schema.decodeKeyAsText(Schema.STRING.encode("device-1"), info);
+
+        assertEquals("device-1", key);
+        assertNotEquals("ZGV2aWNlLTE=", key);
+    }
+
+    @Test
+    public void aSeparatedIntKeyDecodesToItsStringForm() {
+        final SchemaInfo info = keyValueSchemaWithKey(Schema.INT32.getSchemaInfo(), READING,
+                org.apache.pulsar.common.schema.SchemaType.AVRO, KeyValueEncodingType.SEPARATED);
+
+        assertEquals("42", schema.decodeKeyAsText(Schema.INT32.encode(42), info));
+    }
+
+    /**
+     * A struct key is what Pulsar's Debezium connector emits - the changed row's primary key, which is a
+     * record whenever the key is composite. It renders as JSON rather than being dropped.
+     */
+    @Test
+    public void aSeparatedStructKeyDecodesToJson() throws Exception {
+        final SchemaInfo keySchema = SchemaInfo.builder().name("K")
+                .type(org.apache.pulsar.common.schema.SchemaType.AVRO).schema(READING.getBytes(UTF_8)).build();
+
+        final SchemaInfo info = keyValueSchemaWithKey(keySchema, READING,
+                org.apache.pulsar.common.schema.SchemaType.AVRO, KeyValueEncodingType.SEPARATED);
+
+        assertEquals("{\"reading\":7}", schema.decodeKeyAsText(avro(READING, "reading", 7), info));
+    }
+
+    /** INLINE keeps the key in the payload, so the message's key metadata is not the topic's key. */
+    @Test
+    public void anInlineTopicHasNoDecodableMessageKey() {
+        final SchemaInfo info = keyValueSchema(READING, org.apache.pulsar.common.schema.SchemaType.AVRO,
+                KeyValueEncodingType.INLINE);
+
+        assertNull(schema.decodeKeyAsText(Schema.STRING.encode("device-1"), info));
+    }
+
+    @Test
+    public void aNonKeyValueTopicHasNoDecodableMessageKey() {
+        assertNull(schema.decodeKeyAsText(Schema.STRING.encode("device-1"), Schema.STRING.getSchemaInfo()));
+        assertNull(schema.decodeKeyAsText(Schema.STRING.encode("device-1"), null));
+    }
+
+    @Test
+    public void aMessageWithoutAKeyHasNoDecodableMessageKey() {
+        final SchemaInfo info = keyValueSchema(READING, org.apache.pulsar.common.schema.SchemaType.AVRO,
+                KeyValueEncodingType.SEPARATED);
+
+        assertNull(schema.decodeKeyAsText(null, info));
+    }
+
+    /**
+     * A mapped attribute must never be able to fail a message that would otherwise parse.
+     * <p>
+     * Truncated rather than merely wrong bytes: Avro's binary encoding is permissive enough that most
+     * short byte sequences decode to <em>something</em> - {@code {0x00, 0x01}} against this schema
+     * yields {@code {"reading":0}} rather than an error - so only running out of input reliably fails.
+     */
+    @Test
+    public void anUndecodableKeyYieldsNoAttributeRatherThanThrowing() {
+        final SchemaInfo keySchema = SchemaInfo.builder().name("K")
+                .type(org.apache.pulsar.common.schema.SchemaType.AVRO).schema(ORDER.getBytes(UTF_8)).build();
+
+        final SchemaInfo info = keyValueSchemaWithKey(keySchema, READING,
+                org.apache.pulsar.common.schema.SchemaType.AVRO, KeyValueEncodingType.SEPARATED);
+
+        // ORDER needs an int then a nested record holding a string; one byte cannot supply that.
+        assertNull(schema.decodeKeyAsText(new byte[] {0x02}, info));
+    }
+
     // ------------------------------------------------------------------ helpers
+    private static SchemaInfo keyValueSchemaWithKey(final SchemaInfo key, final String valueDefinition,
+            final org.apache.pulsar.common.schema.SchemaType valueType, final KeyValueEncodingType encoding) {
+        final SchemaInfo value = SchemaInfo.builder().name("V").type(valueType)
+                .schema(valueDefinition.getBytes(UTF_8)).build();
+
+        return KeyValueSchemaInfo.encodeKeyValueSchemaInfo("kv", key, value, encoding);
+    }
+
 
     private static SchemaInfo keyValueSchema(final String valueDefinition,
             final org.apache.pulsar.common.schema.SchemaType valueType, final KeyValueEncodingType encoding) {


### PR DESCRIPTION
Closes #198

## Problem

On a KeyValue `SEPARATED` topic the key lives in the message's key metadata, set through `keyBytes()`. `Message.getKey()` returns that as **base64 text**, so a `STRING` key of `device-1` reached a flow as `ZGV2aWNlLTE=`. Nothing downstream can route or filter on that.

The whole defect was one expression in the shared consumer base:

```java
(p) -> PULSAR_MESSAGE_KEY.equals(p) ? msg.getKey() : msg.getProperty(p)
```

This is live in 2.10.0 — the KeyValue + `Topic Schema` combination became reachable in #193.

## The rule

The attribute is always the decoded key: the value's string form for a primitive key, its JSON rendering for a structured one. **Never base64.** One rule regardless of the key schema's type, as settled in the issue — an attribute that appears or vanishes depending on the schema is harder to build a flow against than one that is always present.

## Scope decisions

**Both consume processors.** The broken line is in `AbstractPulsarConsumerProcessor`, so `ConsumePulsar` handed out base64 too. Fixing one would have left the other wrong for the next person to rediscover.

**Triggered by the topic's schema, not by Message Schema Strategy.** Consumers use `Schema.AUTO_CONSUME()`, so the topic's schema is available under every strategy, and base64 is unusable under every strategy. One rule is easier to state, test and document than one whose meaning changes with an unrelated property.

**Structured keys are decoded, not skipped** — verified, not assumed. Pulsar's Debezium connector (`DebeziumSource extends KafkaConnectSource`) wraps the Connect key schema through `KafkaSchemaWrappedSchema`, which builds a `SchemaInfo` of type `AVRO` (or `JSON`), with `getKeyValueEncodingType()` returning `SEPARATED`. For CDC that key is the changed row's primary key — a record whenever the key is composite. So an Avro struct key on a SEPARATED topic is exactly what a first-party connector emits.

## Changes

- **`KeyValueTopicSchema.decodeKeyAsText`** — decodes only the key, reusing the existing `parse` cache and `decodeSide`. Returns `null` rather than throwing: a mapped attribute must never be able to fail a message that would otherwise parse. A key with no text form (BYTES) also yields `null`, leaving the attribute absent rather than swapping base64 for another unusable encoding.
- **`TopicSchemaRecordDecoder.toJsonText`** — the JSON branch of `encodeStruct` extracted so both the publish path and the attribute path render a record through the same writer. No new serialization logic; `writeAsJson` already handles nesting, unions and logical types.
- **`AbstractPulsarConsumerProcessor`** — a three-arg overload taking the decoder; the existing two-arg form delegates with `null` and behaves exactly as before.
- **Call sites** — each processor creates its own decoder **per batch, outside the message loop**, so the schema is parsed once rather than per message and nothing is shared across concurrent tasks. A shared decoder is what caused the silent cross-talk fixed in #195.
- **Docs** — the property description now says that mapping `__KEY__` puts every distinct key in its own FlowFile. Existing behaviour, previously unstated, and expensive on a high-cardinality key.

## Tests

322 pass, up from 313; 9 added.

`KeyValueTopicSchemaTest` — the issue's own example as a regression test (`device-1`, asserted *not* to equal `ZGV2aWNlLTE=`), an `INT32` key, an AVRO struct key rendering as JSON, and the cases that must stay untouched: INLINE topics, non-KeyValue topics, and messages with no key.

`AbstractPulsarConsumerProcessorMessageAttributesTest` — the attribute path end to end, plus a check that without a decoder the key is reported exactly as Pulsar gives it.

One note on the undecodable-key test: Avro's binary encoding is permissive enough that most short byte sequences decode to *something* — `{0x00, 0x01}` against an int-field schema yields `{"reading":0}` rather than an error — so the test uses truncated input against a schema needing more. That permissiveness is also why #207 is worth taking seriously: decoding from the wrong offset is more likely to produce silent nonsense than a clean failure.

## Not in scope

- **#207** — Avro decoding ignores `__AVRO_READ_OFFSET__`, so Kafka Connect / Debezium topics likely decode from the wrong offset. Found while confirming the struct-key case above, affects the value side too, filed separately.
- Narrowing struct keys to decode-only on the **encode** path — agreed separately, its own change.
