### PR TITLE
fix: honour __AVRO_READ_OFFSET__ when decoding Avro (#207)

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/AvroReadOffset.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/AvroReadOffset.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import java.io.IOException;
+
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+/**
+ * How many bytes precede the Avro body in a message (#207).
+ * <p>
+ * A schema may carry {@code __AVRO_READ_OFFSET__}, and Pulsar's own {@code GenericAvroReader} honours it:
+ * it reads the property off the parsed Avro schema and starts its decoder there. The Kafka Connect adaptor
+ * sets it to {@code 5} for Avro — the Confluent wire format's magic byte plus a four-byte schema id — so
+ * every topic fed by a Debezium source carries a five-byte preamble ahead of the record.
+ * <p>
+ * Decoding from byte zero reads that preamble as record data. It rarely fails loudly: Avro's binary
+ * encoding is permissive enough that the wrong bytes usually decode to a plausible-looking record, so the
+ * symptom is wrong values rather than an exception.
+ * <p>
+ * The property is read from the <em>parsed Avro schema</em> first, which is where Pulsar looks and
+ * therefore the authoritative source. {@link SchemaInfo#getProperties()} is consulted as a fallback, since
+ * it costs nothing and a producer that records the offset there rather than in the schema document would
+ * otherwise be silently mishandled. Absent, unparseable or negative all mean zero — today's behaviour, and
+ * the default every topic that is not framed this way depends on.
+ */
+public final class AvroReadOffset {
+
+    static final String PROPERTY = "__AVRO_READ_OFFSET__";
+
+    private AvroReadOffset() {
+    }
+
+    /**
+     * @param avroSchema the parsed schema, which is where Pulsar reads the property from
+     * @param schemaInfo the topic's schema info, consulted only if the schema itself does not carry it
+     * @return the number of bytes to skip, never negative
+     */
+    public static int of(final org.apache.avro.Schema avroSchema, final SchemaInfo schemaInfo) {
+        Object property = avroSchema == null ? null : avroSchema.getObjectProp(PROPERTY);
+
+        if (property == null && schemaInfo != null && schemaInfo.getProperties() != null) {
+            property = schemaInfo.getProperties().get(PROPERTY);
+        }
+
+        if (property == null) {
+            return 0;
+        }
+
+        try {
+            final int offset = Integer.parseInt(property.toString().trim());
+            return Math.max(offset, 0);
+        } catch (final NumberFormatException e) {
+            // A schema we cannot understand should not stop the topic being read the way it always was.
+            return 0;
+        }
+    }
+
+    /**
+     * Checks the payload is long enough for the offset before decoding.
+     *
+     * @throws IOException if the message is shorter than its schema says the preamble is, which means the
+     *                     message and the schema disagree - worth failing on rather than decoding whatever
+     *                     the arithmetic happens to produce
+     */
+    public static void check(final int offset, final byte[] data) throws IOException {
+        if (offset > data.length) {
+            throw new IOException("The schema declares a read offset of " + offset + " bytes but the message "
+                    + "is only " + data.length + " bytes long");
+        }
+    }
+}

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchema.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/KeyValueTopicSchema.java
@@ -301,9 +301,15 @@ public class KeyValueTopicSchema {
                 return org.apache.nifi.serialization.record.util.DataTypeUtils.toRecord(values, schema, null);
             }
 
+            // Each side carries its own read offset, so a KeyValue topic from the Kafka Connect adaptor
+            // frames the value (and the key, when its schema is Avro) independently (#207).
+            final int offset = AvroReadOffset.of(avroSchema, side);
+            AvroReadOffset.check(offset, data);
+
             final org.apache.avro.generic.GenericRecord avroRecord =
                     new org.apache.avro.generic.GenericDatumReader<org.apache.avro.generic.GenericRecord>(avroSchema)
-                            .read(null, org.apache.avro.io.DecoderFactory.get().binaryDecoder(data, null));
+                            .read(null, org.apache.avro.io.DecoderFactory.get()
+                                    .binaryDecoder(data, offset, data.length - offset, null));
 
             return new MapRecord(schema, AvroTypeUtil.convertAvroRecordToMap(avroRecord, schema));
         }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoder.java
