### PR TITLE
feat: close the producer and consumer configuration gaps (#186, #187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,50 @@ starts a new record set - and a new FlowFile - just as a change in the mapped at
 > fields, give the reader an explicit schema (*Schema Text* or a schema registry): every message
 > then resolves to the same schema and the batch stays one FlowFile.
 
+## Failure handling and redelivery
+
+A consumed message leaves the processor by exactly one of three routes, and which one it took
+decides whether Pulsar ever delivers it again.
+
+| What happened | Route | Redelivered? |
+|---|---|---|
+| The message reached a FlowFile | `success`, acknowledged | No |
+| Its content could not be parsed | `parse_failure`, acknowledged | No |
+| It could not be written at all | rolled back, **negatively acknowledged** | Yes, promptly |
+| The Pulsar client itself failed | rolled back, left unacknowledged | Yes, after *Acknowledgment Timeout* |
+
+Acknowledgement happens only after the FlowFile carrying the message is committed, so a message
+is never acknowledged while its content could still be discarded.
+
+The third row is the one to know about. When the processor cannot write a message into a FlowFile
+— a full content repository, a permissions problem, a disk fault — it rolls the session back and
+**negatively acknowledges** the message, which asks the broker to redeliver it now. Without that
+the message is merely unacknowledged, and the broker cannot tell a consumer that has failed from
+one that is still working: it waits out *Acknowledgment Timeout*, thirty seconds by default and
+never less than ten. Set *Negative Acknowledgment Redelivery Delay* to control how soon; it
+defaults to Pulsar's own one minute.
+
+A message routed to `parse_failure` is **not** redelivered. It was delivered and handled — the
+flow has its bytes and can route them anywhere, including back to a Pulsar topic — so nacking it
+would hand the same content to the flow twice.
+
+### Dead letter topics
+
+Set *Max Redelivery Count* to attach a dead letter policy. Once a message has been redelivered
+more times than that, the broker moves it to a dead letter topic instead of delivering it again,
+so a message the flow can never accept stops blocking the subscription and is still there to
+inspect. *Dead Letter Topic* names the destination; leave it unset for the broker's own
+`<topic>-<subscription>-DLQ`.
+
+It is unset by default, so the broker redelivers indefinitely unless you ask otherwise. Two
+constraints worth knowing before you reach for it:
+
+- Pulsar builds a dead letter policy only for `Shared` and `Key_Shared` subscriptions. The
+  processor rejects the combination at validation rather than let a flow watch a dead letter
+  topic that can never receive anything.
+- It catches only messages that never reached the flow. A parse failure is acknowledged, so it
+  goes to `parse_failure` and never to the dead letter topic.
+
 ## Publisher message metadata
 
 `PublishPulsar` and `PublishPulsarRecord` set the message key and message properties from the
@@ -107,6 +151,12 @@ either mode, so keyed messages keep their order per key regardless of the settin
 validation. *Max Pending Messages* bounds the producer's queue of messages awaiting the
 broker's acknowledgement.
 
+*Hashing Scheme* picks the hash used to turn a key into a partition. It has to match every other
+producer writing the topic: two producers using different schemes send the same key to different
+partitions, which silently breaks per-key ordering for anything consuming it. `JavaStringHash`
+is the Java client's default and so this bundle's; `Murmur3_32Hash` is the cross-language one, and
+is what to use when clients in other languages also write the topic.
+
 > **Behaviour change since `2.9.0`:** neither property reached the producer since the publish
 > processors were refactored in 2023 — the producer always ran with the client defaults. A flow
 > that has *Message Routing Mode* set to `SinglePartition` will now really route its unkeyed
@@ -124,6 +174,24 @@ broker's acknowledgement.
 > against a remote or loaded broker than in testing. If you publish large FlowFiles asynchronously,
 > either raise *Max Pending Messages*, set it to `0` to restore the previous unbounded behaviour, or
 > enable *Block if Message Queue Full* so sends wait instead of failing.
+
+## Producer behaviour
+
+*Send Timeout* bounds how long a single send may take. A message the broker has not acknowledged
+within it fails, and its FlowFile is routed to `failure`. It defaults to 30 seconds; set it to `0`
+to wait indefinitely, which is what a flow that must never drop a message wants — and what
+Pulsar's broker-side deduplication requires.
+
+*Producer Access Mode* is how you stop two flows writing the same topic. `Shared`, the default,
+lets any number of producers write. `Exclusive` fails at producer creation if another producer
+already holds the topic; `WaitForExclusive` queues until it can take over; `ExclusiveWithFencing`
+evicts the incumbent and takes the topic.
+
+*Batch Builder* decides how messages are grouped when *Batching Enabled* is on. `Default` fills a
+batch with whatever is pending, interleaving keys. **`Key based` is required for per-key ordering
+on a `Key_Shared` subscription**: a consumer receives a whole batch at a time, so a batch spanning
+several keys hands one consumer messages belonging to another consumer's key range. It has no
+effect when batching is off.
 
 ## Consuming from topics that have a schema
 

--- a/docs/release-notes/2.11.0.md
+++ b/docs/release-notes/2.11.0.md
@@ -2,8 +2,10 @@
 
 Built for **NiFi 2.11.0** against the **Pulsar 4.2.4** client. Java 21.
 
-A small release: the platform moves from NiFi 2.10.0 to 2.11.0, and one consumer
-attribute changes shape. The Pulsar client is unchanged from `2.10.0`.
+The platform moves from NiFi 2.10.0 to 2.11.0, and both halves of the bundle gain configuration
+they were missing. The consumer can now tell the broker when it could not take a message, and can
+be given a dead letter topic. The producer exposes four client settings it never has. The Pulsar
+client is unchanged from `2.10.0`.
 
 ## Platform
 
@@ -29,6 +31,69 @@ unaffected: those keys were never base64 to begin with.
 before. An undecodable key leaves the attribute absent rather than failing the
 message.
 
+## New
+
+**Failed deliveries are negatively acknowledged (#187).** When the processor cannot write a
+message into a FlowFile — a full content repository, a permissions problem, a disk fault — it
+rolls the session back, and until now that was all it did. The message stayed on the
+subscription, so nothing was ever lost, but the broker had no way to tell a consumer that had
+failed from one still working: it waited out *Acknowledgment Timeout*, thirty seconds by
+default and never less than ten. Every write error stalled that batch for the full timeout.
+
+The processor now negatively acknowledges those messages, so the broker redelivers them at
+once. *Negative Acknowledgment Redelivery Delay* controls how soon; it defaults to Pulsar's own
+one minute, and can be set to redeliver sooner.
+
+This applies only to messages that never reached the flow. A message written to a FlowFile is
+acknowledged as before, including one routed to `parse_failure` — that message was delivered
+and handled, and redelivering it would hand the same content to the flow twice.
+
+One case is deliberately left alone: when the failure is the Pulsar client itself, the call
+that would carry the negative acknowledgement is the call that just failed. Those messages
+still fall back to *Acknowledgment Timeout*, which is the right mechanism for a broken
+connection.
+
+**Dead letter topics (#187).** Setting *Max Redelivery Count* attaches a dead letter policy:
+once a message has been redelivered more times than that, the broker moves it to a dead letter
+topic instead of delivering it again, so a message the flow can never accept stops blocking the
+subscription and is still there to look at. *Dead Letter Topic* names the destination; leave it
+unset for the broker's own `<topic>-<subscription>-DLQ`.
+
+Unset by default, so existing flows are unchanged and the broker redelivers indefinitely as
+before. Pulsar builds a dead letter policy only for `Shared` and `Key_Shared` subscriptions, and
+the processor now **rejects the combination at validation** rather than starting a flow that
+watches a dead letter topic which can never receive anything — the same call 2.10.0 made for
+`CustomPartition`.
+
+**Producer settings that were never exposed (#186).** Four properties on `PublishPulsar` and
+`PublishPulsarRecord`, all of which the client supported and none of which could be reached:
+
+- ***Send Timeout*** — how long a send may take before it fails. Previously fixed at the client
+  default of 30 seconds with no way to fail faster, wait longer, or set `0` to wait indefinitely,
+  which is what Pulsar's broker-side deduplication requires.
+- ***Producer Access Mode*** — `Shared`, `Exclusive`, `WaitForExclusive`, `ExclusiveWithFencing`.
+  Exclusive access is how you stop two flows writing the same topic.
+- ***Hashing Scheme*** — `JavaStringHash` or `Murmur3_32Hash`. This has to match every other
+  producer on a partitioned topic; a mismatch sends the same key to different partitions and
+  silently breaks per-key ordering.
+- ***Batch Builder*** — `Key based` keeps same-key messages in one batch, which per-key ordering on
+  a `Key_Shared` subscription requires, since a consumer receives a whole batch at a time. The
+  default interleaves keys.
+
+All four default to the client's own defaults, so no existing flow changes behaviour.
+
+## Fixes
+
+*Max Pending Chunked Message* was registered twice in the consumer's property list, so it
+appeared twice in the UI.
+
+The producer's configuration is assembled as a map handed to `ProducerBuilder.loadConf()`, which
+serialises it through JSON — so a value whose type does not survive that trip is dropped without
+an error. *Batch Builder* is such a value, and is now set on the builder directly rather than
+placed in the map, where it would have looked configured and done nothing. A test now asserts the
+producer configuration the client actually ends up with, rather than the contents of the map,
+which is the check that would have caught #180.
+
 ## Documentation
 
 Mapping `__KEY__` in *Mapped FlowFile Attributes* puts every distinct key in its own
@@ -49,9 +114,14 @@ moves, so the image can no longer drift ahead of the NARs it ships.
 ## Upgrading
 
 Move the runtime to NiFi 2.11.0 and drop in the new NARs. No configuration change is
-required. If you consume from a KeyValue `SEPARATED` topic and map `msg.key`, check
-whether anything downstream was decoding that value itself — see the behaviour change
-above.
+required: negative acknowledgement needs none, and the dead letter policy is off unless you
+set *Max Redelivery Count*.
+
+Two things to look at. If you consume from a KeyValue `SEPARATED` topic and map `msg.key`,
+check whether anything downstream was decoding that value itself — see the behaviour change
+above. And if a flow depended on the delay between a write failure and its redelivery — a
+retry window, a downstream backoff — that gap is now *Negative Acknowledgment Redelivery
+Delay* rather than *Acknowledgment Timeout*, and defaults to one minute.
 
 Coming from `2.9.0` or earlier? Read [the `2.10.0` notes](2.10.0.md) first: that
 release carries several behaviour changes.

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -48,6 +48,7 @@ import org.apache.nifi.processors.pulsar.utils.PropertyMappingUtils;
 import org.apache.nifi.pulsar.PulsarClientService;
 import org.apache.nifi.pulsar.cache.PulsarConsumerLRUCache;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.Message;
@@ -198,6 +199,42 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "configured timeout will be replayed. This value needs to be greater than 10 seconds.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("30 sec")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor NEGATIVE_ACK_REDELIVERY_DELAY = new PropertyDescriptor.Builder()
+            .name("NEGATIVE_ACK_REDELIVERY_DELAY")
+            .displayName("Negative Acknowledgment Redelivery Delay")
+            .description("How long the broker waits before redelivering a message this processor could not hand "
+                    + "to the flow. A message whose FlowFile could not be written is now negatively acknowledged "
+                    + "rather than left to expire, so its redelivery is governed by this property. The "
+                    + "Acknowledgment Timeout remains the ceiling for a message that was never acted on at all.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("1 min")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor MAX_REDELIVER_COUNT = new PropertyDescriptor.Builder()
+            .name("MAX_REDELIVER_COUNT")
+            .displayName("Max Redelivery Count")
+            .description("Enables a dead letter policy: once a message has been redelivered this many times the "
+                    + "broker moves it to the dead letter topic instead of delivering it again. Leave unset to "
+                    + "let the broker redeliver indefinitely, which is the previous behaviour. This governs only "
+                    + "messages the processor could not deliver into the flow at all - a message that reached a "
+                    + "FlowFile and was then routed to a failure relationship has been acknowledged, and never "
+                    + "reaches the dead letter topic. Pulsar supports a dead letter policy only on Shared and "
+                    + "Key_Shared subscriptions.")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor DEAD_LETTER_TOPIC = new PropertyDescriptor.Builder()
+            .name("DEAD_LETTER_TOPIC")
+            .displayName("Dead Letter Topic")
+            .description("The topic messages are moved to once they exceed Max Redelivery Count. Defaults to the "
+                    + "broker's own naming, '<topic>-<subscription>-DLQ'. Has no effect unless Max Redelivery "
+                    + "Count is set.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .required(false)
             .build();
 
@@ -360,7 +397,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         descriptorList.add(ASYNC_ENABLED);
         descriptorList.add(MAX_ASYNC_REQUESTS);
         descriptorList.add(ACK_TIMEOUT);
-        descriptorList.add(MAX_PENDING_CHUNKED_MESSAGE);
+        descriptorList.add(NEGATIVE_ACK_REDELIVERY_DELAY);
+        descriptorList.add(MAX_REDELIVER_COUNT);
+        descriptorList.add(DEAD_LETTER_TOPIC);
         descriptorList.add(AUTO_ACK_OLDEST_CHUNKED_ON_QUEUE_FULL);
         descriptorList.add(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE);
         descriptorList.add(MAX_PENDING_CHUNKED_MESSAGE);
@@ -416,6 +455,25 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         if (validationContext.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.SECONDS) < 10) {
            results.add(new ValidationResult.Builder().valid(false).explanation(
                "Acknowledgment Timeout needs to be greater than 10 seconds.").build());
+        }
+
+        final boolean deadLetterEnabled = validationContext.getProperty(MAX_REDELIVER_COUNT).isSet();
+        final String subscriptionType = validationContext.getProperty(SUBSCRIPTION_TYPE).getValue();
+
+        // The client builds a dead letter policy only for Shared and Key_Shared subscriptions. On the other
+        // two the consumer is accepted and simply never dead-letters anything, so a flow would sit waiting on
+        // a dead letter topic that can never receive a message. Reject it here instead, as CustomPartition is
+        // rejected on the producer side, rather than let the configuration look like it took effect.
+        if (deadLetterEnabled && !SHARED.getValue().equals(subscriptionType)
+                && !KEY_SHARED.getValue().equals(subscriptionType)) {
+            results.add(new ValidationResult.Builder().valid(false).subject(MAX_REDELIVER_COUNT.getDisplayName())
+                .explanation("a dead letter policy is supported only on Shared and Key_Shared subscriptions, but "
+                    + "the Subscription Type is " + subscriptionType).build());
+        }
+
+        if (validationContext.getProperty(DEAD_LETTER_TOPIC).isSet() && !deadLetterEnabled) {
+            results.add(new ValidationResult.Builder().valid(false).subject(DEAD_LETTER_TOPIC.getDisplayName())
+                .explanation("Dead Letter Topic has no effect unless Max Redelivery Count is set").build());
         }
 
         return results;
@@ -563,12 +621,27 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             builder = builder.consumerName(context.getProperty(CONSUMER_NAME).getValue());
         }
 
+        // Only built when Max Redelivery Count is set: the policy's redeliver count has no "unlimited"
+        // value, so attaching one unconditionally would impose a ceiling no flow asked for.
+        if (context.getProperty(MAX_REDELIVER_COUNT).isSet()) {
+            final DeadLetterPolicy.DeadLetterPolicyBuilder deadLetterPolicy = DeadLetterPolicy.builder()
+                    .maxRedeliverCount(context.getProperty(MAX_REDELIVER_COUNT).asInteger());
+
+            if (context.getProperty(DEAD_LETTER_TOPIC).isSet()) {
+                deadLetterPolicy.deadLetterTopic(context.getProperty(DEAD_LETTER_TOPIC).getValue());
+            }
+
+            builder = builder.deadLetterPolicy(deadLetterPolicy.build());
+        }
+
         return builder.subscriptionName(context.getProperty(SUBSCRIPTION_NAME).getValue())
                 .subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(context.getProperty(SUBSCRIPTION_INITIAL_POSITION).getValue()))
                 .autoUpdatePartitions(context.getProperty(AUTO_UPDATE_PARTITIONS).asBoolean())
                 .autoUpdatePartitionsInterval(context.getProperty(AUTO_UPDATE_PARTITION_INTERVAL)
                         .asTimePeriod(TimeUnit.SECONDS).intValue(), TimeUnit.SECONDS)
                 .ackTimeout(context.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue(), TimeUnit.MILLISECONDS)
+                .negativeAckRedeliveryDelay(context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY)
+                        .asTimePeriod(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS)
                 .autoAckOldestChunkedMessageOnQueueFull(context.getProperty(AUTO_ACK_OLDEST_CHUNKED_ON_QUEUE_FULL).asBoolean())
                 .expireTimeOfIncompleteChunkedMessage(context.getProperty(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE)
                         .asTimePeriod(TimeUnit.SECONDS), TimeUnit.SECONDS)
@@ -674,6 +747,38 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         messages.clear();
 
         session.commitAsync(() -> acknowledge(consumer, committed, shared, async));
+    }
+
+    /**
+     * Rolls the session back and negatively acknowledges the messages it carried, so the broker redelivers
+     * them once the Negative Acknowledgment Redelivery Delay elapses.
+     *
+     * <p>Rolling back alone leaves the messages merely unacknowledged, and the broker cannot tell a consumer
+     * that has failed from one that is still working: it waits out the Acknowledgment Timeout - thirty seconds
+     * by default and never less than ten, by validation - before redelivering. Nothing was ever lost, but the
+     * flow stalled for that long on every write error. The negative acknowledgement says which of the two it
+     * is.
+     *
+     * @param session  the session to roll back
+     * @param consumer the consumer the messages were received from
+     * @param messages the messages carried by the rolled-back session; cleared on return
+     */
+    protected void rollbackAndRedeliver(final ProcessSession session, final Consumer<GenericRecord> consumer,
+                                        final List<Message<GenericRecord>> messages) {
+        session.rollback();
+
+        for (final Message<GenericRecord> message : messages) {
+            try {
+                consumer.negativeAcknowledge(message);
+            } catch (final RuntimeException e) {
+                // The message is unacknowledged either way, so the Acknowledgment Timeout still redelivers it;
+                // only the promptness is lost. Not worth failing a trigger whose session is already rolled back.
+                getLogger().warn("Unable to negatively acknowledge a message whose session was rolled back; it "
+                        + "will be redelivered when the Acknowledgment Timeout expires", e);
+            }
+        }
+
+        messages.clear();
     }
 
     private void acknowledge(final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -40,7 +40,10 @@ import org.apache.nifi.pulsar.PulsarClientService;
 import org.apache.nifi.pulsar.cache.PulsarConsumerLRUCache;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -246,6 +249,63 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
             .defaultValue("1000")
             .build();
 
+    /** BatcherBuilder is an interface, not an enum, so the two supported builders are named here. */
+    protected static final String BATCHER_DEFAULT = "Default";
+    protected static final String BATCHER_KEY_BASED = "Key based";
+
+    public static final PropertyDescriptor SEND_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("SEND_TIMEOUT")
+            .displayName("Send Timeout")
+            .description("How long a send may take before it fails. A message that is not acknowledged by the "
+                    + "broker within this window fails, and its FlowFile is routed to failure. Set to 0 to wait "
+                    + "indefinitely, which is what you want when the flow must never drop a message and would "
+                    + "rather block. Note that a send timeout of 0 is required for Pulsar's broker-side "
+                    + "deduplication to work correctly.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("30 sec")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor ACCESS_MODE = new PropertyDescriptor.Builder()
+            .name("ACCESS_MODE")
+            .displayName("Producer Access Mode")
+            .description("Whether this producer requires exclusive access to the topic. 'Shared' is Pulsar's "
+                    + "default and lets any number of producers write to the topic. The exclusive modes are how "
+                    + "you stop two flows writing the same topic: 'Exclusive' fails at producer creation if "
+                    + "another producer already holds the topic, 'WaitForExclusive' queues until it can take "
+                    + "over, and 'ExclusiveWithFencing' evicts the existing producer and takes it.")
+            .required(false)
+            .allowableValues(ProducerAccessMode.Shared.name(), ProducerAccessMode.Exclusive.name(),
+                    ProducerAccessMode.WaitForExclusive.name(), ProducerAccessMode.ExclusiveWithFencing.name())
+            .defaultValue(ProducerAccessMode.Shared.name())
+            .build();
+
+    public static final PropertyDescriptor HASHING_SCHEME = new PropertyDescriptor.Builder()
+            .name("HASHING_SCHEME")
+            .displayName("Hashing Scheme")
+            .description("The hash used to choose a partition from a message key on a partitioned topic. This "
+                    + "must match every other producer writing the topic: two producers with different schemes "
+                    + "send the same key to different partitions, which breaks per-key ordering for anything "
+                    + "consuming it. 'JavaStringHash' is the Java client's default; 'Murmur3_32Hash' is the "
+                    + "cross-language one, and is what to use when other clients also write this topic.")
+            .required(false)
+            .allowableValues(HashingScheme.JavaStringHash.name(), HashingScheme.Murmur3_32Hash.name())
+            .defaultValue(HashingScheme.JavaStringHash.name())
+            .build();
+
+    public static final PropertyDescriptor BATCHER_BUILDER = new PropertyDescriptor.Builder()
+            .name("BATCHER_BUILDER")
+            .displayName("Batch Builder")
+            .description("How messages are grouped into batches. 'Default' fills a batch with whatever is "
+                    + "pending, interleaving keys. 'Key based' keeps messages with the same key in the same "
+                    + "batch, which is what per-key ordering on a Key_Shared subscription requires: a consumer "
+                    + "receives a whole batch, so a batch spanning several keys hands one consumer messages "
+                    + "belonging to another's key range. Only applies when Batching Enabled is true.")
+            .required(false)
+            .allowableValues(BATCHER_DEFAULT, BATCHER_KEY_BASED)
+            .defaultValue(BATCHER_DEFAULT)
+            .build();
+
     public static final PropertyDescriptor MAPPED_MESSAGE_PROPERTIES = new PropertyDescriptor.Builder()
             .name("MAPPED_MESSAGE_PROPERTIES")
             .displayName("Mapped Message Properties")
@@ -287,6 +347,10 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         descriptorList.add(MESSAGE_ROUTING_MODE);
         descriptorList.add(MESSAGE_DEMARCATOR);
         descriptorList.add(PENDING_MAX_MESSAGES);
+        descriptorList.add(SEND_TIMEOUT);
+        descriptorList.add(ACCESS_MODE);
+        descriptorList.add(HASHING_SCHEME);
+        descriptorList.add(BATCHER_BUILDER);
         descriptorList.add(MAPPED_MESSAGE_PROPERTIES);
         descriptorList.add(MESSAGE_KEY);
 
@@ -360,7 +424,8 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
     }
 
     protected PublisherPool createPublisherPool(final ProcessContext context) {
-        return new PublisherPool(getLogger(), getPulsarProducerConfiguration(context), this.getPulsarClientService().getPulsarClient());
+        return new PublisherPool(getLogger(), getPulsarProducerConfiguration(context),
+                this.getPulsarClientService().getPulsarClient(), getBatcherBuilder(context));
     }
 
     protected Map<String, Object> getPulsarProducerConfiguration(ProcessContext ctx) {
@@ -375,6 +440,9 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         // the properties stayed in the UI while the producer silently ran with the client defaults.
         config.put("messageRoutingMode", MessageRoutingMode.valueOf(ctx.getProperty(MESSAGE_ROUTING_MODE).getValue()));
         config.put("maxPendingMessages", ctx.getProperty(PENDING_MAX_MESSAGES).evaluateAttributeExpressions().asInteger());
+        config.put("sendTimeoutMs", ctx.getProperty(SEND_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue());
+        config.put("accessMode", ProducerAccessMode.valueOf(ctx.getProperty(ACCESS_MODE).getValue()));
+        config.put("hashingScheme", HashingScheme.valueOf(ctx.getProperty(HASHING_SCHEME).getValue()));
 
         if (ctx.getProperty(BATCHING_ENABLED).asBoolean()) {
             config.put("batchingEnabled", Boolean.TRUE);
@@ -391,6 +459,24 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         }
 
         return config;
+    }
+
+    /**
+     * The batch builder to set on the producer, or {@code null} to leave the client default in place.
+     *
+     * <p>This is deliberately not part of {@link #getPulsarProducerConfiguration(ProcessContext)}:
+     * {@code loadConf} serialises that map through JSON, and a BatcherBuilder does not survive the trip -
+     * it is dropped without an error and the producer batches with the default builder. Only meaningful
+     * when batching is enabled; the client ignores it otherwise.
+     */
+    protected BatcherBuilder getBatcherBuilder(final ProcessContext ctx) {
+        if (!ctx.getProperty(BATCHING_ENABLED).asBoolean()) {
+            return null;
+        }
+
+        return BATCHER_KEY_BASED.equals(ctx.getProperty(BATCHER_BUILDER).getValue())
+                ? BatcherBuilder.KEY_BASED
+                : BatcherBuilder.DEFAULT;
     }
 
     protected synchronized PulsarClientService getPulsarClientService() {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -173,10 +173,11 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             }
                              
                         } catch (final IOException ioEx) {
-                            // nothing has been acknowledged, so the broker redelivers the whole batch
+                            // nothing has been acknowledged, and the messages are negatively acknowledged so the
+                            // broker redelivers the whole batch without waiting out the Acknowledgment Timeout
                             getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", ioEx);
                             IOUtils.closeQuietly(out);
-                            session.rollback();
+                            rollbackAndRedeliver(session, consumer, uncommitted);
                             return;
                         }
                     }
@@ -289,10 +290,11 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     }
                     
                 } catch (final IOException ioEx) {
-                    // nothing has been acknowledged, so the broker redelivers the whole batch
+                    // nothing has been acknowledged, and the messages are negatively acknowledged so the broker
+                    // redelivers the whole batch without waiting out the Acknowledgment Timeout
                     getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", ioEx);
                     IOUtils.closeQuietly(out);
-                    session.rollback();
+                    rollbackAndRedeliver(session, consumer, uncommitted);
                     return;
                 }
             }
