### PR TITLE
chore: build for NiFi 2.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
       # The base image must track `nifi.version`, not lead it: the image ships a
       # NiFi runtime that loads NARs compiled against that exact NiFi version, and
       # a mismatch in EITHER direction is an API gap between the platform and its
-      # extensions. Allow patch updates (2.10.x), which are security and bugfix
+      # extensions. Allow patch updates (2.11.x), which are security and bugfix
       # releases within the same NiFi minor; block minor and major so the base
       # image only moves when someone deliberately bumps `nifi.version` and the
       # FROM line together.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 | Bundle version | NiFi | Pulsar client | Java |
 |---|---|---|---|
+| `2.11.0` | 2.11.0 | 4.2.4 | 21 |
 | `2.10.0` | 2.10.0 | 4.2.4 | 21 |
 | `2.9.0` | 2.9.0 | 4.2.2 | 21 |
 | `2.1.0` | 2.1.0 | 3.3.7 | 21 |
@@ -16,8 +17,10 @@ The bundle version tracks the NiFi platform version it is built for; each releas
 line targets one Pulsar client major. See [VERSIONING.md](VERSIONING.md) for the
 full scheme, branching model, and release process.
 
-Release notes live in [`docs/release-notes/`](docs/release-notes/). `2.10.0` carries
-several behaviour changes — see [its notes](docs/release-notes/2.10.0.md) before upgrading.
+Release notes live in [`docs/release-notes/`](docs/release-notes/). `2.11.0` is a
+platform bump — see [its notes](docs/release-notes/2.11.0.md). If you are coming from
+`2.9.0` or earlier, read [the `2.10.0` notes](docs/release-notes/2.10.0.md) too: that
+release carries several behaviour changes.
 
 ## Consumer FlowFile attributes
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -78,6 +78,8 @@ truth — nothing needs to be committed beforehand.
 
 | Bundle version | NiFi | Pulsar client | Java |
 |---|---|---|---|
+| `2.11.0` | 2.11.0 | 4.2.4 | 21 |
+| `2.10.0` | 2.10.0 | 4.2.4 | 21 |
 | `2.9.0` | 2.9.0 | 4.2.2 | 21 |
 | `2.1.0` | 2.1.0 | 3.3.7 | 21 |
 

--- a/docker-image/src/main/docker/nifi/Dockerfile
+++ b/docker-image/src/main/docker/nifi/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM apache/nifi:2.10.0
+FROM apache/nifi:2.11.0
 
 #############################################################################
 # Add the custom NAR files