@@ -74,9 +74,12 @@ public class TopicSchemaRecordDecoder {
         private final String primitiveField;
         private final org.apache.avro.Schema avroSchema;
         private final RecordSchema recordSchema;
+        private final SchemaInfo schemaInfo;
 
         private Parsed(final String definition, final SchemaType type, final String primitiveField,
-                final org.apache.avro.Schema avroSchema, final RecordSchema recordSchema) {
+                final org.apache.avro.Schema avroSchema, final RecordSchema recordSchema,
+                final SchemaInfo schemaInfo) {
+            this.schemaInfo = schemaInfo;
             this.definition = definition;
             this.type = type;
             this.primitiveField = primitiveField;
@@ -147,7 +150,7 @@ public class TopicSchemaRecordDecoder {
         if (current == null || !current.matches(definition, schemaInfo.getType(), null)) {
             final org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(definition);
             current = new Parsed(definition, schemaInfo.getType(), null, avroSchema,
-                    AvroTypeUtil.createSchema(avroSchema));
+                    AvroTypeUtil.createSchema(avroSchema), schemaInfo);
             parsed = current;
         }
 
@@ -159,8 +162,13 @@ public class TopicSchemaRecordDecoder {
         final GenericDatumReader<org.apache.avro.generic.GenericRecord> datumReader =
                 new GenericDatumReader<>(current.avroSchema);
 
-        final org.apache.avro.generic.GenericRecord avroRecord =
-                datumReader.read(null, DecoderFactory.get().binaryDecoder(data, null));
+        // The body may not start at byte zero: a schema fed through the Kafka Connect adaptor declares a
+        // preamble ahead of it (#207). Zero when the schema says nothing, which is every other topic.
+        final int offset = AvroReadOffset.of(current.avroSchema, current.schemaInfo);
+        AvroReadOffset.check(offset, data);
+
+        final org.apache.avro.generic.GenericRecord avroRecord = datumReader.read(null,
+                DecoderFactory.get().binaryDecoder(data, offset, data.length - offset, null));
 
         return new MapRecord(current.recordSchema,
                 AvroTypeUtil.convertAvroRecordToMap(avroRecord, current.recordSchema));
@@ -190,7 +198,7 @@ public class TopicSchemaRecordDecoder {
 
         if (current == null || !current.matches(null, type, fieldName)) {
             current = new Parsed(null, type, fieldName, null, new SimpleRecordSchema(Collections.singletonList(
-                    new RecordField(fieldName, PrimitiveTopicSchema.dataTypeOf(type)))));
+                    new RecordField(fieldName, PrimitiveTopicSchema.dataTypeOf(type)))), null);
             parsed = current;
         }
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/AvroReadOffsetIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/AvroReadOffsetIT.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.Test;
+
+/**
+ * Topics whose registered schema declares {@code __AVRO_READ_OFFSET__} (#207), read through a real broker.
+ * <p>
+ * The unit test in {@code TopicSchemaRecordDecoderTest} proves the decoder honours the property when it is
+ * handed one. What it cannot prove is the part that involves the broker: that a schema carrying a
+ * non-standard property survives registration, comes back on {@code AUTO_CONSUME}'s reader schema with the
+ * property intact, and is therefore visible to the decoder at all. A property that the broker silently
+ * dropped would leave the unit test passing and production still broken.
+ * <p>
+ * The framing here is written by hand rather than by a Debezium source: a magic byte and a four-byte
+ * schema id ahead of the Avro body, which is what the Kafka Connect adaptor emits and why it sets the
+ * property to 5. Confirming that a real Debezium source emits exactly this is not covered - that still
+ * rests on reading the adaptor's code.
+ */
+public class AvroReadOffsetIT extends AbstractPulsarIT {
+
+    private static final int RECORDS = 5;
+
+    /** The Confluent wire format's preamble: one magic byte, then a four-byte big-endian schema id. */
+    private static final int PREAMBLE = 5;
+
+    private static final String SENSOR_FIELDS = "\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"reading\",\"type\":\"int\"}]";
+
+    private static final String FRAMED_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"Sensor\",\"__AVRO_READ_OFFSET__\":\"5\"," + SENSOR_FIELDS + "}";
+
+    private static final String PLAIN_SCHEMA =
+            "{\"type\":\"record\",\"name\":\"Sensor\"," + SENSOR_FIELDS + "}";
+
+    /**
+     * The case from the issue: the topic's schema says the body starts five bytes in, and it does. Asserted
+     * on decoded values rather than on the absence of a failure - decoding from byte zero yields a
+     * plausible record rather than an error, so a test that only checked for parse failures would pass
+     * against the bug.
+     */
+    @Test
+    public void aFramedTopicIsDecodedPastItsPreamble() throws Exception {
+        final String topic = registeredTopic("framed", FRAMED_SCHEMA);
+        publishFramed(topic, PREAMBLE);
+
+        final TestRunner consumer = consumer(topic, "framed");
+        assertEquals(RECORDS, consumeRecords(consumer, RECORDS));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+
+        final String content = successContent(consumer);
+        for (int seq = 1; seq <= RECORDS; seq++) {
+            assertTrue("record " + seq + " should have decoded its real id, got " + content,
+                    content.contains("\"sensor-" + seq + "\""));
+            assertTrue("and its real reading", content.contains("\"reading\":" + (seq * 10)));
+        }
+    }
+
+    /**
+     * The control, and the thing that must not regress: a topic whose schema declares no offset is still
+     * read from byte zero. Almost every topic is this one.
+     */
+    @Test
+    public void aTopicWithoutTheOffsetPropertyIsUnaffected() throws Exception {
+        final String topic = registeredTopic("plain", PLAIN_SCHEMA);
+        publishFramed(topic, 0);
+
+        final TestRunner consumer = consumer(topic, "plain");
+        assertEquals(RECORDS, consumeRecords(consumer, RECORDS));
+        consumer.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 0);
+        assertTrue(successContent(consumer).contains("\"sensor-1\""));
+    }
+
+    /**
+     * The property has to survive the round trip through the schema registry to be of any use. Read back
+     * from the broker rather than from the constant this test wrote, so a broker that dropped or rewrote
+     * the property would fail here rather than silently reducing the test above to a no-op.
+     */
+    @Test
+    public void theOffsetPropertySurvivesSchemaRegistration() throws Exception {
+        final String topic = registeredTopic("survives", FRAMED_SCHEMA);
+
+        // read back through the admin API rather than a consumer: a reader schema only appears once a
+        // message has been received, and this asserts about registration itself
+        final org.testcontainers.containers.Container.ExecResult result =
+                PULSAR.execInContainer("bin/pulsar-admin", "schemas", "get", topic);
+        final String output = result.getStdout() + result.getStderr();
+
+        assertTrue("the broker should have kept __AVRO_READ_OFFSET__, but returned:\n" + output,
+                output.contains("__AVRO_READ_OFFSET__"));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    /** Registers {@code definition} on a fresh topic by creating a producer that carries it. */
+    private static String registeredTopic(final String name, final String definition) throws Exception {
+        final String topic = "persistent://public/default/avro-offset-" + name + "-" + System.nanoTime();
+
+        final SchemaInfo info = SchemaInfo.builder().name("Sensor").type(SchemaType.AVRO)
+                .schema(definition.getBytes(UTF_8)).build();
+
+        try (Producer<GenericRecord> registrar = getClient().newProducer(Schema.generic(info)).topic(topic).create()) {
+            // creating the producer is what registers the schema; nothing needs to be sent through it
+            registrar.getTopic();
+        }
+
+        return topic;
+    }
+
+    /**
+     * Publishes {@link #RECORDS} Avro records with {@code preamble} bytes of framing ahead of each body,
+     * through a plain bytes producer - the same shape the Kafka Connect adaptor puts on the wire.
+     */
+    private static void publishFramed(final String topic, final int preamble) throws Exception {
+        final org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(PLAIN_SCHEMA);
+
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            for (int seq = 1; seq <= RECORDS; seq++) {
+                final org.apache.avro.generic.GenericData.Record record =
+                        new org.apache.avro.generic.GenericData.Record(avroSchema);
+                record.put("id", "sensor-" + seq);
+                record.put("reading", seq * 10);
+
+                final ByteArrayOutputStream body = new ByteArrayOutputStream();
+                final org.apache.avro.io.BinaryEncoder encoder =
+                        org.apache.avro.io.EncoderFactory.get().binaryEncoder(body, null);
+                new org.apache.avro.generic.GenericDatumWriter<org.apache.avro.generic.GenericRecord>(avroSchema)
+                        .write(record, encoder);
+                encoder.flush();
+
+                final byte[] encoded = body.toByteArray();
+                final byte[] framed = new byte[preamble + encoded.length];
+
+                if (preamble >= PREAMBLE) {
+                    framed[0] = 0x00;                       // magic byte
+                    framed[4] = (byte) (seq & 0xFF);        // schema id, low byte varied per message
+                }
+
+                System.arraycopy(encoded, 0, framed, preamble, encoded.length);
+                producer.send(framed);
+            }
+        }
+    }
+
+    private TestRunner consumer(final String topic, final String subscription) throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(ConsumePulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(ConsumePulsarRecord.MESSAGE_SCHEMA_STRATEGY, "Topic Schema");
+        runner.setProperty(ConsumePulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, subscription);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "100");
+        runner.setProperty(ConsumePulsarRecord.MAX_WAIT_TIME, "0 sec");
+        return runner;
+    }
+
+    private static String successContent(final TestRunner runner) {
+        final StringBuilder content = new StringBuilder();
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+            content.append(new String(flowFile.toByteArray(), UTF_8));
+        }
+        return content.toString();
+    }
+
+    private static int consumeRecords(final TestRunner runner, final int expected) throws Exception {
+        final int[] records = {0};
+        runner.run(1, false, true);
+        await(expected + " records to be consumed", () -> {
+            runner.run(1, false, false);
+            records[0] = 0;
+            for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsarRecord.REL_SUCCESS)) {
+                records[0] += Integer.parseInt(flowFile.getAttribute("record.count"));
+            }
+            return records[0] >= expected;
+        });
+        runner.run(1, true, false);
+        return records[0];
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/TopicSchemaRecordDecoderTest.java
@@ -188,6 +188,47 @@ public class TopicSchemaRecordDecoderTest {
         };
     }
 