@@ -317,6 +319,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             commitAndAcknowledge(session, consumer, uncommitted, shared, false);
 
         } catch (PulsarClientException e) {
+            // Deliberately not negatively acknowledged: this is the client itself failing, so the call that
+            // would carry the negative acknowledgement is the call that just failed. The Acknowledgment
+            // Timeout is the right fallback here, and is what redelivers these messages.
             getLogger().error("Error communicating with Apache Pulsar", e);
             context.yield();
             session.rollback();

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -590,11 +590,12 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
 
             dropUnroutedFailures(session, parseFailures, demarcator, uncommitted);
         } catch (IOException e) {
-            // nothing has been acknowledged, so the broker redelivers the whole batch
+            // nothing has been acknowledged, and the messages are negatively acknowledged so the broker
+            // redelivers the whole batch without waiting out the Acknowledgment Timeout
             getLogger().error("Unable to write the received messages to a FlowFile; they will be redelivered", e);
             IOUtils.closeQuietly(writer);
             IOUtils.closeQuietly(rawOut);
-            session.rollback();
+            rollbackAndRedeliver(session, consumer, uncommitted);
             return;
         }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -19,6 +19,8 @@ package org.apache.nifi.processors.pulsar.utils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -51,6 +53,15 @@ public class PublisherPool implements Closeable {
     private final Map<String, Object> pulsarProducerProperties;
     private final PulsarClient pulsarClient;
 
+    /**
+     * Set on the builder rather than passed in {@link #pulsarProducerProperties}, because
+     * {@code loadConf} cannot carry it: it serialises the configuration map through JSON, and
+     * BatcherBuilder is an interface with no serialisable state, so a builder placed in the map is
+     * dropped in silence and the producer runs with the default one. That is the same shape of bug
+     * as the two properties #180 lost. May be null, which leaves the client default in place.
+     */
+    private final BatcherBuilder batcherBuilder;
+
     /** Idle leases per topic, ready to be handed out again. */
     private final Map<String, Queue<PooledPublisherLease>> idleLeases = new ConcurrentHashMap<>();
 
@@ -60,9 +71,15 @@ public class PublisherPool implements Closeable {
     private volatile boolean closed = false;
 
     public PublisherPool(ComponentLog logger, Map<String, Object> pulsarProducerProperties, PulsarClient pulsarClient) {
+        this(logger, pulsarProducerProperties, pulsarClient, null);
+    }
+
+    public PublisherPool(ComponentLog logger, Map<String, Object> pulsarProducerProperties, PulsarClient pulsarClient,
+                         BatcherBuilder batcherBuilder) {
         this.logger = logger;
         this.pulsarProducerProperties = pulsarProducerProperties;
         this.pulsarClient = pulsarClient;
+        this.batcherBuilder = batcherBuilder;
     }
 
     /**
@@ -111,10 +128,16 @@ public class PublisherPool implements Closeable {
         // schema has been bound to the topic and reports its SchemaInfo.
         final Schema<byte[]> topicSchema = Schema.AUTO_PRODUCE_BYTES();
 
-        final Producer producer = pulsarClient.newProducer(topicSchema)
+        final ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer(topicSchema)
                 .topic(topicName)
-                .loadConf(properties)
-                .create();
+                .loadConf(properties);
+
+        // After loadConf, so it is not overwritten by the map, and only when one was chosen.
+        if (batcherBuilder != null) {
+            producerBuilder.batcherBuilder(batcherBuilder);
+        }
+
+        final Producer producer = producerBuilder.create();
 
         final PooledPublisherLease lease = new PooledPublisherLease(producer, topicName, topicSchema);
         openLeases.add(lease);

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -29,6 +29,50 @@
     This processor provides the ability to consume raw bytes from an Apache &trade; Pulsar topic.
 </p>
 
+
+<br/>
+<h3>Failure handling and redelivery</h3>
+<p>
+    A consumed message leaves this processor by exactly one route, and which one it took decides whether
+    Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
+    committed, so a message is never acknowledged while its content could still be discarded.
+</p>
+<table>
+    <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>
+    <tr><td>The message reached a FlowFile</td><td><code>success</code>, acknowledged</td><td>No</td></tr>
+    <tr><td>It could not be written at all</td><td>rolled back, negatively acknowledged</td><td>Yes, promptly</td></tr>
+    <tr><td>The Pulsar client itself failed</td><td>rolled back, left unacknowledged</td><td>Yes, after <i>Acknowledgment Timeout</i></td></tr>
+</table>
+<p>
+    When the processor cannot write a message into a FlowFile - a full content repository, a permissions
+    problem, a disk fault - it rolls the session back and <b>negatively acknowledges</b> the message, asking
+    the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
+    tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
+    seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
+    soon redelivery happens, and defaults to Pulsar's own one minute.
+</p>
+<p>
+    When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would
+    carry it is the call that just failed. Those messages fall back to <i>Acknowledgment Timeout</i>, which is
+    the right mechanism for a broken connection.
+</p>
+
+<br/>
+<h3>Dead letter topics</h3>
+<p>
+    Setting <i>Max Redelivery Count</i> attaches a dead letter policy. Once a message has been redelivered more
+    times than that, the broker moves it to a dead letter topic instead of delivering it again, so a message
+    the flow can never accept stops blocking the subscription and is still there to inspect.
+    <i>Dead Letter Topic</i> names the destination; leave it unset for the broker's own
+    <code>&lt;topic&gt;-&lt;subscription&gt;-DLQ</code>.
+</p>
+<p>
+    It is unset by default, so the broker redelivers indefinitely unless you ask otherwise. Two constraints
+    apply. Pulsar builds a dead letter policy only for <code>Shared</code> and <code>Key_Shared</code>
+    subscriptions, and this processor rejects the combination at validation rather than let a flow watch a
+    dead letter topic that can never receive anything. And the policy catches only messages that never
+    reached the flow: a message that reached a FlowFile has been acknowledged and never reaches the dead letter topic.
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -28,6 +28,51 @@
 <p>
     This processor provides the ability to consume records from a schema-aware topic in Apache &trade; Pulsar.
 </p>
+
+<br/>
+<h3>Failure handling and redelivery</h3>
+<p>
+    A consumed message leaves this processor by exactly one route, and which one it took decides whether
+    Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
+    committed, so a message is never acknowledged while its content could still be discarded.
+</p>
+<table>
+    <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>
+    <tr><td>The message reached a FlowFile</td><td><code>success</code>, acknowledged</td><td>No</td></tr>
+    <tr><td>Its content could not be parsed</td><td><code>parse_failure</code>, acknowledged</td><td>No</td></tr>
+    <tr><td>It could not be written at all</td><td>rolled back, negatively acknowledged</td><td>Yes, promptly</td></tr>
+    <tr><td>The Pulsar client itself failed</td><td>rolled back, left unacknowledged</td><td>Yes, after <i>Acknowledgment Timeout</i></td></tr>
+</table>
+<p>
+    When the processor cannot write a message into a FlowFile - a full content repository, a permissions
+    problem, a disk fault - it rolls the session back and <b>negatively acknowledges</b> the message, asking
+    the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
+    tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
+    seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
+    soon redelivery happens, and defaults to Pulsar's own one minute.
+</p>
+<p>
+    When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would
+    carry it is the call that just failed. Those messages fall back to <i>Acknowledgment Timeout</i>, which is
+    the right mechanism for a broken connection.
+</p>
+
+<br/>
+<h3>Dead letter topics</h3>
+<p>
+    Setting <i>Max Redelivery Count</i> attaches a dead letter policy. Once a message has been redelivered more
+    times than that, the broker moves it to a dead letter topic instead of delivering it again, so a message
+    the flow can never accept stops blocking the subscription and is still there to inspect.
+    <i>Dead Letter Topic</i> names the destination; leave it unset for the broker's own
+    <code>&lt;topic&gt;-&lt;subscription&gt;-DLQ</code>.
+</p>
+<p>
+    It is unset by default, so the broker redelivers indefinitely unless you ask otherwise. Two constraints
+    apply. Pulsar builds a dead letter policy only for <code>Shared</code> and <code>Key_Shared</code>
+    subscriptions, and this processor rejects the combination at validation rather than let a flow watch a
+    dead letter topic that can never receive anything. And the policy catches only messages that never
+    reached the flow: a message routed to <code>parse_failure</code> was delivered and handled, so it is acknowledged and never reaches the dead letter topic.
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
@@ -28,6 +28,35 @@
 <p>
     This processor provides the ability to publish raw bytes to an Apache &trade; Pulsar topic. 
 </p>
+
+<br/>
+<h3>Producer behaviour</h3>
+<p>
+    <i>Send Timeout</i> bounds how long a single send may take. A message the broker has not acknowledged
+    within it fails, and its FlowFile is routed to <code>failure</code>. It defaults to 30 seconds; set it to
+    <code>0</code> to wait indefinitely, which is what a flow that must never drop a message wants - and what
+    Pulsar's broker-side deduplication requires.
+</p>
+<p>
+    <i>Producer Access Mode</i> is how you stop two flows writing the same topic. <code>Shared</code>, the
+    default, lets any number of producers write. <code>Exclusive</code> fails at producer creation if another
+    producer already holds the topic, <code>WaitForExclusive</code> queues until it can take over, and
+    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic.
+</p>
+<p>
+    <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.
+    It must match every other producer writing that topic: two producers using different schemes send the same
+    key to different partitions, which silently breaks per-key ordering for anything consuming it.
+    <code>JavaStringHash</code> is the Java client's default; <code>Murmur3_32Hash</code> is the cross-language
+    one, and is what to use when clients in other languages also write the topic.
+</p>
+<p>
+    <i>Batch Builder</i> decides how messages are grouped when <i>Batching Enabled</i> is on.
+    <code>Default</code> fills a batch with whatever is pending, interleaving keys. <b><code>Key based</code>
+    is required for per-key ordering on a <code>Key_Shared</code> subscription</b>: a consumer receives a whole
+    batch at a time, so a batch spanning several keys hands one consumer messages belonging to another
+    consumer's key range. It has no effect when batching is off.
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -28,6 +28,35 @@
 <p>
     This processor provides the ability to publish records to a schema-aware topic in Apache &trade; Pulsar.
 </p>
+
+<br/>
+<h3>Producer behaviour</h3>
+<p>
+    <i>Send Timeout</i> bounds how long a single send may take. A message the broker has not acknowledged
+    within it fails, and its FlowFile is routed to <code>failure</code>. It defaults to 30 seconds; set it to
+    <code>0</code> to wait indefinitely, which is what a flow that must never drop a message wants - and what
+    Pulsar's broker-side deduplication requires.
+</p>
+<p>
+    <i>Producer Access Mode</i> is how you stop two flows writing the same topic. <code>Shared</code>, the
+    default, lets any number of producers write. <code>Exclusive</code> fails at producer creation if another
+    producer already holds the topic, <code>WaitForExclusive</code> queues until it can take over, and
+    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic.
+</p>
+<p>
+    <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.
+    It must match every other producer writing that topic: two producers using different schemes send the same
+    key to different partitions, which silently breaks per-key ordering for anything consuming it.
+    <code>JavaStringHash</code> is the Java client's default; <code>Murmur3_32Hash</code> is the cross-language
+    one, and is what to use when clients in other languages also write the topic.
+</p>
+<p>
+    <i>Batch Builder</i> decides how messages are grouped when <i>Batching Enabled</i> is on.
+    <code>Default</code> fills a batch with whatever is pending, interleaving keys. <b><code>Key based</code>
+    is required for per-key ordering on a <code>Key_Shared</code> subscription</b>: a consumer receives a whole
+    batch at a time, so a batch spanning several keys hands one consumer messages belonging to another
+    consumer's key range. It has no effect when batching is off.
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/PublishPulsarProducerConfigurationTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/PublishPulsarProducerConfigurationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Every producer property must actually reach the producer.
+ * <p>
+ * The producer is configured by handing a {@code Map<String, Object>} to {@code ProducerBuilder.loadConf()},
+ * so a property is wired only if someone remembered to put it in the map - a missing entry looks like nothing
+ * at all. That is how #180 lost <i>Message Routing Mode</i> and <i>Max Pending Messages</i>: both had been
+ * shown in the UI for two years while the producer ran with the client defaults.
+ * <p>
+ * These tests assert against the {@link ProducerConfigurationData} that {@code loadConf} actually produces,
+ * not against the map. The distinction matters: {@code loadConf} serialises the map through JSON, so a value
+ * of a type that does not survive that trip is dropped in silence. {@code batcherBuilder} is exactly such a
+ * value, which is why it is set on the builder instead and asserted separately.
+ */
+public class PublishPulsarProducerConfigurationTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    private AbstractPulsarProducerProcessor<byte[]> processor;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "persistent://public/default/configuration");
+        processor = (AbstractPulsarProducerProcessor<byte[]>) runner.getProcessor();
+    }
+
+    /**
+     * The guard #186 asked for: whatever the map claims, this is what the client ends up configured with.
+     * A property dropped from the map shows up here as a client default.
+     */
+    @Test
+    public void everyConfiguredPropertyReachesTheProducerConfiguration() {
+        runner.setProperty(AbstractPulsarProducerProcessor.SEND_TIMEOUT, "5 sec");
+        runner.setProperty(AbstractPulsarProducerProcessor.ACCESS_MODE, "Exclusive");
+        runner.setProperty(AbstractPulsarProducerProcessor.HASHING_SCHEME, "Murmur3_32Hash");
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_ROUTING_MODE, "RoundRobinPartition");
+        runner.setProperty(AbstractPulsarProducerProcessor.PENDING_MAX_MESSAGES, "500");
+
+        final ProducerConfigurationData conf = producerConfiguration();
+
+        assertEquals(5000L, conf.getSendTimeoutMs());
+        assertEquals(ProducerAccessMode.Exclusive, conf.getAccessMode());
+        assertEquals(HashingScheme.Murmur3_32Hash, conf.getHashingScheme());
+        assertEquals(500, conf.getMaxPendingMessages());
+        // the two #180 lost, kept here so they cannot be lost the same way twice
+        assertEquals("RoundRobinPartition", conf.getMessageRoutingMode().name());
+    }
+
+    /** The defaults the processor declares are the defaults the client is given. */
+    @Test
+    public void theDeclaredDefaultsReachTheProducerConfiguration() {
+        final ProducerConfigurationData conf = producerConfiguration();
+
+        assertEquals("Send Timeout defaults to 30 sec", 30000L, conf.getSendTimeoutMs());
+        assertEquals(ProducerAccessMode.Shared, conf.getAccessMode());
+        assertEquals(HashingScheme.JavaStringHash, conf.getHashingScheme());
+    }
+
+    /** A send timeout of 0 has a specific meaning to Pulsar - wait forever - so it must survive as 0. */
+    @Test
+    public void aZeroSendTimeoutIsPassedThroughRatherThanTreatedAsUnset() {
+        runner.setProperty(AbstractPulsarProducerProcessor.SEND_TIMEOUT, "0 sec");
+
+        assertEquals(0L, producerConfiguration().getSendTimeoutMs());
+    }
+
+    /**
+     * The reason Batch Builder is not in the configuration map. Placing a BatcherBuilder there and letting
+     * loadConf carry it leaves the producer on the default builder without an error - so this asserts the
+     * property reaches the producer by the path that works, and that the map is not quietly relied on.
+     */
+    @Test
+    public void theKeyBasedBatchBuilderIsSetOnTheBuilderNotThroughTheConfigurationMap() {
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "true");
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHER_BUILDER, "Key based");
+
+        assertEquals(BatcherBuilder.KEY_BASED, processor.getBatcherBuilder(runner.getProcessContext()));
+        assertTrue("a BatcherBuilder in the configuration map would be dropped by loadConf without an error",
+                !configurationMap().containsKey("batcherBuilder"));
+    }
+
+    @Test
+    public void theDefaultBatchBuilderIsUsedWhenNoneIsChosen() {
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "true");
+
+        assertEquals(BatcherBuilder.DEFAULT, processor.getBatcherBuilder(runner.getProcessContext()));
+    }
+
+    /** With batching off the builder is meaningless, and the client is not given one. */
+    @Test
+    public void noBatchBuilderIsSetWhenBatchingIsDisabled() {
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHER_BUILDER, "Key based");
+
+        assertNull(processor.getBatcherBuilder(runner.getProcessContext()));
+    }
+
+    private Map<String, Object> configurationMap() {
+        final Map<String, Object> config = processor.getPulsarProducerConfiguration(runner.getProcessContext());
+        assertNotNull(config);
+        return config;
+    }
+
+    /** What {@code ProducerBuilder.loadConf()} actually makes of the map the processor builds. */
+    private ProducerConfigurationData producerConfiguration() {
+        return ConfigurationDataUtils.loadData(
+                configurationMap(), new ProducerConfigurationData(), ProducerConfigurationData.class);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Negative acknowledgement and the dead letter policy, against a real broker.
+ * <p>
+ * Neither can be proven with a mocked client: both are broker-side behaviour. A mock can show that
+ * {@code negativeAcknowledge} was called - {@code ConsumePulsarNegativeAcknowledgementTest} does - but only
+ * a broker decides whether that produces a redelivery, and only a broker moves a message to the dead letter
+ * topic once the redelivery count is exceeded.
+ */
+public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        // The dead letter policy is built only for Shared and Key_Shared subscriptions.
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
+        // Redeliver as soon as the broker will, so the test does not wait on the one-minute default.
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "1 sec");
+        // The floor the validator allows. The point of the redelivery test is that it completes well
+        // inside this, which is the only thing that could have redelivered the message before.
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "10 sec");
+    }
+
+    /**
+     * A message the processor could not write is redelivered promptly, rather than after the Acknowledgment
+     * Timeout. The assertion is the timing: the redelivery has to arrive inside the timeout that would
+     * otherwise have been the only thing to produce it.
+     */
+    @Test
+    public void aMessageThatCouldNotBeWrittenIsRedeliveredWithoutWaitingOutTheAckTimeout() throws Exception {
+        final String topic = topic("nack-redelivery");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nack-sub");
+
+        publish(topic, "payload");
+
+        // First pass: the content repository rejects the write, so the batch is rolled back and nacked.
+        runner.run(1, false, true);
+        final long nackedAt = System.nanoTime();
+        ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
+
+        // Second pass with a healthy session: the broker should hand the message back.
+        await("the negatively acknowledged message to be redelivered", () -> {
+            runner.run(1, false, false);
+            return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
+        });
+
+        final long elapsed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - nackedAt);
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 1);
+        runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).get(0).assertContentEquals("payload");
+        // 10s is the Acknowledgment Timeout, the only redelivery mechanism before the negative
+        // acknowledgement existed. Landing inside it is what proves the nack did the work.
+        org.junit.Assert.assertTrue(
+                "redelivery took " + elapsed + "s, which is not distinguishable from the Acknowledgment Timeout",
+                elapsed < 8);
+    }
+
+    /**
+     * Once a message has been redelivered more times than Max Redelivery Count, the broker moves it to the
+     * dead letter topic instead of delivering it again - so a message the flow can never accept stops
+     * blocking the subscription, and is still available to look at.
+     */
+    @Test
+    public void aRepeatedlyUndeliverableMessageEndsUpOnTheDeadLetterTopic() throws Exception {
+        final String topic = topic("dead-letter");
+        final String deadLetterTopic = topic + "-DLQ";
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "dlq-sub");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "2");
+        runner.setProperty(AbstractPulsarConsumerProcessor.DEAD_LETTER_TOPIC, deadLetterTopic);
+
+        // Subscribe to the dead letter topic before anything is published to it, so the message cannot be
+        // missed by a subscription that starts at the latest position.
+        try (Consumer<byte[]> deadLetters = getClient().newConsumer(Schema.BYTES)
+                .topic(deadLetterTopic)
+                .subscriptionName("dlq-reader")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe()) {
+
+            publish(topic, "poison");
+
+            runner.run(1, false, true);
+
+            // Each pass receives the message, fails to write it, rolls back and negatively acknowledges it.
+            // The passes have to be spaced: redelivery is what increments the count the dead letter policy
+            // measures, and it does not happen until Negative Acknowledgment Redelivery Delay has elapsed.
+            // Triggering in a tight loop just finds an empty receiver queue every time after the first.
+            Message<byte[]> deadLettered = null;
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+
+            while (deadLettered == null && System.nanoTime() < deadline) {
+                ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
+                // Long enough for the negative acknowledgement tracker to fire and the broker to redeliver.
+                deadLettered = deadLetters.receive(2, TimeUnit.SECONDS);
+            }
+
+            assertNotNull("the poison message never reached the dead letter topic", deadLettered);
+            assertEquals("poison", new String(deadLettered.getValue(), UTF_8));
+        }
+    }
+
+    private static String topic(final String name) {
+        return "persistent://public/default/" + name + "-" + System.nanoTime();
+    }
+
+    /**
+     * A session whose FlowFile content cannot be written - what a full or read-only content repository
+     * looks like to the processor.
+     */
+    private MockProcessSession failingSession() {
+        final Processor processor = runner.getProcessor();
+
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("Intentional Integration Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarProducerConfigurationIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarProducerConfigurationIT.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Producer configuration that only a broker can confirm.
+ * <p>
+ * {@code PublishPulsarProducerConfigurationTest} asserts what the client is configured with, which catches a
+ * property dropped from the configuration map. It cannot show that the broker then honours it. Producer
+ * access mode is the one of the four with a plainly observable broker behaviour - the broker refuses a second
+ * producer - so it is what pins the configuration actually taking effect end to end.
+ */
+public class PublishPulsarProducerConfigurationIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    /**
+     * With Exclusive access the processor's producer owns the topic, and a second producer is refused. That
+     * refusal is the whole point of the property: it is how two flows are stopped from writing one topic.
+     */
+    @Test
+    public void anExclusiveProducerLocksOutEveryOtherProducer() throws Exception {
+        final String topic = topic("exclusive");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.ACCESS_MODE, ProducerAccessMode.Exclusive.name());
+
+        runner.enqueue("owned");
+        runner.run(1, false, true);
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+        // The processor's producer is still open and holds the topic exclusively.
+        try (Producer<byte[]> intruder = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            fail("a second producer was allowed onto a topic held with Exclusive access: " + intruder);
+        } catch (final PulsarClientException.ProducerBusyException expected) {
+            assertTrue(true);
+        }
+    }
+
+    /**
+     * The default. Shared access has to keep letting other producers in, or the new property would be a
+     * breaking change for every existing flow.
+     */
+    @Test
+    public void aSharedProducerLeavesTheTopicOpenToOthers() throws Exception {
+        final String topic = topic("shared");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        // deliberately not setting ACCESS_MODE: this is what an existing flow looks like
+
+        runner.enqueue("shared-write");
+        runner.run(1, false, true);
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+        try (Producer<byte[]> second = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            second.send("also-mine".getBytes());
+        }
+    }
+
+    private static String topic(final String name) {
+        return "persistent://public/default/producer-config-" + name + "-" + System.nanoTime();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarDeadLetterPolicyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarDeadLetterPolicyTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The dead letter policy is configuration the broker can silently ignore, so the processor rejects the
+ * combinations where it would never take effect.
+ * <p>
+ * Pulsar builds a dead letter policy only for Shared and Key_Shared subscriptions. On an Exclusive or
+ * Failover subscription the consumer is accepted and simply never dead-letters anything - a flow would sit
+ * watching a dead letter topic that cannot receive a message, with nothing anywhere saying why. That is the
+ * same failure shape as {@code CustomPartition} on the producer, which 2.10.0 moved to validation for the
+ * same reason.
+ */
+public class ConsumePulsarDeadLetterPolicyTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/dead-letter";
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+    }
+
+    /** No dead letter policy at all is the default, and stays valid: the broker redelivers indefinitely. */
+    @Test
+    public void aConsumerWithoutADeadLetterPolicyIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+
+        runner.assertValid();
+    }
+
+    @Test
+    public void aDeadLetterPolicyIsValidOnASharedSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+
+        runner.assertValid();
+    }
+
+    @Test
+    public void aDeadLetterPolicyIsValidOnAKeySharedSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Key_Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+
+        runner.assertValid();
+    }
+
+    /** The client ignores the policy here, so accepting the configuration would be a lie. */
+    @Test
+    public void aDeadLetterPolicyIsRejectedOnAnExclusiveSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void aDeadLetterPolicyIsRejectedOnAFailoverSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Failover");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+
+        runner.assertNotValid();
+    }
+
+    /**
+     * A dead letter topic without a redelivery count names a destination nothing can ever be sent to:
+     * the count is what arms the policy.
+     */
+    @Test
+    public void aDeadLetterTopicWithoutARedeliveryCountIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.DEAD_LETTER_TOPIC, TOPIC + "-DLQ");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void aDeadLetterTopicWithARedeliveryCountIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+        runner.setProperty(AbstractPulsarConsumerProcessor.DEAD_LETTER_TOPIC, TOPIC + "-DLQ");
+
+        runner.assertValid();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAcknowledgementTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * A message the processor could not hand to the flow is negatively acknowledged, not merely left unacknowledged.
+ * <p>
+ * Both leave the message on the subscription, so neither loses it - {@link ConsumePulsarAcknowledgementTest}
+ * covers that guarantee. The difference is how long redelivery takes. An unacknowledged message is
+ * indistinguishable to the broker from one a healthy consumer is still working on, so it waits out the
+ * Acknowledgment Timeout: thirty seconds by default and never less than ten, by validation. The processor
+ * never called {@code negativeAcknowledge} at all, so every write error stalled the batch for that long.
+ * <p>
+ * Runs in synchronous and asynchronous mode on a Shared and on an Exclusive subscription, matching the
+ * acknowledgement suite: each combination reaches the rollback through a different path.
+ */
+@RunWith(Parameterized.class)
+public class ConsumePulsarNegativeAcknowledgementTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/negative-acknowledgement";
+
+    @Parameters(name = "async={0}, subscription={1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+            {false, "Exclusive"}, {false, "Shared"}, {true, "Exclusive"}, {true, "Shared"}});
+    }
+
+    private final boolean async;
+    private final String subscriptionType;
+
+    public ConsumePulsarNegativeAcknowledgementTest(final boolean async, final String subscriptionType) {
+        this.async = async;
+        this.subscriptionType = subscriptionType;
+    }
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, subscriptionType);
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, Boolean.toString(async));
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "10");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+    }
+
+    /**
+     * The regression: the content repository rejects the write, so the batch is rolled back. Every message
+     * the rolled-back session carried is negatively acknowledged, which is what asks the broker to redeliver
+     * now rather than when the Acknowledgment Timeout expires. Before this change nothing was negatively
+     * acknowledged and the flow waited out that timeout.
+     */
+    @Test
+    public void messagesAreNegativelyAcknowledgedWhenTheContentCannotBeWritten() throws PulsarClientException {
+        // schedule the processor against the still-empty topic
+        runner.run(1, false, true);
+        mockClientService.setMockMessageQueue(messages(3, "payload"));
+        final MockProcessSession session = sessionWhoseContentCannotBeWritten();
+
+        ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), session);
+        // what the framework does once onTrigger returns: it has to find a clean, rolled-back session
+        session.commitAsync();
+        ((AbstractPulsarConsumerProcessor<?>) runner.getProcessor()).shutDown(runner.getProcessContext());
+
+        session.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        // The count varies with the path - the synchronous write fails on the first message, the
+        // asynchronous one has the whole batch in hand - so what matters is that redelivery was asked
+        // for at all, which is exactly what did not happen before.
+        verify(mockClientService.getMockConsumer(), atLeastOnce()).negativeAcknowledge(any(Message.class));
+    }
+
+    /**
+     * A message that reached a FlowFile is acknowledged, never negatively acknowledged. Nacking a message
+     * the flow already owns would hand the same content to the flow twice.
+     */
+    @Test
+    public void nothingIsNegativelyAcknowledgedWhenTheContentIsWritten() throws PulsarClientException {
+        mockClientService.setMockMessageQueue(messages(3, "payload"));
+
+        runner.run(1, true);
+
+        runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
+        verifyNothingNegativelyAcknowledged();
+    }
+
+    /**
+     * Messages with an empty payload are discarded on purpose and acknowledged, so they are not redelivered.
+     * A discard is a decision, not a failure.
+     */
+    @Test
+    public void discardedEmptyMessagesAreNotNegativelyAcknowledged() throws PulsarClientException {
+        mockClientService.setMockMessageQueue(messages(3, null));
+
+        runner.run(1, true);
+
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
+        verifyNothingNegativelyAcknowledged();
+    }
+
+    private void verifyNothingNegativelyAcknowledged() throws PulsarClientException {
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+
+        verify(consumer, never()).negativeAcknowledge(any(Message.class));
+    }
+
+    /**
+     * A session whose FlowFile content cannot be written - what a full or read-only content repository
+     * looks like to the processor. Everything else behaves like the runner's own session.
+     */
+    private MockProcessSession sessionWhoseContentCannotBeWritten() {
+        final Processor processor = runner.getProcessor();
+
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("Intentional Unit Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+
+    /** {@code count} messages with distinct ids; a {@code null} payload produces empty messages. */
+    private static List<Message<GenericRecord>> messages(final int count, final String payload) {
+        final List<Message<GenericRecord>> msgs = new ArrayList<>();
+
+        for (int n = 1; n <= count; n++) {
+            final byte[] data = payload == null ? new byte[0] : (payload + "-" + n).getBytes(UTF_8);
+            msgs.add(new MockPulsarMessage<GenericRecord>(TOPIC, data, "1234:" + n + ":0", null, null));
+        }
+
+        return msgs;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.BatcherBuilder;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -83,6 +84,31 @@ public class PublisherPoolTest {
         }).when(builder).create();
 
         pool = new PublisherPool(mock(ComponentLog.class), Collections.emptyMap(), client);
+    }
+
+    /**
+     * The Batch Builder has to reach the producer through the builder, because it cannot reach it through
+     * the configuration map: {@code loadConf} serialises that map through JSON, and BatcherBuilder is an
+     * interface with no serialisable state, so a builder placed there is dropped without an error and the
+     * producer batches with the default one. This is the link nothing else covers - the processor's own test
+     * proves only which builder it chose, not that the pool passes it on.
+     */
+    @Test
+    public void theBatchBuilderIsSetOnTheProducerBuilder() {
+        final PublisherPool keyBased = new PublisherPool(
+                mock(ComponentLog.class), Collections.emptyMap(), client, BatcherBuilder.KEY_BASED);
+
+        keyBased.obtainPublisher("persistent://public/default/key-based");
+
+        verify(builder).batcherBuilder(BatcherBuilder.KEY_BASED);
+    }
+
+    /** No builder chosen means the client keeps its own default, not a null handed to the builder. */
+    @Test
+    public void noBatchBuilderIsSetWhenNoneWasChosen() {
+        pool.obtainPublisher("persistent://public/default/no-batcher");
+
+        verify(builder, never()).batcherBuilder(any());
     }
 
     /**


### PR DESCRIPTION
Closes the behaviour gaps in #186 and #187 so `2.11.0` ships as a platform bump **plus** the
producer and consumer configuration the bundle was missing, rather than a bare NiFi bump.

Two commits, each reviewable on its own. They share a release so they share a branch; say the
word if you would rather have two PRs.

### Scope, and why it stops where it does

#188 blocks #186/#187 on the grounds that client-tuning properties are version-specific and
belong on the versioned service after the restructure. That objection is correct and is honoured
here — the tuning tail is **not** in this PR: `negativeAckPrecisionBitCnt`,
`autoScaledReceiverQueueSizeEnabled`, `batchIndexAckEnabled`,
`maxTotalReceiverQueueSizeAcrossPartitions`, `compressMinMsgBodySize`, and the encryption group
all wait for #188 Phase 3.

What is here is missing *capability*, not knobs: concepts that survive a client rewrite. Building
negative acknowledgement now also informs #188 Phase 0, whose `PulsarConsumerService` sketch
already lists negative-acknowledge as a method — better designed from working code than from the
javadoc.

### `537556d` — negative acknowledgement + dead letter policy (#187)

A message the processor could not write was rolled back and left unacknowledged. Nothing was ever
lost, but the broker cannot tell a failed consumer from a busy one, so it waited out
*Acknowledgment Timeout* — 30s by default, never less than 10 by validation. Every write error
stalled that batch for the full ceiling. The three write-failure rollback sites now negatively
acknowledge what the session carried.

The fourth rollback site is deliberately untouched: it catches `PulsarClientException`, and the
call that would carry the nack is the call that just failed.

**`parse_failure` is unchanged.** That message was delivered and handled — the flow has its bytes
and can route them anywhere, including back to Pulsar. Nacking it would hand the same content to
the flow twice. This is why the dead letter policy is not wired to parse failures, which is where
someone coming from Pulsar's own DLQ semantics would look for it.

*Max Redelivery Count* arms a dead letter policy; unset by default. The client builds one only for
`Shared`/`Key_Shared` and silently never dead-letters on the others, so that combination is
rejected at validation rather than left looking configured — the call 2.10.0 made for
`CustomPartition`.

Also drops a duplicate registration of *Max Pending Chunked Message*, which rendered twice in the UI.

### `5d02cf9` — four producer properties (#186)

*Send Timeout*, *Producer Access Mode*, *Hashing Scheme*, *Batch Builder*. All default to the
client's own defaults, so no existing flow changes behaviour.

**The finding worth reviewing:** `batcherBuilder` **cannot travel through `loadConf`**. Probed
against the 4.2.4 client directly:

| Property | Survives `loadConf` |
|---|---|
| `sendTimeoutMs` | yes — 30000 -> 5000 |
| `accessMode` | yes — Shared -> Exclusive |
| `hashingScheme` | yes — JavaStringHash -> Murmur3_32Hash |
| `batcherBuilder` | **no — silently ignored** |

`loadConf` serialises the map through JSON and `BatcherBuilder` is an interface with no
serialisable state, so a builder placed in that map disappears without an error and the producer
batches with the default. That is exactly the #180 shape #186 warns about, so it is set on the
`ProducerBuilder` instead. Putting it in the map and fishing it back out would reproduce the bug
with an extra step.

The guard test #186 asked for therefore asserts the `ProducerConfigurationData` that `loadConf`
actually yields, **not** the contents of the map — the map is the thing that lies.

### `86b3d03` — tests for what only a broker can confirm

The producer work had a hole in exactly the place its own finding warns about. Batch Builder is
not in the configuration map — it cannot be — so it is set on the `ProducerBuilder` by
`PublisherPool`, and nothing covered that path: the processor test proved only which builder was
*chosen*. Guarding the map while leaving the builder unverified is the same silent-drop risk one
level up.

- `PublisherPoolTest` now verifies the pool sets the chosen builder on the `ProducerBuilder`, and
  sets none when none was chosen so the client keeps its own default rather than being handed null.
- `PublishPulsarProducerConfigurationIT` covers what a unit test cannot: *Producer Access Mode* is
  the one of the four with plainly observable broker behaviour, so it pins configuration taking
  effect end to end. `Exclusive` makes the broker refuse a second producer; with the property unset
  — what every existing flow looks like — one is still admitted, which is the "defaults break
  nothing" claim actually tested rather than asserted.

No introspection of `ProducerConfigurationData` from the IT: `ProducerImpl` exposes no public
accessor, so that would mean reflecting into client internals that move between versions.

### Verification

- **349 unit tests** pass (322 before; +19 consumer, +6 producer config, +2 pool wiring).
- **Integration tests against a real broker** (Testcontainers):
  - `ConsumePulsarDeadLetterIT` — a negatively acknowledged message returns well inside
    *Acknowledgment Timeout*; a repeatedly undeliverable one reaches the dead letter topic.
  - `PublishPulsarProducerConfigurationIT` — `Exclusive` locks the topic; the default does not.
- **Every new guard mutation-tested**, because a test that would also pass on `main` is worth
  nothing:
  - neutralising the negative acknowledgement (keeping the rollback) fails 4 of 12 unit cases;
  - deleting the `sendTimeoutMs` map entry — literally the #180 bug — fails with
    `expected:<5000> but was:<30000>`, the client default arriving silently;
  - deleting the `accessMode` entry fails the IT with *"a second producer was allowed onto a topic
    held with Exclusive access"* — and the unit suite catches the same mutation first, which is the
    layering working.

### Documentation

Property descriptions are NiFi's generated docs, and all seven are written. Beyond that: a
*Failure handling and redelivery* section and a *Dead letter topics* section on both consumers'
`additionalDetails.html`, a *Producer behaviour* section on both publishers', and matching README
sections — with *Hashing Scheme* placed in the existing partition-routing section, since a scheme
mismatch across producers is a partition-routing problem.

Release notes for `2.11.0` updated to cover both.

Refs #186, #187, #180