--- a/docs/release-notes/2.11.0.md
+++ b/docs/release-notes/2.11.0.md
@@ -1,0 +1,57 @@
+# 2.11.0
+
+Built for **NiFi 2.11.0** against the **Pulsar 4.2.4** client. Java 21.
+
+A small release: the platform moves from NiFi 2.10.0 to 2.11.0, and one consumer
+attribute changes shape. The Pulsar client is unchanged from `2.10.0`.
+
+## Platform
+
+**NiFi 2.11.0.** The NARs are compiled against the 2.11.0 API and the published
+container image is built `FROM apache/nifi:2.11.0`. Load these NARs into a NiFi
+2.11.0 runtime — the bundle tracks one platform version per release line, and a
+mismatch in either direction is an API gap between the platform and its extensions.
+
+## Behaviour changes
+
+**The mapped `msg.key` attribute now carries the decoded key, never base64 (#198).**
+On a KeyValue `SEPARATED` topic the key travels in the message's key metadata, and
+`Message.getKey()` renders that as base64 — a `STRING` key of `device-1` reached a
+flow as `ZGV2aWNlLTE=`, which nothing downstream could route or filter on. The
+attribute is now always the decoded key: the value's string form for a primitive
+key, its JSON rendering for a structured one, under every *Message Schema Strategy*.
+
+Flows that worked around the old value — decoding base64 downstream, or matching on
+the encoded text — must drop that step. Flows on topics with no key schema are
+unaffected: those keys were never base64 to begin with.
+
+`ConsumePulsar` and `ConsumePulsarRecord` behave alike here; both handed out base64
+before. An undecodable key leaves the attribute absent rather than failing the
+message.
+
+## Documentation
+
+Mapping `__KEY__` in *Mapped FlowFile Attributes* puts every distinct key in its own
+FlowFile. That has always been true and is how attribute-based batching works, but it
+was unstated — and it is expensive on a high-cardinality key. It is now documented on
+the property.
+
+## Maintenance
+
+A security policy and a scheduled dependency vulnerability scan (#197). A scheduled
+report on what the pinned NiFi parent POM is holding back (#206) — the parent stays on
+`2.1.0` because a newer one bans JUnit 4 and forces a JUnit 4 → 5 migration, and that
+deferral now has something watching it rather than being silently forgotten.
+
+The container base image is pinned to `nifi.version` and moves only when that property
+moves, so the image can no longer drift ahead of the NARs it ships.
+
+## Upgrading
+
+Move the runtime to NiFi 2.11.0 and drop in the new NARs. No configuration change is
+required. If you consume from a KeyValue `SEPARATED` topic and map `msg.key`, check
+whether anything downstream was decoding that value itself — see the behaviour change
+above.
+
+Coming from `2.9.0` or earlier? Read [the `2.10.0` notes](2.10.0.md) first: that
+release carries several behaviour changes.

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <jackson-core.version>2.22.2</jackson-core.version>
         <junit.version>4.13.2</junit.version>
         <mockito-core.version>5.23.0</mockito-core.version>
-        <nifi.version>2.10.0</nifi.version>
+        <nifi.version>2.11.0</nifi.version>
         <protobuf3.version>4.36.0</protobuf3.version>
         <pulsar.version>4.2.4</pulsar.version>
         <slf4j-simple.version>2.0.18</slf4j-simple.version>


### PR DESCRIPTION
Moves the platform from NiFi 2.10.0 to 2.11.0 so a `v2.11.0` release can be cut.
The Pulsar client is unchanged at 4.2.4, so this is a platform bump and nothing
else — `nifi.version` drives every NiFi coordinate in the build.

### What changed

- **`nifi.version` 2.10.0 → 2.11.0.** One property, 14 coordinates across the modules.
- **`Dockerfile` `FROM apache/nifi:2.11.0`.** That tag is pinned literally rather than
  templated from `nifi.version` so Dependabot can see it, which means the two only stay
  in step if they are bumped together. The image ships the runtime that loads NARs
  compiled against this exact NiFi version, and a mismatch in *either* direction is an
  API gap between the platform and its extensions. Confirmed the tag exists and is
  multi-arch (linux/amd64 + linux/arm64).
- **`.github/dependabot.yml`** — the base-image ignore rationale allowed "patch updates
  (2.10.x)"; now 2.11.x, for the same reason the rule exists.
- **Compatibility matrices.** README gains a `2.11.0` row. `VERSIONING.md` had silently
  drifted — it never received the `2.10.0` row README has — so it gains **both**, and the
  two tables agree again.
- **`docs/release-notes/2.11.0.md`.**

### Scope

Deliberately excluded, to keep a platform-version release free of unrelated risk:

- **#204** bundles this same NiFi bump with a **testcontainers 1.21.3 → 2.0.5 major**,
  which is why auto-merge held it. Once this merges, #204 rebases down to just
  testcontainers + failsafe and can be assessed on its own — TC 2.x moves `PulsarContainer`
  between modules and needs the IT suite re-proven.
- **#211** (`__AVRO_READ_OFFSET__`) lands after this release, shipping in `2.11.0.1`.

### Verification

- `mvn clean package` — clean.
- `mvn test` — **322/322 pass** on NiFi 2.11.0.
- `mvn -B -ntp verify -Dgpg.skip=true -pl nifi-pulsar-processors -am` (the exact CI
  command) — **67/67 integration tests pass** against a real Pulsar broker via
  Testcontainers. BUILD SUCCESS.

Note: plain `mvn verify` fails locally on `maven-gpg-plugin` before any test runs when no
signing key is present; CI passes `-Dgpg.skip=true`. Environmental, not a code failure.

### After merge

`main` is ready to cut the release — push tag `v2.11.0` and `release.yml` stamps the pom
from the tag, builds the NARs, publishes the GitHub Release, and pushes the image to GHCR.

#203 (actions/setup-java v5 → v6) was handled as part of this effort and merged
separately as 4df339a; this branch is rebased on top of it.