+    /**
+     * A schema carrying {@code __AVRO_READ_OFFSET__} says how many bytes precede the Avro body (#207).
+     * <p>
+     * Pulsar's own {@code GenericAvroReader} honours it by reading the property off the parsed Avro schema
+     * and starting the decoder there. The Kafka Connect adaptor sets it to 5 for Avro - the Confluent wire
+     * format's magic byte plus a four-byte schema id - so every Debezium-sourced topic carries a five-byte
+     * preamble. Decoding from byte zero reads the preamble as record data.
+     * <p>
+     * The assertion is on the decoded values rather than on "no exception" deliberately: Avro's binary
+     * encoding is permissive enough that a wrong offset usually yields a plausible record instead of an
+     * error, which is what makes this silent.
+     */
+    @Test
+    public void anAvroReadOffsetSkipsThePreamble() throws Exception {
+        final String withOffset = "{\"type\":\"record\",\"name\":\"Sensor\",\"__AVRO_READ_OFFSET__\":\"5\","
+                + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"},"
+                + "{\"name\":\"reading\",\"type\":\"int\"}]}";
+
+        // the Confluent preamble the adaptor prepends: magic byte 0x00 then a four-byte schema id
+        final byte[] body = avroBytes("sensor-9", 99);
+        final byte[] framed = new byte[5 + body.length];
+        framed[0] = 0x00;
+        framed[1] = 0x00; framed[2] = 0x00; framed[3] = 0x00; framed[4] = 0x2A;
+        System.arraycopy(body, 0, framed, 5, body.length);
+
+        final Record record = decoder.decode(framed, SchemaInfo.builder().name("Sensor")
+                .type(SchemaType.AVRO).schema(withOffset.getBytes(UTF_8)).build());
+
+        assertEquals("sensor-9", record.getValue("id"));
+        assertEquals(99, record.getValue("reading"));
+    }
+
+    /** No property means offset zero, which is what every topic not fed through the adaptor relies on. */
+    @Test
+    public void aSchemaWithoutTheOffsetPropertyStillDecodesFromByteZero() throws Exception {
+        final Record record = decoder.decode(avroBytes("sensor-1", 42), schemaInfo(SchemaType.AVRO));
+
+        assertEquals("sensor-1", record.getValue("id"));
+        assertEquals(42, record.getValue("reading"));
+    }
+
     // ------------------------------------------------------------------ helpers
 
     private static SchemaInfo schemaInfo(final SchemaType type) {


### PR DESCRIPTION
Addresses #207.

## Confirmed before writing anything

- `__AVRO_READ_OFFSET__` is real and Pulsar honours it — `GenericAvroReader` reads it and starts its decoder there.
- This bundle never referenced it; both decode sites started at byte zero.

## Why it is silent

Against the unfixed decoder, end to end through a real broker — five framed messages published, all five consumed:

```
[{"id":"","reading":0},{"id":"","reading":0},{"id":"","reading":0},{"id":"","reading":0},{"id":"","reading":0}]
```

Every field empty or zero, **routed to `success`, no parse failures**. Avro's binary encoding is permissive enough that the wrong bytes decode to a plausible record rather than failing, and `ConsumePulsarRecord` treats a decode failure as a fallback — so both paths are quiet. The tests therefore assert decoded field values, not absence of a throw; a test checking only for parse failures would pass against the bug.

## One correction to the fix proposed on the issue

The issue suggests reading the property from `SchemaInfo.getProperties()`. Pulsar reads it from the **parsed Avro schema**:

```
113: ldc  #128  // String __AVRO_READ_OFFSET__
115: invokevirtual  Schema.getObjectProp:(Ljava/lang/String;)Ljava/lang/Object;
```

Following that suggestion would have produced a fix that compiled, passed a test built on the same assumption, and did nothing in production — the same failure mode as the bug. This reads the Avro schema property first, matching Pulsar, and falls back to `SchemaInfo` properties, which costs nothing and covers a producer that records it there instead.

Absent, unparseable or negative all mean offset 0 — today's behaviour, and what every topic not framed this way depends on.

## The fix

- Both decode sites: the record path, and **each side of a KeyValue topic independently**, since a KeyValue schema frames key and value separately.
- A message shorter than its declared offset fails rather than decoding whatever the arithmetic produces — message and schema disagree, which is worth surfacing.

## Tests

**`TopicSchemaRecordDecoderTest`** — the fast regression, so it runs in CI's Build & Test job and not only behind Docker.

**`AvroReadOffsetIT`** — against a real broker, because the unit test cannot prove the part that involves one: that a schema carrying a non-standard property survives registration and returns on `AUTO_CONSUME`'s reader schema intact. A broker that dropped it would leave the unit test passing and production broken. Three tests: a framed topic decoded past its preamble; a topic with no offset property still read from byte zero; and the property read back from the broker, so a broker that dropped it fails loudly instead of quietly reducing the first test to a no-op.

Fail-first, with the offset lookup neutralised: **1 of 3 fails**. The other two are controls and correctly do not depend on the fix.

**324 unit tests and 70 integration tests green**, rebased on `64755dd` so #208's `decodeKeyAsText` / `toJsonText` and this coexist.

## Scope note

The issue asked for a **CDC-backed** integration test with a real Debezium source. David decided to take this smaller broker-backed IT for now instead. So what remains unverified is narrow but real: that a live Debezium source emits exactly this framing. The preamble here is written by hand from the Kafka Connect adaptor's documented behaviour — magic byte plus four-byte schema id — rather than observed from a running CDC stack. Worth keeping on #207 rather than closing it silently.
