### PR TITLE
feat: finish Topics Pattern, and add Read Compacted and Subscription Mode (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,33 @@ is what to use when clients in other languages also write the topic.
 > either raise *Max Pending Messages*, set it to `0` to restore the previous unbounded behaviour, or
 > enable *Block if Message Queue Full* so sends wait instead of failing.
 
+## Choosing what to consume
+
+*Topics* and *Topics Pattern* are alternatives; exactly one must be set.
+
+A pattern matches **persistent topics only** by default, which is why a pattern that plainly
+matches a non-persistent topic can appear to do nothing. *Topics Pattern Match Mode* changes
+that — `PersistentOnly` (the default and the previous behaviour), `NonPersistentOnly`, or
+`AllTopics`. *Topics Pattern Discovery Interval* is how often the client re-evaluates the
+pattern, and so the worst-case delay before a newly created matching topic is read. Both are
+ignored when *Topics* is used.
+
+*Subscription Mode* decides whether the broker keeps a cursor. `Durable` (the default) survives
+a restart and resumes where it left off. `NonDurable` leaves no cursor: the subscription exists
+only while the consumer is connected, which is what tailing wants, and it accumulates no backlog
+on the broker while the flow is stopped.
+
+*Read Compacted* reads the compacted view of a topic — the latest value per key — instead of its
+backlog. Messages without a key are not delivered at all, and the topic must actually have
+compaction running for there to be a compacted view; without it the subscription reads the normal
+backlog.
+
+> **The two single-consumer constraints are mirror images.** A compacted read needs a *single
+> active consumer*, so Pulsar permits it only on `Exclusive` and `Failover`. A dead letter policy
+> needs *competing* consumers, so Pulsar builds one only for `Shared` and `Key_Shared`. No
+> subscription type satisfies both, and the processor rejects each on the wrong type at validation
+> rather than letting the client fail at subscribe time.
+
 ## Producer behaviour
 
 *Send Timeout* bounds how long a single send may take. A message the broker has not acknowledged

--- a/README.md
+++ b/README.md
@@ -208,8 +208,11 @@ with exclusive or failover **persistent** subscriptions"*.
 - **A single active consumer** — so `Exclusive` or `Failover`.
 - **The persistent domain** — only a persistent topic has a compacted view. A `non-persistent://`
   topic named literally in *Topics* is rejected at validation, as is a *Topics Pattern* whose *Match
-  Mode* admits non-persistent topics. A topic supplied by an expression cannot be checked until the
-  expression resolves, so that case is warned about at startup instead. That second case matters because the client cannot catch it: with a pattern its topic list
+  Mode* admits non-persistent topics. A topic supplied by an expression is only checked if the
+  expression resolves at startup — an environment variable or a system property does, and a
+  non-persistent topic from one of those is warned about when the processor starts. A topic taken
+  from FlowFile attributes does not resolve at startup, so neither validation nor the warning can
+  see it and the client is what refuses the subscription. That second case matters because the client cannot catch it: with a pattern its topic list
   is empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches
   is served as a live stream — the flow would read a full stream while its configuration says it is
   reading the latest value per key, with nothing reporting it. A `non-persistent://` prefix on the

--- a/README.md
+++ b/README.md
@@ -184,12 +184,18 @@ matches a non-persistent topic can appear to do nothing. *Topics Pattern Match M
 that — `PersistentOnly` (the default and the previous behaviour), `NonPersistentOnly`, or
 `AllTopics`. *Topics Pattern Discovery Interval* is how often the client re-evaluates the
 pattern, and so the worst-case delay before a newly created matching topic is read. Both are
-ignored when *Topics* is used.
+ignored when *Topics* is used — with one exception: the discovery interval is still bounded to a
+whole number of seconds within `int` range whichever is set, because the client checks that bound
+when it builds any consumer, not only a pattern one.
 
 *Subscription Mode* decides whether the broker keeps a cursor. `Durable` (the default) survives
 a restart and resumes where it left off. `NonDurable` leaves no cursor: the subscription exists
 only while the consumer is connected, which is what tailing wants, and it accumulates no backlog
-on the broker while the flow is stopped.
+on the broker while the flow is stopped. What it gives up is delivery across restarts — with no
+cursor there is no resume point, so a `NonDurable` subscription set to *Subscription Initial
+Position* `Earliest` re-reads the topic from the beginning every time it is scheduled, and every
+time a consumer is evicted from the cache. The processor warns when it starts in that state.
+Worth knowing because the *Read Compacted* guidance below sends you to `Earliest`.
 
 *Read Compacted* reads the compacted view of a topic — the latest value per key — instead of its
 backlog. Messages without a key are not delivered at all, and the topic must actually have

--- a/README.md
+++ b/README.md
@@ -196,11 +196,28 @@ backlog. Messages without a key are not delivered at all, and the topic must act
 compaction running for there to be a compacted view; without it the subscription reads the normal
 backlog.
 
+*Read Compacted* has two requirements, and the client states both: *"Read compacted can only be used
+with exclusive or failover **persistent** subscriptions"*.
+
+- **A single active consumer** — so `Exclusive` or `Failover`.
+- **The persistent domain** — only a persistent topic has a compacted view. A `non-persistent://`
+  topic is rejected at validation, as is a *Topics Pattern* whose *Match Mode* admits non-persistent
+  topics. That second case matters because the client cannot catch it: with a pattern its topic list
+  is empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches
+  is served as a live stream — the flow would read a full stream while its configuration says it is
+  reading the latest value per key, with nothing reporting it.
+
 > **The two single-consumer constraints are mirror images.** A compacted read needs a *single
 > active consumer*, so Pulsar permits it only on `Exclusive` and `Failover`. A dead letter policy
 > needs *competing* consumers, so Pulsar builds one only for `Shared` and `Key_Shared`. No
 > subscription type satisfies both, and the processor rejects each on the wrong type at validation
 > rather than letting the client fail at subscribe time.
+
+> **Concurrent Tasks and non-Shared subscriptions.** Because *Read Compacted* requires `Exclusive` or
+> `Failover`, flows using it are on a subscription type where *Concurrent Tasks* > 1 is not currently
+> safe: one task's cumulative acknowledgement can acknowledge messages another task still holds. See
+> [#223](https://github.com/david-streamlio/pulsar-nifi-bundle/issues/223). Run these flows with a
+> single task until that is resolved.
 
 ## Producer behaviour
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ with exclusive or failover **persistent** subscriptions"*.
 
 - **A single active consumer** — so `Exclusive` or `Failover`.
 - **The persistent domain** — only a persistent topic has a compacted view. A `non-persistent://`
-  topic is rejected at validation, as is a *Topics Pattern* whose *Match Mode* admits non-persistent
-  topics. That second case matters because the client cannot catch it: with a pattern its topic list
+  topic named literally in *Topics* is rejected at validation, as is a *Topics Pattern* whose *Match
+  Mode* admits non-persistent topics. A topic supplied by an expression cannot be checked until the
+  expression resolves, so that case is warned about at startup instead. That second case matters because the client cannot catch it: with a pattern its topic list
   is empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches
   is served as a live stream — the flow would read a full stream while its configuration says it is
   reading the latest value per key, with nothing reporting it. A `non-persistent://` prefix on the

--- a/README.md
+++ b/README.md
@@ -205,7 +205,14 @@ with exclusive or failover **persistent** subscriptions"*.
   topics. That second case matters because the client cannot catch it: with a pattern its topic list
   is empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches
   is served as a live stream — the flow would read a full stream while its configuration says it is
-  reading the latest value per key, with nothing reporting it.
+  reading the latest value per key, with nothing reporting it. A `non-persistent://` prefix on the
+  *pattern itself* is not rejected, because it is inert: the client strips the scheme from the pattern
+  and from every candidate topic, so the domain comes from *Match Mode* alone.
+
+> **Set *Subscription Initial Position* to `Earliest`.** The compacted view is the history of the
+> topic — the latest value for each key seen so far. A new subscription left at the default of
+> `Latest` starts at the tail, so a compacted read delivers **nothing at all** until a new message
+> arrives, which looks identical to a broken flow.
 
 > **The two single-consumer constraints are mirror images.** A compacted read needs a *single
 > active consumer*, so Pulsar permits it only on `Exclusive` and `Failover`. A dead letter policy

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -55,7 +55,9 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 
@@ -199,6 +201,60 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "configured timeout will be replayed. This value needs to be greater than 10 seconds.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("30 sec")
+            .required(false)
+            .build();
+
+    public static final PropertyDescriptor READ_COMPACTED = new PropertyDescriptor.Builder()
+            .name("READ_COMPACTED")
+            .displayName("Read Compacted")
+            .description("Read the compacted view of the topic - the latest value for each key - rather than "
+                    + "its full backlog. Only the most recent message per key is delivered, and messages with "
+                    + "no key are not delivered at all. The topic must have compaction running for there to be "
+                    + "a compacted view to read; without it the subscription reads the normal backlog. Pulsar "
+                    + "permits this only on a persistent topic with a single active consumer, so the "
+                    + "Subscription Type must be Exclusive or Failover.")
+            .required(false)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .build();
+
+    public static final PropertyDescriptor SUBSCRIPTION_MODE = new PropertyDescriptor.Builder()
+            .name("SUBSCRIPTION_MODE")
+            .displayName("Subscription Mode")
+            .description("Whether the subscription's cursor is persisted by the broker. 'Durable' keeps a "
+                    + "cursor, so the subscription survives a restart and resumes where it left off - which is "
+                    + "what a flow that must not miss messages needs. 'NonDurable' leaves no cursor behind: the "
+                    + "subscription exists only while the consumer is connected and is forgotten afterwards, "
+                    + "which is what tailing a topic wants, and it does not accumulate a backlog on the broker "
+                    + "when the flow is stopped.")
+            .required(false)
+            .allowableValues(SubscriptionMode.Durable.name(), SubscriptionMode.NonDurable.name())
+            .defaultValue(SubscriptionMode.Durable.name())
+            .build();
+
+    public static final PropertyDescriptor REGEX_SUBSCRIPTION_MODE = new PropertyDescriptor.Builder()
+            .name("REGEX_SUBSCRIPTION_MODE")
+            .displayName("Topics Pattern Match Mode")
+            .description("Which topics a Topics Pattern is allowed to match: persistent only, non-persistent "
+                    + "only, or all. This only applies when Topics Pattern is used, and its default is why a "
+                    + "pattern that plainly matches a non-persistent topic silently does not consume from it - "
+                    + "the default has always been persistent-only, and there was previously no way to say "
+                    + "otherwise. Ignored when Topics is used instead.")
+            .required(false)
+            .allowableValues(RegexSubscriptionMode.PersistentOnly.name(),
+                    RegexSubscriptionMode.NonPersistentOnly.name(), RegexSubscriptionMode.AllTopics.name())
+            .defaultValue(RegexSubscriptionMode.PersistentOnly.name())
+            .build();
+
+    public static final PropertyDescriptor PATTERN_AUTO_DISCOVERY_PERIOD = new PropertyDescriptor.Builder()
+            .name("PATTERN_AUTO_DISCOVERY_PERIOD")
+            .displayName("Topics Pattern Discovery Interval")
+            .description("How often the client re-evaluates a Topics Pattern to pick up topics created since "
+                    + "it subscribed. A topic that starts matching is not consumed until the next sweep, so "
+                    + "this is the worst-case delay before a newly created topic is read. Only applies when "
+                    + "Topics Pattern is used; ignored when Topics is used instead.")
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("60 sec")
             .required(false)
             .build();
 
@@ -408,6 +464,10 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         descriptorList.add(PRIORITY_LEVEL);
         descriptorList.add(RECEIVER_QUEUE_SIZE);
         descriptorList.add(SUBSCRIPTION_TYPE);
+        descriptorList.add(SUBSCRIPTION_MODE);
+        descriptorList.add(READ_COMPACTED);
+        descriptorList.add(REGEX_SUBSCRIPTION_MODE);
+        descriptorList.add(PATTERN_AUTO_DISCOVERY_PERIOD);
         descriptorList.add(CONSUMER_BATCH_SIZE);
         descriptorList.add(MESSAGE_DEMARCATOR);
         descriptorList.add(MAPPED_FLOWFILE_ATTRIBUTES);
@@ -469,6 +529,18 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             results.add(new ValidationResult.Builder().valid(false).subject(MAX_REDELIVER_COUNT.getDisplayName())
                 .explanation("a dead letter policy is supported only on Shared and Key_Shared subscriptions, but "
                     + "the Subscription Type is " + subscriptionType).build());
+        }
+
+        // The client refuses this at subscribe time - "Read compacted can only be used with exclusive or
+        // failover persistent subscriptions" - so without this the processor validates cleanly and then
+        // fails every time it is scheduled. The constraint is the mirror of the dead letter policy's: a
+        // compacted read needs a single active consumer, a dead letter policy needs competing ones, so the
+        // two can never be enabled together.
+        if (validationContext.getProperty(READ_COMPACTED).asBoolean()
+                && (SHARED.getValue().equals(subscriptionType) || KEY_SHARED.getValue().equals(subscriptionType))) {
+            results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                .explanation("a compacted read needs a single active consumer, so it is supported only on "
+                    + "Exclusive and Failover subscriptions, but the Subscription Type is " + subscriptionType).build());
         }
 
         if (validationContext.getProperty(DEAD_LETTER_TOPIC).isSet() && !deadLetterEnabled) {
@@ -649,6 +721,14 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                 .priorityLevel(context.getProperty(PRIORITY_LEVEL).asInteger())
                 .receiverQueueSize(context.getProperty(RECEIVER_QUEUE_SIZE).asInteger())
                 .subscriptionType(SubscriptionType.valueOf(context.getProperty(SUBSCRIPTION_TYPE).getValue()))
+                .subscriptionMode(SubscriptionMode.valueOf(context.getProperty(SUBSCRIPTION_MODE).getValue()))
+                .readCompacted(context.getProperty(READ_COMPACTED).asBoolean())
+                // Both are read by the client only when a pattern was given, so they are set unconditionally
+                // rather than guarded: a topic-list subscription ignores them, and mirroring that condition
+                // here would be a second place to keep in step with the topics/pattern choice above.
+                .subscriptionTopicsMode(RegexSubscriptionMode.valueOf(context.getProperty(REGEX_SUBSCRIPTION_MODE).getValue()))
+                .patternAutoDiscoveryPeriod(context.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
+                        .asTimePeriod(TimeUnit.SECONDS).intValue(), TimeUnit.SECONDS)
                 .replicateSubscriptionState(context.getProperty(REPLICATE_SUBSCRIPTION_STATE).asBoolean());
     }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -669,9 +669,15 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // works. On an idle topic it delivers nothing at all, because the compacted view is the topic's
         // history and a subscription at the tail has none of it, which is indistinguishable from a broken
         // flow. Said once per start, where it is seen, rather than never.
-        // Validation reads the raw property, so an expression hides a non-persistent topic from it. Here the
-        // expression has been resolved, which makes this the first point the real topic is knowable - and
-        // the last before the client throws on every schedule.
+        // Validation reads the raw property, so an expression hides a non-persistent topic from it. This
+        // catches the expressions that resolve without a FlowFile - environment variables and system
+        // properties - which is the last point before the client throws on every schedule.
+        //
+        // It does NOT catch a topic taken from FlowFile attributes, and cannot: there is no FlowFile at
+        // @OnScheduled, so such an expression resolves to an empty string here. That case is not silently
+        // unprotected so much as already broken - getConsumerBuilder resolves TOPICS without a FlowFile
+        // too, so the subscription is built from the same empty value, while getConsumerId resolves it
+        // with one. That asymmetry predates this property and is tracked as #232.
         if (context.getProperty(READ_COMPACTED).asBoolean() && context.getProperty(TOPICS).isSet()) {
             for (final String topic : context.getProperty(TOPICS).evaluateAttributeExpressions().getValue().split("[, ]")) {
                 if (topic.trim().startsWith(NON_PERSISTENT_PREFIX)) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -231,7 +231,10 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "what a flow that must not miss messages needs. 'NonDurable' leaves no cursor behind: the "
                     + "subscription exists only while the consumer is connected and is forgotten afterwards, "
                     + "which is what tailing a topic wants, and it does not accumulate a backlog on the broker "
-                    + "when the flow is stopped.")
+                    + "when the flow is stopped. What it gives up is delivery across restarts: with no cursor "
+                    + "there is nothing to resume from, so the flow does not pick up where it left off, and "
+                    + "with Subscription Initial Position set to Earliest it re-reads the topic from the "
+                    + "beginning every time it is scheduled.")
             .required(false)
             .allowableValues(SubscriptionMode.Durable.name(), SubscriptionMode.NonDurable.name())
             .defaultValue(SubscriptionMode.Durable.name())
@@ -257,7 +260,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .description("How often the client re-evaluates a Topics Pattern to pick up topics created since "
                     + "it subscribed. A topic that starts matching is not consumed until the next sweep, so "
                     + "this is the worst-case delay before a newly created topic is read. Only applies when "
-                    + "Topics Pattern is used; ignored when Topics is used instead.")
+                    + "Topics Pattern is used; ignored when Topics is used instead - except that the value "
+                    + "must be a whole number of seconds within int range either way, because the client "
+                    + "checks that when it builds any consumer.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("60 sec")
             .required(false)
@@ -674,6 +679,22 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "view is this topic's history, and a new subscription starting at the tail will not see "
                     + "any of it. Set Subscription Initial Position to {} to read the compacted view.",
                     OFFSET_LATEST.getValue(), OFFSET_EARLIEST.getValue());
+        }
+
+        // The mirror of the warning above, and the reason it is worth saying: the Read Compacted guidance
+        // sends users to Earliest, and Earliest on a NonDurable subscription re-reads the whole topic every
+        // time the consumer subscribes. The broker keeps no cursor for a NonDurable subscription, so there
+        // is no resume point - newNonDurableCursor resolves Earliest to the first position in the ledger.
+        // That is every stop/start, and every eviction from the consumer cache too, since removeLRU closes
+        // the consumer it drops and getConsumerId varies with the incoming FlowFile's attributes.
+        if (SubscriptionMode.NonDurable.name().equals(context.getProperty(SUBSCRIPTION_MODE).getValue())
+                && OFFSET_EARLIEST.getValue().equals(context.getProperty(SUBSCRIPTION_INITIAL_POSITION).getValue())) {
+            getLogger().warn("Subscription Mode is {} with Subscription Initial Position {}: the broker keeps "
+                    + "no cursor for a non-durable subscription, so this flow re-reads the topic from the "
+                    + "beginning every time it is scheduled and every time a consumer is evicted from the "
+                    + "cache, rather than resuming. Use {} to resume where it left off, or {} to tail.",
+                    SubscriptionMode.NonDurable.name(), OFFSET_EARLIEST.getValue(),
+                    SubscriptionMode.Durable.name(), OFFSET_LATEST.getValue());
         }
 
         // Record the size only. Replacing the cache here would abandon the consumers the previous one

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -541,6 +541,18 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // subscription type and that every topic is in the persistent domain. Enforcing only the first half
         // leaves exactly the failure this validation exists to prevent - valid on the canvas, then throwing
         // on every schedule - for a non-persistent topic.
+        // Said once, because each half on its own sends the user in a circle: on Shared the compacted read
+        // complains and points at Exclusive, on Exclusive the dead letter policy complains and points back
+        // at Shared. The docs state that no subscription type satisfies both; the validation messages are
+        // the only place the user actually looks.
+        if (validationContext.getProperty(READ_COMPACTED).asBoolean() && deadLetterEnabled) {
+            results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                .explanation("Read Compacted and Max Redelivery Count cannot both be set: a compacted read "
+                    + "needs a single active consumer (Exclusive or Failover) and a dead letter policy needs "
+                    + "competing consumers (Shared or Key_Shared), so no Subscription Type satisfies both")
+                .build());
+        }
+
         if (validationContext.getProperty(READ_COMPACTED).asBoolean()) {
             // Half one: a compacted read needs a single active consumer. This is the mirror of the dead
             // letter policy's constraint, which needs competing consumers, so the two can never both be on.
@@ -598,6 +610,11 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             final long millis = validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
                     .asTimePeriod(TimeUnit.MILLISECONDS);
 
+            // Stricter than the sibling time properties (Auto Update Partition Interval, Expire Time of
+            // Incomplete Chunked Message), which truncate the same way and accept a fraction in silence.
+            // That inconsistency is real, but the fix for it is to tighten those, not to loosen this one -
+            // and tightening them would invalidate flows that are running today, so it belongs in its own
+            // change. Tracked as #225.
             if (millis < 1000L || millis % 1000L != 0L) {
                 results.add(new ValidationResult.Builder().valid(false)
                     .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
@@ -621,6 +638,20 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // works. On an idle topic it delivers nothing at all, because the compacted view is the topic's
         // history and a subscription at the tail has none of it, which is indistinguishable from a broken
         // flow. Said once per start, where it is seen, rather than never.
+        // Validation reads the raw property, so an expression hides a non-persistent topic from it. Here the
+        // expression has been resolved, which makes this the first point the real topic is knowable - and
+        // the last before the client throws on every schedule.
+        if (context.getProperty(READ_COMPACTED).asBoolean() && context.getProperty(TOPICS).isSet()) {
+            for (final String topic : context.getProperty(TOPICS).evaluateAttributeExpressions().getValue().split("[, ]")) {
+                if (topic.trim().startsWith(NON_PERSISTENT_PREFIX)) {
+                    getLogger().warn("Read Compacted is enabled but Topics resolves to the non-persistent "
+                            + "topic {}: only a persistent topic has a compacted view, and the client will "
+                            + "refuse this subscription.", topic.trim());
+                    break;
+                }
+            }
+        }
+
         if (context.getProperty(READ_COMPACTED).asBoolean()
                 && OFFSET_LATEST.getValue().equals(context.getProperty(SUBSCRIPTION_INITIAL_POSITION).getValue())) {
             getLogger().warn("Read Compacted is enabled with Subscription Initial Position {}: the compacted "

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -599,6 +599,25 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             }
         }
 
+        final long discoveryPeriodMillis = validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
+                .asTimePeriod(TimeUnit.MILLISECONDS);
+
+        // Not gated on TOPICS_PATTERN, unlike the granularity rule below, because the two are enforced by
+        // different things. ConsumerBuilderImpl.patternAutoDiscoveryPeriod checks "interval needs to be >= 0"
+        // when the consumer is BUILT, for every consumer, whether or not a pattern was given - while the value
+        // itself is only READ, by PatternMultiTopicsConsumerImpl, when one was. TIME_PERIOD_VALIDATOR already
+        // guarantees a non-negative duration, so an int overflow in the intValue() below is the only way the
+        // builder can see a negative interval, and a topic-list flow would hit that precondition too: without
+        // this bound "30000 days" is accepted here and then throws on every schedule.
+        if (TimeUnit.MILLISECONDS.toSeconds(discoveryPeriodMillis) > Integer.MAX_VALUE) {
+            results.add(new ValidationResult.Builder().valid(false)
+                .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
+                .explanation("the client keeps this as an int number of seconds, so it cannot exceed "
+                    + Integer.MAX_VALUE + " seconds (about 68 years), but "
+                    + validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD).getValue() + " is "
+                    + TimeUnit.MILLISECONDS.toSeconds(discoveryPeriodMillis) + " seconds").build());
+        }
+
         // Only when a pattern is actually in use: the client reads this property nowhere else, so failing a
         // topic-list flow over it would reject a configuration the property has no effect on - which is what
         // the inertness documented on the property, and asserted in the tests, means.
@@ -607,15 +626,12 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             // clamps 0 to 1 - so any fraction of a second is silently discarded, not just a sub-second
             // value: "1500 millis" would run as a one-second sweep and "500 millis" as one per second.
             // Rejecting only the sub-second case would leave the same silent rounding one step up.
-            final long millis = validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
-                    .asTimePeriod(TimeUnit.MILLISECONDS);
-
             // Stricter than the sibling time properties (Auto Update Partition Interval, Expire Time of
             // Incomplete Chunked Message), which truncate the same way and accept a fraction in silence.
             // That inconsistency is real, but the fix for it is to tighten those, not to loosen this one -
             // and tightening them would invalidate flows that are running today, so it belongs in its own
             // change. Tracked as #225.
-            if (millis < 1000L || millis % 1000L != 0L) {
+            if (discoveryPeriodMillis < 1000L || discoveryPeriodMillis % 1000L != 0L) {
                 results.add(new ValidationResult.Builder().valid(false)
                     .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
                     .explanation("the client takes this as whole seconds, so it must be a whole number of "

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -64,6 +64,9 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcessor {
     protected static final String PULSAR_MESSAGE_KEY = "__KEY__";
 
+    /** Pulsar's non-persistent topic domain. A compacted view exists only in the persistent domain. */
+    protected static final String NON_PERSISTENT_PREFIX = "non-persistent://";
+
     protected static final AllowableValue EXCLUSIVE = new AllowableValue("Exclusive", "Exclusive", "There can be only 1 consumer on the same topic with the same subscription name");
     protected static final AllowableValue KEY_SHARED = new AllowableValue("Key_Shared", "Key_Shared", "Multiple consumers will be able to use the same subscription name and messages "
     		+ "but only 1 consumer will receive the messages for a given message key.");
@@ -531,16 +534,56 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "the Subscription Type is " + subscriptionType).build());
         }
 
-        // The client refuses this at subscribe time - "Read compacted can only be used with exclusive or
-        // failover persistent subscriptions" - so without this the processor validates cleanly and then
-        // fails every time it is scheduled. The constraint is the mirror of the dead letter policy's: a
-        // compacted read needs a single active consumer, a dead letter policy needs competing ones, so the
-        // two can never be enabled together.
-        if (validationContext.getProperty(READ_COMPACTED).asBoolean()
-                && (SHARED.getValue().equals(subscriptionType) || KEY_SHARED.getValue().equals(subscriptionType))) {
-            results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
-                .explanation("a compacted read needs a single active consumer, so it is supported only on "
-                    + "Exclusive and Failover subscriptions, but the Subscription Type is " + subscriptionType).build());
+        // The client's precondition has TWO halves, and the message it throws states both: "Read compacted
+        // can only be used with exclusive or failover PERSISTENT subscriptions". PulsarClientImpl checks the
+        // subscription type and that every topic is in the persistent domain. Enforcing only the first half
+        // leaves exactly the failure this validation exists to prevent - valid on the canvas, then throwing
+        // on every schedule - for a non-persistent topic.
+        if (validationContext.getProperty(READ_COMPACTED).asBoolean()) {
+            // Half one: a compacted read needs a single active consumer. This is the mirror of the dead
+            // letter policy's constraint, which needs competing consumers, so the two can never both be on.
+            if (SHARED.getValue().equals(subscriptionType) || KEY_SHARED.getValue().equals(subscriptionType)) {
+                results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                    .explanation("a compacted read needs a single active consumer, so it is supported only on "
+                        + "Exclusive and Failover subscriptions, but the Subscription Type is " + subscriptionType).build());
+            }
+
+            // Half two: only a persistent topic has a compacted view. A non-persistent topic is refused
+            // outright when named directly, and - worse - is accepted and silently served uncompacted when
+            // it arrives through a pattern, because the client's check reads the topic list, which a pattern
+            // subscription leaves empty.
+            if (validationContext.getProperty(TOPICS).isSet()) {
+                for (final String topic : validationContext.getProperty(TOPICS).getValue().split("[, ]")) {
+                    // An expression cannot be resolved here, so it is left to the client to refuse.
+                    if (topic.trim().startsWith(NON_PERSISTENT_PREFIX)) {
+                        results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                            .explanation("only a persistent topic has a compacted view, but Topics names the "
+                                + "non-persistent topic " + topic.trim()).build());
+                        break;
+                    }
+                }
+            } else if (validationContext.getProperty(TOPICS_PATTERN).isSet()) {
+                final String pattern = validationContext.getProperty(TOPICS_PATTERN).getValue();
+                final String matchMode = validationContext.getProperty(REGEX_SUBSCRIPTION_MODE).getValue();
+
+                // The client cannot catch this one: with a pattern its topic list is empty, so its
+                // persistent-domain check passes vacuously and the non-persistent topics the pattern matches
+                // are subscribed and served as a live stream. The flow then reads a full stream while its
+                // configuration says it is reading the latest value per key, and nothing reports it.
+                if (!RegexSubscriptionMode.PersistentOnly.name().equals(matchMode)) {
+                    results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                        .explanation("a Topics Pattern that can match non-persistent topics cannot be read "
+                            + "compacted - those topics would be served uncompacted with no error - so Topics "
+                            + "Pattern Match Mode must be " + RegexSubscriptionMode.PersistentOnly.name()
+                            + ", not " + matchMode).build());
+                }
+
+                if (pattern != null && pattern.trim().startsWith(NON_PERSISTENT_PREFIX)) {
+                    results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
+                        .explanation("only a persistent topic has a compacted view, but Topics Pattern matches "
+                            + "the non-persistent domain").build());
+                }
+            }
         }
 
         if (validationContext.getProperty(DEAD_LETTER_TOPIC).isSet() && !deadLetterEnabled) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -587,14 +587,23 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             }
         }
 
-        // asTimePeriod truncates to whole seconds, and the client clamps 0 to 1 with Math.max(1, period).
-        // So "500 millis" becomes a broker topic lookup every second - not what was asked for, and silent.
-        if (validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
-                .asTimePeriod(TimeUnit.MILLISECONDS) < 1000L) {
-            results.add(new ValidationResult.Builder().valid(false)
-                .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
-                .explanation("the discovery interval is whole seconds; anything under 1 second would be "
-                    + "silently rounded to a topic lookup every second").build());
+        // Only when a pattern is actually in use: the client reads this property nowhere else, so failing a
+        // topic-list flow over it would reject a configuration the property has no effect on - which is what
+        // the inertness documented on the property, and asserted in the tests, means.
+        if (validationContext.getProperty(TOPICS_PATTERN).isSet()) {
+            // The value reaches the client as whole seconds - asTimePeriod truncates and the client then
+            // clamps 0 to 1 - so any fraction of a second is silently discarded, not just a sub-second
+            // value: "1500 millis" would run as a one-second sweep and "500 millis" as one per second.
+            // Rejecting only the sub-second case would leave the same silent rounding one step up.
+            final long millis = validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
+                    .asTimePeriod(TimeUnit.MILLISECONDS);
+
+            if (millis < 1000L || millis % 1000L != 0L) {
+                results.add(new ValidationResult.Builder().valid(false)
+                    .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
+                    .explanation("the client takes this as whole seconds, so it must be a whole number of "
+                        + "seconds and at least 1; anything else is silently rounded down").build());
+            }
         }
 
         if (validationContext.getProperty(DEAD_LETTER_TOPIC).isSet() && !deadLetterEnabled) {
@@ -607,6 +616,19 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
 
     @OnScheduled
     public void init(ProcessContext context) {
+        // Not a validation error: on a live topic this configuration does deliver - new messages arrive and
+        // are read compacted - so it is unusual rather than invalid, and rejecting it would fail a flow that
+        // works. On an idle topic it delivers nothing at all, because the compacted view is the topic's
+        // history and a subscription at the tail has none of it, which is indistinguishable from a broken
+        // flow. Said once per start, where it is seen, rather than never.
+        if (context.getProperty(READ_COMPACTED).asBoolean()
+                && OFFSET_LATEST.getValue().equals(context.getProperty(SUBSCRIPTION_INITIAL_POSITION).getValue())) {
+            getLogger().warn("Read Compacted is enabled with Subscription Initial Position {}: the compacted "
+                    + "view is this topic's history, and a new subscription starting at the tail will not see "
+                    + "any of it. Set Subscription Initial Position to {} to read the compacted view.",
+                    OFFSET_LATEST.getValue(), OFFSET_EARLIEST.getValue());
+        }
+
         // Record the size only. Replacing the cache here would abandon the consumers the previous one
         // holds without closing them, and the broker then refuses the replacement consumer on an
         // Exclusive subscription with "Exclusive consumer is already connected". The cache is built

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -528,13 +528,16 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         }
 
         final boolean deadLetterEnabled = validationContext.getProperty(MAX_REDELIVER_COUNT).isSet();
+        final boolean readCompacted = validationContext.getProperty(READ_COMPACTED).asBoolean();
         final String subscriptionType = validationContext.getProperty(SUBSCRIPTION_TYPE).getValue();
 
         // The client builds a dead letter policy only for Shared and Key_Shared subscriptions. On the other
         // two the consumer is accepted and simply never dead-letters anything, so a flow would sit waiting on
         // a dead letter topic that can never receive a message. Reject it here instead, as CustomPartition is
         // rejected on the producer side, rather than let the configuration look like it took effect.
-        if (deadLetterEnabled && !SHARED.getValue().equals(subscriptionType)
+        // Not when a compacted read is also on: the combination has its own message below, and this one
+        // would send the user to Shared, which that message has just told them cannot work either.
+        if (deadLetterEnabled && !readCompacted && !SHARED.getValue().equals(subscriptionType)
                 && !KEY_SHARED.getValue().equals(subscriptionType)) {
             results.add(new ValidationResult.Builder().valid(false).subject(MAX_REDELIVER_COUNT.getDisplayName())
                 .explanation("a dead letter policy is supported only on Shared and Key_Shared subscriptions, but "
@@ -550,7 +553,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // complains and points at Exclusive, on Exclusive the dead letter policy complains and points back
         // at Shared. The docs state that no subscription type satisfies both; the validation messages are
         // the only place the user actually looks.
-        if (validationContext.getProperty(READ_COMPACTED).asBoolean() && deadLetterEnabled) {
+        if (readCompacted && deadLetterEnabled) {
             results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
                 .explanation("Read Compacted and Max Redelivery Count cannot both be set: a compacted read "
                     + "needs a single active consumer (Exclusive or Failover) and a dead letter policy needs "
@@ -558,10 +561,17 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                 .build());
         }
 
-        if (validationContext.getProperty(READ_COMPACTED).asBoolean()) {
+        if (readCompacted) {
             // Half one: a compacted read needs a single active consumer. This is the mirror of the dead
             // letter policy's constraint, which needs competing consumers, so the two can never both be on.
-            if (SHARED.getValue().equals(subscriptionType) || KEY_SHARED.getValue().equals(subscriptionType)) {
+            // Suppressed when the dead letter policy is on, which is what makes "said once" true rather
+            // than aspirational: this message names Exclusive, the dead letter rule above names Shared, and
+            // a user alternating between them never reaches a valid state. The combined message is the only
+            // one that describes the actual situation. Half two below is not suppressed - it names no
+            // subscription type, so it is not part of that circle, and a non-persistent topic is a second
+            // independent problem worth hearing about.
+            if (!deadLetterEnabled
+                    && (SHARED.getValue().equals(subscriptionType) || KEY_SHARED.getValue().equals(subscriptionType))) {
                 results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
                     .explanation("a compacted read needs a single active consumer, so it is supported only on "
                         + "Exclusive and Failover subscriptions, but the Subscription Type is " + subscriptionType).build());

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -215,7 +215,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "no key are not delivered at all. The topic must have compaction running for there to be "
                     + "a compacted view to read; without it the subscription reads the normal backlog. Pulsar "
                     + "permits this only on a persistent topic with a single active consumer, so the "
-                    + "Subscription Type must be Exclusive or Failover.")
+                    + "Subscription Type must be Exclusive or Failover. Set Subscription Initial Position to "
+                    + "Earliest: the compacted view is the history of the topic, so a new subscription left at "
+                    + "the default of Latest starts at the tail and delivers nothing at all.")
             .required(false)
             .allowableValues("true", "false")
             .defaultValue("false")
@@ -563,10 +565,15 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     }
                 }
             } else if (validationContext.getProperty(TOPICS_PATTERN).isSet()) {
-                final String pattern = validationContext.getProperty(TOPICS_PATTERN).getValue();
                 final String matchMode = validationContext.getProperty(REGEX_SUBSCRIPTION_MODE).getValue();
 
-                // The client cannot catch this one: with a pattern its topic list is empty, so its
+                // Only the match mode is checked, never the pattern's own scheme: TopicsPatternFactory
+                // runs the pattern through TopicList.removeTopicDomainScheme(), and matching strips the
+                // scheme from every candidate topic too, so a "non-persistent://" prefix on the pattern
+                // selects nothing - the domain comes from RegexSubscriptionMode alone. Rejecting on the
+                // prefix would fail a working configuration.
+                //
+                // The client cannot catch the real hazard: with a pattern its topic list is empty, so its
                 // persistent-domain check passes vacuously and the non-persistent topics the pattern matches
                 // are subscribed and served as a live stream. The flow then reads a full stream while its
                 // configuration says it is reading the latest value per key, and nothing reports it.
@@ -577,13 +584,17 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                             + "Pattern Match Mode must be " + RegexSubscriptionMode.PersistentOnly.name()
                             + ", not " + matchMode).build());
                 }
-
-                if (pattern != null && pattern.trim().startsWith(NON_PERSISTENT_PREFIX)) {
-                    results.add(new ValidationResult.Builder().valid(false).subject(READ_COMPACTED.getDisplayName())
-                        .explanation("only a persistent topic has a compacted view, but Topics Pattern matches "
-                            + "the non-persistent domain").build());
-                }
             }
+        }
+
+        // asTimePeriod truncates to whole seconds, and the client clamps 0 to 1 with Math.max(1, period).
+        // So "500 millis" becomes a broker topic lookup every second - not what was asked for, and silent.
+        if (validationContext.getProperty(PATTERN_AUTO_DISCOVERY_PERIOD)
+                .asTimePeriod(TimeUnit.MILLISECONDS) < 1000L) {
+            results.add(new ValidationResult.Builder().valid(false)
+                .subject(PATTERN_AUTO_DISCOVERY_PERIOD.getDisplayName())
+                .explanation("the discovery interval is whole seconds; anything under 1 second would be "
+                    + "silently rounded to a topic lookup every second").build());
         }
 
         if (validationContext.getProperty(DEAD_LETTER_TOPIC).isSet() && !deadLetterEnabled) {

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -30,6 +30,38 @@
 </p>
 
 
+
+<br/>
+<h3>Choosing what to consume</h3>
+<p>
+    <i>Topics</i> and <i>Topics Pattern</i> are alternatives; exactly one must be set.
+</p>
+<p>
+    A pattern matches <b>persistent topics only</b> by default, which is why a pattern that plainly matches a
+    non-persistent topic can appear to do nothing. <i>Topics Pattern Match Mode</i> changes that -
+    <code>PersistentOnly</code> (the default, and the previous behaviour), <code>NonPersistentOnly</code>, or
+    <code>AllTopics</code>. <i>Topics Pattern Discovery Interval</i> is how often the client re-evaluates the
+    pattern, and so the worst-case delay before a newly created matching topic is read. Both are ignored when
+    <i>Topics</i> is used.
+</p>
+<p>
+    <i>Subscription Mode</i> decides whether the broker keeps a cursor. <code>Durable</code>, the default,
+    survives a restart and resumes where it left off. <code>NonDurable</code> leaves no cursor behind: the
+    subscription exists only while the consumer is connected, which is what tailing a topic wants, and it
+    accumulates no backlog on the broker while the flow is stopped.
+</p>
+<p>
+    <i>Read Compacted</i> reads the compacted view of a topic - the latest value for each key - instead of its
+    backlog. Messages without a key are not delivered at all, and the topic must actually have compaction
+    running for there to be a compacted view to read; without one the subscription reads the normal backlog.
+</p>
+<p>
+    <b>The two single-consumer constraints are mirror images.</b> A compacted read needs a <i>single active
+    consumer</i>, so Pulsar permits it only on <code>Exclusive</code> and <code>Failover</code>. A dead letter
+    policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
+    <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
+    type at validation rather than letting the client fail at subscribe time.
+</p>
 <br/>
 <h3>Failure handling and redelivery</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -67,8 +67,11 @@
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
     named literally in <i>Topics</i> is rejected at validation, as is a <i>Topics Pattern</i> whose
-    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression cannot be checked
-    until the expression resolves, so that case is warned about at startup instead. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression is only checked if
+    the expression resolves at startup - an environment variable or a system property does, and a
+    non-persistent topic from one of those is warned about when the processor starts. A topic taken from
+    FlowFile attributes does not resolve at startup, so neither validation nor the warning can see it and
+    the client is what refuses the subscription. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
     is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
     comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -60,8 +60,9 @@
     used with exclusive or failover <b>persistent</b> subscriptions"</i>. It needs a <b>single active
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
-    is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
-    topics. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    named literally in <i>Topics</i> is rejected at validation, as is a <i>Topics Pattern</i> whose
+    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression cannot be checked
+    until the expression resolves, so that case is warned about at startup instead. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
     is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
     comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -42,13 +42,19 @@
     <code>PersistentOnly</code> (the default, and the previous behaviour), <code>NonPersistentOnly</code>, or
     <code>AllTopics</code>. <i>Topics Pattern Discovery Interval</i> is how often the client re-evaluates the
     pattern, and so the worst-case delay before a newly created matching topic is read. Both are ignored when
-    <i>Topics</i> is used.
+    <i>Topics</i> is used - with one exception: the discovery interval is still bounded to a whole number of
+    seconds within <code>int</code> range whichever is set, because the client checks that bound when it
+    builds any consumer, not only a pattern one.
 </p>
 <p>
     <i>Subscription Mode</i> decides whether the broker keeps a cursor. <code>Durable</code>, the default,
     survives a restart and resumes where it left off. <code>NonDurable</code> leaves no cursor behind: the
     subscription exists only while the consumer is connected, which is what tailing a topic wants, and it
     accumulates no backlog on the broker while the flow is stopped.
+ What it gives up is delivery across restarts: with no cursor there is no resume point, so a
+    <code>NonDurable</code> subscription set to <i>Subscription Initial Position</i>
+    <code>Earliest</code> re-reads the topic from the beginning every time it is scheduled, and every
+    time a consumer is evicted from the cache. The processor warns when it starts in that state.
 </p>
 <p>
     <i>Read Compacted</i> reads the compacted view of a topic - the latest value for each key - instead of its

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -61,7 +61,9 @@
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
     is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
-    topics. That second case matters because the client cannot catch it: with a pattern its topic list is
+    topics. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
+    comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is
     served as a live stream - the flow reads a full stream while its configuration says it is reading the
     latest value per key, and nothing reports it.
@@ -72,6 +74,12 @@
     policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
     <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
     type at validation rather than letting the client fail at subscribe time.
+</p>
+<p>
+    <b>Set <i>Subscription Initial Position</i> to <code>Earliest</code>.</b> The compacted view is the
+    history of the topic - the latest value for each key seen so far. A new subscription left at the default
+    of <code>Latest</code> starts at the tail, so a compacted read delivers <b>nothing at all</b> until a new
+    message arrives, which looks identical to a broken flow.
 </p>
 <p>
     <b>Concurrent Tasks.</b> Because <i>Read Compacted</i> requires <code>Exclusive</code> or

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -56,11 +56,28 @@
     running for there to be a compacted view to read; without one the subscription reads the normal backlog.
 </p>
 <p>
+    <i>Read Compacted</i> has two requirements, and the client states both: <i>"Read compacted can only be
+    used with exclusive or failover <b>persistent</b> subscriptions"</i>. It needs a <b>single active
+    consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
+    domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
+    is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
+    topics. That second case matters because the client cannot catch it: with a pattern its topic list is
+    empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is
+    served as a live stream - the flow reads a full stream while its configuration says it is reading the
+    latest value per key, and nothing reports it.
+</p>
+<p>
     <b>The two single-consumer constraints are mirror images.</b> A compacted read needs a <i>single active
     consumer</i>, so Pulsar permits it only on <code>Exclusive</code> and <code>Failover</code>. A dead letter
     policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
     <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
     type at validation rather than letting the client fail at subscribe time.
+</p>
+<p>
+    <b>Concurrent Tasks.</b> Because <i>Read Compacted</i> requires <code>Exclusive</code> or
+    <code>Failover</code>, a flow using it sits on a subscription type where <i>Concurrent Tasks</i> greater
+    than one is not currently safe - one task's cumulative acknowledgement can acknowledge messages another
+    task is still holding. Run such flows with a single task until issue #223 is resolved.
 </p>
 <br/>
 <h3>Failure handling and redelivery</h3>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -29,6 +29,38 @@
     This processor provides the ability to consume records from a schema-aware topic in Apache &trade; Pulsar.
 </p>
 
+
+<br/>
+<h3>Choosing what to consume</h3>
+<p>
+    <i>Topics</i> and <i>Topics Pattern</i> are alternatives; exactly one must be set.
+</p>
+<p>
+    A pattern matches <b>persistent topics only</b> by default, which is why a pattern that plainly matches a
+    non-persistent topic can appear to do nothing. <i>Topics Pattern Match Mode</i> changes that -
+    <code>PersistentOnly</code> (the default, and the previous behaviour), <code>NonPersistentOnly</code>, or
+    <code>AllTopics</code>. <i>Topics Pattern Discovery Interval</i> is how often the client re-evaluates the
+    pattern, and so the worst-case delay before a newly created matching topic is read. Both are ignored when
+    <i>Topics</i> is used.
+</p>
+<p>
+    <i>Subscription Mode</i> decides whether the broker keeps a cursor. <code>Durable</code>, the default,
+    survives a restart and resumes where it left off. <code>NonDurable</code> leaves no cursor behind: the
+    subscription exists only while the consumer is connected, which is what tailing a topic wants, and it
+    accumulates no backlog on the broker while the flow is stopped.
+</p>
+<p>
+    <i>Read Compacted</i> reads the compacted view of a topic - the latest value for each key - instead of its
+    backlog. Messages without a key are not delivered at all, and the topic must actually have compaction
+    running for there to be a compacted view to read; without one the subscription reads the normal backlog.
+</p>
+<p>
+    <b>The two single-consumer constraints are mirror images.</b> A compacted read needs a <i>single active
+    consumer</i>, so Pulsar permits it only on <code>Exclusive</code> and <code>Failover</code>. A dead letter
+    policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
+    <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
+    type at validation rather than letting the client fail at subscribe time.
+</p>
 <br/>
 <h3>Failure handling and redelivery</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -60,7 +60,9 @@
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
     is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
-    topics. That second case matters because the client cannot catch it: with a pattern its topic list is
+    topics. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
+    comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is
     served as a live stream - the flow reads a full stream while its configuration says it is reading the
     latest value per key, and nothing reports it.
@@ -71,6 +73,12 @@
     policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
     <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
     type at validation rather than letting the client fail at subscribe time.
+</p>
+<p>
+    <b>Set <i>Subscription Initial Position</i> to <code>Earliest</code>.</b> The compacted view is the
+    history of the topic - the latest value for each key seen so far. A new subscription left at the default
+    of <code>Latest</code> starts at the tail, so a compacted read delivers <b>nothing at all</b> until a new
+    message arrives, which looks identical to a broken flow.
 </p>
 <p>
     <b>Concurrent Tasks.</b> Because <i>Read Compacted</i> requires <code>Exclusive</code> or

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -66,8 +66,11 @@
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
     named literally in <i>Topics</i> is rejected at validation, as is a <i>Topics Pattern</i> whose
-    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression cannot be checked
-    until the expression resolves, so that case is warned about at startup instead. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression is only checked if
+    the expression resolves at startup - an environment variable or a system property does, and a
+    non-persistent topic from one of those is warned about when the processor starts. A topic taken from
+    FlowFile attributes does not resolve at startup, so neither validation nor the warning can see it and
+    the client is what refuses the subscription. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
     is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
     comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -41,13 +41,19 @@
     <code>PersistentOnly</code> (the default, and the previous behaviour), <code>NonPersistentOnly</code>, or
     <code>AllTopics</code>. <i>Topics Pattern Discovery Interval</i> is how often the client re-evaluates the
     pattern, and so the worst-case delay before a newly created matching topic is read. Both are ignored when
-    <i>Topics</i> is used.
+    <i>Topics</i> is used - with one exception: the discovery interval is still bounded to a whole number of
+    seconds within <code>int</code> range whichever is set, because the client checks that bound when it
+    builds any consumer, not only a pattern one.
 </p>
 <p>
     <i>Subscription Mode</i> decides whether the broker keeps a cursor. <code>Durable</code>, the default,
     survives a restart and resumes where it left off. <code>NonDurable</code> leaves no cursor behind: the
     subscription exists only while the consumer is connected, which is what tailing a topic wants, and it
     accumulates no backlog on the broker while the flow is stopped.
+ What it gives up is delivery across restarts: with no cursor there is no resume point, so a
+    <code>NonDurable</code> subscription set to <i>Subscription Initial Position</i>
+    <code>Earliest</code> re-reads the topic from the beginning every time it is scheduled, and every
+    time a consumer is evicted from the cache. The processor warns when it starts in that state.
 </p>
 <p>
     <i>Read Compacted</i> reads the compacted view of a topic - the latest value for each key - instead of its

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -59,8 +59,9 @@
     used with exclusive or failover <b>persistent</b> subscriptions"</i>. It needs a <b>single active
     consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
     domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
-    is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
-    topics. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
+    named literally in <i>Topics</i> is rejected at validation, as is a <i>Topics Pattern</i> whose
+    <i>Match Mode</i> admits non-persistent topics. A topic supplied by an expression cannot be checked
+    until the expression resolves, so that case is warned about at startup instead. A <code>non-persistent://</code> prefix on the <i>pattern itself</i> is not rejected, because it
     is inert - the client strips the scheme from the pattern and from every candidate topic, so the domain
     comes from <i>Match Mode</i> alone. That second case matters because the client cannot catch it: with a pattern its topic list is
     empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -55,11 +55,28 @@
     running for there to be a compacted view to read; without one the subscription reads the normal backlog.
 </p>
 <p>
+    <i>Read Compacted</i> has two requirements, and the client states both: <i>"Read compacted can only be
+    used with exclusive or failover <b>persistent</b> subscriptions"</i>. It needs a <b>single active
+    consumer</b> - <code>Exclusive</code> or <code>Failover</code> - and it needs the <b>persistent
+    domain</b>, because only a persistent topic has a compacted view. A <code>non-persistent://</code> topic
+    is rejected at validation, as is a <i>Topics Pattern</i> whose <i>Match Mode</i> admits non-persistent
+    topics. That second case matters because the client cannot catch it: with a pattern its topic list is
+    empty, so its own domain check passes vacuously and any non-persistent topic the pattern matches is
+    served as a live stream - the flow reads a full stream while its configuration says it is reading the
+    latest value per key, and nothing reports it.
+</p>
+<p>
     <b>The two single-consumer constraints are mirror images.</b> A compacted read needs a <i>single active
     consumer</i>, so Pulsar permits it only on <code>Exclusive</code> and <code>Failover</code>. A dead letter
     policy needs <i>competing</i> consumers, so Pulsar builds one only for <code>Shared</code> and
     <code>Key_Shared</code>. No subscription type satisfies both, and this processor rejects each on the wrong
     type at validation rather than letting the client fail at subscribe time.
+</p>
+<p>
+    <b>Concurrent Tasks.</b> Because <i>Read Compacted</i> requires <code>Exclusive</code> or
+    <code>Failover</code>, a flow using it sits on a subscription type where <i>Concurrent Tasks</i> greater
+    than one is not currently safe - one task's cumulative acknowledgement can acknowledge messages another
+    task is still holding. Run such flows with a single task until issue #223 is resolved.
 </p>
 <br/>
 <h3>Failure handling and redelivery</h3>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Read Compacted and the Topics Pattern match mode, against a real broker.
+ * <p>
+ * Neither can be shown with a mocked client. A compacted read is the broker serving a different view of the
+ * topic, and what a pattern matches is decided broker-side. The unit suite covers the validation rules; this
+ * covers what the broker then does.
+ */
+public class ConsumePulsarTopicPropertiesIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "20");
+    }
+
+    /**
+     * A Topics Pattern has always defaulted to matching persistent topics only, with no way to say
+     * otherwise - so a pattern that plainly matches a non-persistent topic silently did not consume from it.
+     * This is the property that fixes that, and the assertion is that the non-persistent topic is now read.
+     */
+    @Test
+    public void aNonPersistentTopicIsMatchedOnlyWhenTheMatchModeAllowsIt() throws Exception {
+        final String suffix = "match-" + System.nanoTime();
+        final String nonPersistent = "non-persistent://public/default/" + suffix;
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN,
+                "non-persistent://public/default/" + suffix);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "match-sub");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "NonPersistentOnly");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "1 sec");
+
+        // A non-persistent topic drops messages with no connected consumer, so the processor has to be
+        // subscribed before anything is published.
+        runner.run(1, false, true);
+
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(nonPersistent).create()) {
+            await("the pattern to discover the non-persistent topic and deliver a message", () -> {
+                producer.send("non-persistent-payload".getBytes());
+                runner.run(1, false, false);
+                return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
+            });
+        }
+
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
+        assertTrue("nothing was consumed from the non-persistent topic", !flowFiles.isEmpty());
+        assertTrue("the consumed content did not come from the non-persistent topic",
+                new String(flowFiles.get(0).toByteArray()).contains("non-persistent-payload"));
+    }
+
+    /**
+     * A compacted read serves the latest value per key rather than the backlog. The topic is written with
+     * two values for one key, so a normal read sees both and a compacted read sees only the second.
+     * <p>
+     * Compaction is triggered explicitly and waited for: without a compacted ledger the broker serves the
+     * normal backlog, and the test would pass for the wrong reason on a topic that was simply never
+     * compacted.
+     */
+    @Test
+    public void aCompactedReadSeesOnlyTheLatestValuePerKey() throws Exception {
+        final String topic = "persistent://public/default/compacted-" + System.nanoTime();
+
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            producer.newMessage().key("k1").value("v1-old".getBytes()).send();
+            producer.newMessage().key("k1").value("v2-new".getBytes()).send();
+        }
+
+        // Compact, and wait for it to actually finish, so there is genuinely a compacted view to read.
+        // The admin CLI reports "Compaction was a success" when it has, and "Compaction has not been run
+        // for <topic> since broker startup" when it has not - so matching the success string is what keeps
+        // this test from passing against an uncompacted topic, where the broker just serves the backlog and
+        // the assertions below would be measuring nothing.
+        exec("bin/pulsar-admin", "topics", "compact", topic);
+        await("compaction to report success", () ->
+                exec("bin/pulsar-admin", "topics", "compaction-status", topic).contains("was a success"));
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "compacted-sub");
+        // Read Compacted needs a single active consumer; the validator enforces this.
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        runner.assertValid();
+
+        await("the compacted view to be delivered", () -> {
+            runner.run(1, false, true);
+            return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
+        });
+
+        final String content = new String(
+                runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).get(0).toByteArray());
+
+        assertTrue("the latest value for the key was not delivered: " + content, content.contains("v2-new"));
+        assertTrue("the superseded value was delivered, so this was not a compacted read: " + content,
+                !content.contains("v1-old"));
+    }
+
+    /** Runs a command inside the broker container and returns its combined output. */
+    private static String exec(final String... command) throws Exception {
+        final org.testcontainers.containers.Container.ExecResult result = PULSAR.execInContainer(command);
+        return result.getStdout() + result.getStderr();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
@@ -19,12 +19,10 @@ package org.apache.nifi.processors.pulsar.it;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -134,83 +132,6 @@ public class ConsumePulsarTopicPropertiesIT extends AbstractPulsarIT {
         assertTrue("the latest value for the key was not delivered: " + content, content.contains("v2-new"));
         assertTrue("the superseded value was delivered, so this was not a compacted read: " + content,
                 !content.contains("v1-old"));
-    }
-
-    /**
-     * The <em>subscribe</em> path survives Concurrent Tasks &gt; 1 on an Exclusive subscription: both tasks
-     * share one consumer, so the broker never sees a second one and never refuses it.
-     *
-     * <p><b>This is not a green light for Concurrent Tasks &gt; 1 on a non-Shared subscription.</b> The
-     * acknowledge path is unsafe there and this test does not exercise it: with a shared consumer, one
-     * task's {@code acknowledgeCumulative} acknowledges messages still held by another task's in-flight
-     * batch, so a write failure in that other task loses them - see #223. Read Compacted makes that path
-     * more likely to be reached, because it requires Exclusive or Failover.
-     *
-     * <p>What this pins is narrow and worth pinning on its own: {@code getConsumer()} is synchronized and
-     * caches by consumer id, so concurrent tasks share one consumer rather than each creating one. If that
-     * ever changed, the second consumer would be refused and messages would silently stop arriving. The
-     * producer side had no such sharing, which is what #219 was.
-     */
-    @Test
-    public void concurrentTasksShareOneConsumerSoTheBrokerNeverRefusesASecond() throws Exception {
-        final String topic = "persistent://public/default/compacted-concurrent-" + System.nanoTime();
-
-        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
-            producer.newMessage().key("k1").value("v1-old".getBytes()).send();
-            producer.newMessage().key("k1").value("v2-new".getBytes()).send();
-            producer.newMessage().key("k2").value("w1-only".getBytes()).send();
-        }
-
-        exec("bin/pulsar-admin", "topics", "compact", topic);
-        await("compaction to report success", () ->
-                exec("bin/pulsar-admin", "topics", "compaction-status", topic).contains("was a success"));
-
-        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "compacted-concurrent-sub");
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
-        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
-        // The configuration that broke the producer side in #219.
-        runner.setThreadCount(2);
-        runner.assertValid();
-
-        // The wait has to demand everything the assertions demand. consume() drains with
-        // receive(0, SECONDS), which returns null as soon as the local queue is empty, so a first trigger
-        // can legitimately emit one key and stop - waiting on "any FlowFile" would then race the second.
-        await("both compacted keys to be delivered under two concurrent tasks", () -> {
-            runner.run(2, false, true);
-            final String sofar = consumedContent();
-            return sofar.contains("v2-new") && sofar.contains("w1-only");
-        });
-
-        final String content = consumedContent();
-
-        assertTrue("the latest value for k1 was not delivered: " + content, content.contains("v2-new"));
-        assertTrue("the only value for k2 was not delivered: " + content, content.contains("w1-only"));
-        assertTrue("a superseded value was delivered, so this was not a compacted read: " + content,
-                !content.contains("v1-old"));
-
-        // The broker refusing a second consumer surfaces as a PulsarClientException carried on the log
-        // record, not in its message: MockComponentLog keeps the throwable in a separate field, so
-        // getMsg() holds only the processor's own format string and asserting on it would assert nothing.
-        for (final LogMessage error : runner.getLogger().getErrorMessages()) {
-            final Throwable thrown = error.getThrowable();
-            if (thrown != null && thrown.getMessage() != null) {
-                assertTrue("a second consumer was refused, so the tasks did not share one consumer: "
-                                + thrown.getMessage(),
-                        !thrown.getMessage().contains("Exclusive consumer is already connected"));
-            }
-        }
-    }
-
-    /** Everything routed to success so far, concatenated. */
-    private String consumedContent() {
-        final StringBuilder consumed = new StringBuilder();
-
-        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS)) {
-            consumed.append(new String(flowFile.toByteArray())).append("\n");
-        }
-
-        return consumed.toString();
     }
 
     /** Runs a command inside the broker container and returns its combined output. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.pulsar.it;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
@@ -86,6 +87,46 @@ public class ConsumePulsarTopicPropertiesIT extends AbstractPulsarIT {
         assertTrue("nothing was consumed from the non-persistent topic", !flowFiles.isEmpty());
         assertTrue("the consumed content did not come from the non-persistent topic",
                 new String(flowFiles.get(0).toByteArray()).contains("non-persistent-payload"));
+    }
+
+    /**
+     * The other half of the rule above, and the premise the Read Compacted validation rests on: under the
+     * default <code>PersistentOnly</code> the same pattern must not match the same non-persistent topic.
+     * Without this, the positive case alone would also hold on a broker that ignored the match mode
+     * entirely - and the rule at customValidate ("Match Mode must be PersistentOnly" for a compacted read)
+     * would be resting on an untested assumption.
+     * <p>
+     * The wait is the same 30s the positive case gets before it gives up, so this is "did not arrive in the
+     * time the match mode needs to work", not "did not arrive yet".
+     */
+    @Test
+    public void aNonPersistentTopicIsNotMatchedUnderTheDefaultMatchMode() throws Exception {
+        final String suffix = "no-match-" + System.nanoTime();
+        final String nonPersistent = "non-persistent://public/default/" + suffix;
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN,
+                "non-persistent://public/default/" + suffix);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "no-match-sub");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "PersistentOnly");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "1 sec");
+
+        runner.run(1, false, true);
+
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(nonPersistent).create()) {
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+
+            while (System.nanoTime() < deadline) {
+                producer.send("non-persistent-payload".getBytes());
+                runner.run(1, false, false);
+
+                assertTrue("the non-persistent topic was consumed under PersistentOnly, so the match mode "
+                        + "is not what decides the domain a pattern matches",
+                        runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty());
+
+                Thread.sleep(250);
+            }
+        }
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
@@ -121,8 +121,13 @@ public class ConsumePulsarTopicPropertiesIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
         runner.assertValid();
 
+        // One initializing run, then poll without re-initializing: run(1, false, true) re-runs @OnScheduled
+        // on every iteration with no matching @OnStopped, which leaks a thread pool per poll once
+        // Async Enabled is on. The sibling test above already does it this way.
+        runner.run(1, false, true);
+
         await("the compacted view to be delivered", () -> {
-            runner.run(1, false, true);
+            runner.run(1, false, false);
             return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
         });
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarTopicPropertiesIT.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -133,6 +134,83 @@ public class ConsumePulsarTopicPropertiesIT extends AbstractPulsarIT {
         assertTrue("the latest value for the key was not delivered: " + content, content.contains("v2-new"));
         assertTrue("the superseded value was delivered, so this was not a compacted read: " + content,
                 !content.contains("v1-old"));
+    }
+
+    /**
+     * The <em>subscribe</em> path survives Concurrent Tasks &gt; 1 on an Exclusive subscription: both tasks
+     * share one consumer, so the broker never sees a second one and never refuses it.
+     *
+     * <p><b>This is not a green light for Concurrent Tasks &gt; 1 on a non-Shared subscription.</b> The
+     * acknowledge path is unsafe there and this test does not exercise it: with a shared consumer, one
+     * task's {@code acknowledgeCumulative} acknowledges messages still held by another task's in-flight
+     * batch, so a write failure in that other task loses them - see #223. Read Compacted makes that path
+     * more likely to be reached, because it requires Exclusive or Failover.
+     *
+     * <p>What this pins is narrow and worth pinning on its own: {@code getConsumer()} is synchronized and
+     * caches by consumer id, so concurrent tasks share one consumer rather than each creating one. If that
+     * ever changed, the second consumer would be refused and messages would silently stop arriving. The
+     * producer side had no such sharing, which is what #219 was.
+     */
+    @Test
+    public void concurrentTasksShareOneConsumerSoTheBrokerNeverRefusesASecond() throws Exception {
+        final String topic = "persistent://public/default/compacted-concurrent-" + System.nanoTime();
+
+        try (Producer<byte[]> producer = getClient().newProducer(Schema.BYTES).topic(topic).create()) {
+            producer.newMessage().key("k1").value("v1-old".getBytes()).send();
+            producer.newMessage().key("k1").value("v2-new".getBytes()).send();
+            producer.newMessage().key("k2").value("w1-only".getBytes()).send();
+        }
+
+        exec("bin/pulsar-admin", "topics", "compact", topic);
+        await("compaction to report success", () ->
+                exec("bin/pulsar-admin", "topics", "compaction-status", topic).contains("was a success"));
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "compacted-concurrent-sub");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        // The configuration that broke the producer side in #219.
+        runner.setThreadCount(2);
+        runner.assertValid();
+
+        // The wait has to demand everything the assertions demand. consume() drains with
+        // receive(0, SECONDS), which returns null as soon as the local queue is empty, so a first trigger
+        // can legitimately emit one key and stop - waiting on "any FlowFile" would then race the second.
+        await("both compacted keys to be delivered under two concurrent tasks", () -> {
+            runner.run(2, false, true);
+            final String sofar = consumedContent();
+            return sofar.contains("v2-new") && sofar.contains("w1-only");
+        });
+
+        final String content = consumedContent();
+
+        assertTrue("the latest value for k1 was not delivered: " + content, content.contains("v2-new"));
+        assertTrue("the only value for k2 was not delivered: " + content, content.contains("w1-only"));
+        assertTrue("a superseded value was delivered, so this was not a compacted read: " + content,
+                !content.contains("v1-old"));
+
+        // The broker refusing a second consumer surfaces as a PulsarClientException carried on the log
+        // record, not in its message: MockComponentLog keeps the throwable in a separate field, so
+        // getMsg() holds only the processor's own format string and asserting on it would assert nothing.
+        for (final LogMessage error : runner.getLogger().getErrorMessages()) {
+            final Throwable thrown = error.getThrowable();
+            if (thrown != null && thrown.getMessage() != null) {
+                assertTrue("a second consumer was refused, so the tasks did not share one consumer: "
+                                + thrown.getMessage(),
+                        !thrown.getMessage().contains("Exclusive consumer is already connected"));
+            }
+        }
+    }
+
+    /** Everything routed to success so far, concatenated. */
+    private String consumedContent() {
+        final StringBuilder consumed = new StringBuilder();
+
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS)) {
+            consumed.append(new String(flowFile.toByteArray())).append("\n");
+        }
+
+        return consumed.toString();
     }
 
     /** Runs a command inside the broker container and returns its combined output. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Read Compacted, Subscription Mode, and the two properties that finish Topics Pattern.
+ * <p>
+ * Read Compacted is the one with a constraint the processor has to enforce: the client refuses it at
+ * subscribe time with "Read compacted can only be used with exclusive or failover persistent subscriptions",
+ * so a flow that configures it on a Shared subscription validates cleanly and then fails every time it is
+ * scheduled. That constraint is the mirror of the dead letter policy's - a compacted read needs a single
+ * active consumer, a dead letter policy needs competing ones - so the two can never both be on.
+ */
+public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/topic-properties";
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+    }
+
+    /** The defaults have to leave every existing flow exactly as it was. */
+    @Test
+    public void theDefaultsAreTheClientDefaultsAndStayValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+
+        runner.assertValid();
+    }
+
+    @Test
+    public void readCompactedIsValidOnAnExclusiveSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertValid();
+    }
+
+    @Test
+    public void readCompactedIsValidOnAFailoverSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Failover");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertValid();
+    }
+
+    /** Shared is the processor's default subscription type, so this is the combination most likely hit. */
+    @Test
+    public void readCompactedIsRejectedOnASharedSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void readCompactedIsRejectedOnAKeySharedSubscription() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Key_Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertNotValid();
+    }
+
+    /**
+     * The two constraints are mirror images, so no subscription type satisfies both. Pinned because it
+     * would otherwise be discovered by a user who configured both and could not see why neither worked.
+     */
+    @Test
+    public void readCompactedAndADeadLetterPolicyCannotBothBeEnabled() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+
+        // Shared satisfies the dead letter policy and breaks the compacted read
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.assertNotValid();
+
+        // Exclusive satisfies the compacted read and breaks the dead letter policy
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.assertNotValid();
+    }
+
+    /** Turning it off must not carry the constraint with it. */
+    @Test
+    public void readCompactedFalseIsValidOnEverySubscriptionType() {
+        for (final String type : new String[] {"Exclusive", "Failover", "Shared", "Key_Shared"}) {
+            runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, type);
+            runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "false");
+
+            runner.assertValid();
+        }
+    }
+
+    @Test
+    public void aNonDurableSubscriptionIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_MODE, "NonDurable");
+
+        runner.assertValid();
+    }
+
+    /** The two Topics Pattern properties are accepted alongside a pattern subscription. */
+    @Test
+    public void theTopicsPatternPropertiesAreValidWithAPattern() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "AllTopics");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "5 sec");
+
+        runner.assertValid();
+    }
+
+    /**
+     * They are inert with a topic list rather than rejected. Unlike a dead letter topic that can never
+     * receive a message, a match mode on a subscription that does no matching misleads nobody, and
+     * rejecting it would make the two properties awkward to leave configured while switching between a
+     * list and a pattern.
+     */
+    @Test
+    public void theTopicsPatternPropertiesAreInertWithATopicList() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "AllTopics");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "5 sec");
+
+        runner.assertValid();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.reporting.InitializationException;
@@ -189,14 +191,16 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
     }
 
     /**
-     * The interval is passed to the client in whole seconds and the client clamps 0 to 1, so a sub-second
-     * value becomes a topic lookup every second rather than the interval that was asked for - silently.
+     * The value reaches the client as whole seconds, so any fraction is silently discarded - not only a
+     * sub-second value. Rejecting only the sub-second case would leave the same silent rounding one step up.
      */
     @Test
-    public void aSubSecondDiscoveryIntervalIsRejected() {
+    public void aDiscoveryIntervalThatIsNotWholeSecondsIsRejected() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
 
-        for (final String interval : new String[] {"500 millis", "0 sec"}) {
+        for (final String interval : new String[] {"500 millis", "0 sec", "1500 millis", "2500 millis"}) {
             runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, interval);
             runner.assertNotValid();
         }
@@ -204,20 +208,78 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
 
     @Test
     public void aWholeSecondDiscoveryIntervalIsValid() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
-        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "1 sec");
+
+        for (final String interval : new String[] {"1 sec", "60 sec", "2 min"}) {
+            runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, interval);
+            runner.assertValid();
+        }
+    }
+
+    /**
+     * The property is inert with a topic list - the client reads it only on the pattern path - so failing a
+     * topic-list flow over its value would reject a configuration it has no effect on. The inertness is
+     * documented on the property and asserted for a valid value in
+     * {@link #theTopicsPatternPropertiesAreInertWithATopicList()}; this pins it for an invalid one.
+     */
+    @Test
+    public void aBadDiscoveryIntervalIsIgnoredWithATopicList() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "500 millis");
 
         runner.assertValid();
     }
 
-    /** None of the new domain rules may fire when the compacted read is off. */
+    /**
+     * Read Compacted with the default Subscription Initial Position of Latest warns rather than failing
+     * validation. On a live topic it does deliver - new messages arrive and are read compacted - so it is
+     * unusual, not invalid, and rejecting it would fail a working flow. On an idle topic it delivers
+     * nothing, because the compacted view is the topic's history and a subscription at the tail has none of
+     * it, which is indistinguishable from a broken flow. Hence a warning, once per start.
+     */
     @Test
-    public void aNonPersistentTopicIsValidWhenReadCompactedIsOff() {
-        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "non-persistent://public/default/live");
+    public void readCompactedAtTheLatestPositionWarnsRatherThanFailingValidation() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        // Subscription Initial Position is left at its default, which is Latest.
+
+        runner.assertValid();
+        runner.run(1, false, true);
+
+        assertEquals("exactly one warning is expected at scheduling", 1,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("Read Compacted is enabled"))
+                        .count());
+    }
+
+    @Test
+    public void readCompactedAtTheEarliestPositionDoesNotWarn() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+
+        runner.run(1, false, true);
+
+        assertEquals("no warning is expected when the position can see the compacted view", 0,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("Read Compacted is enabled"))
+                        .count());
+    }
+
+    /** The warning is about the combination, so it must not fire when the compacted read is off. */
+    @Test
+    public void theLatestPositionAloneDoesNotWarn() throws Exception {
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
         runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "false");
 
-        runner.assertValid();
+        runner.run(1, false, true);
+
+        assertEquals("no warning is expected without Read Compacted", 0,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("Read Compacted is enabled"))
+                        .count());
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -115,6 +115,84 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         }
     }
 
+    /**
+     * The client's precondition has two halves and its message states both: "exclusive or failover
+     * PERSISTENT subscriptions". Enforcing only the subscription type leaves the exact failure this
+     * validation exists to prevent - valid on the canvas, throwing on every schedule.
+     */
+    @Test
+    public void readCompactedIsRejectedOnANonPersistentTopic() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "non-persistent://public/default/live");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertNotValid();
+    }
+
+    /** One non-persistent topic in a list is enough: the client requires every topic to be persistent. */
+    @Test
+    public void readCompactedIsRejectedWhenAnyTopicInTheListIsNonPersistent() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS,
+                "persistent://public/default/a,non-persistent://public/default/b");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertNotValid();
+    }
+
+    /** A bare topic name is in the persistent domain by default, so it stays valid. */
+    @Test
+    public void readCompactedIsValidOnAnUnqualifiedTopicName() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "my-topic");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertValid();
+    }
+
+    /**
+     * The case the client cannot catch. With a pattern its topic list is empty, so its persistent-domain
+     * check passes vacuously and any non-persistent topic the pattern matches is subscribed and served as a
+     * live stream - the flow reads a full stream while its configuration says compacted, with no error.
+     */
+    @Test
+    public void readCompactedIsRejectedWithAPatternThatCanMatchNonPersistentTopics() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        for (final String mode : new String[] {"NonPersistentOnly", "AllTopics"}) {
+            runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, mode);
+            runner.assertNotValid();
+        }
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "PersistentOnly");
+        runner.assertValid();
+    }
+
+    /** A pattern in the non-persistent domain matches nothing compactable, whatever the match mode. */
+    @Test
+    public void readCompactedIsRejectedWithANonPersistentPattern() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "non-persistent://public/default/tp-.*");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "PersistentOnly");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        runner.assertNotValid();
+    }
+
+    /** None of the new domain rules may fire when the compacted read is off. */
+    @Test
+    public void aNonPersistentTopicIsValidWhenReadCompactedIsOff() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "non-persistent://public/default/live");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "false");
+
+        runner.assertValid();
+    }
+
     @Test
     public void aNonDurableSubscriptionIsValid() {
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -171,16 +171,43 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         runner.assertValid();
     }
 
-    /** A pattern in the non-persistent domain matches nothing compactable, whatever the match mode. */
+    /**
+     * A pattern's own domain scheme is inert, so it must not be rejected. TopicsPatternFactory runs the
+     * pattern through TopicList.removeTopicDomainScheme() and matching strips the scheme from every
+     * candidate topic, so the domain comes from Topics Pattern Match Mode alone. An earlier version of
+     * this validator rejected the prefix and failed this working configuration.
+     */
     @Test
-    public void readCompactedIsRejectedWithANonPersistentPattern() {
+    public void aNonPersistentPatternPrefixIsInertAndMustNotBeRejected() {
         runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
         runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "non-persistent://public/default/tp-.*");
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
         runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE, "PersistentOnly");
         runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
 
-        runner.assertNotValid();
+        runner.assertValid();
+    }
+
+    /**
+     * The interval is passed to the client in whole seconds and the client clamps 0 to 1, so a sub-second
+     * value becomes a topic lookup every second rather than the interval that was asked for - silently.
+     */
+    @Test
+    public void aSubSecondDiscoveryIntervalIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+
+        for (final String interval : new String[] {"500 millis", "0 sec"}) {
+            runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, interval);
+            runner.assertNotValid();
+        }
+    }
+
+    @Test
+    public void aWholeSecondDiscoveryIntervalIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "1 sec");
+
+        runner.assertValid();
     }
 
     /** None of the new domain rules may fire when the compacted read is off. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -17,10 +17,12 @@
 package org.apache.nifi.processors.pulsar.pubsub;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.junit.Before;
@@ -104,6 +106,24 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         // Exclusive satisfies the compacted read and breaks the dead letter policy
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
         runner.assertNotValid();
+    }
+
+    /**
+     * ...and the reason is stated once, rather than each half pointing at the subscription type the other
+     * half forbids. Switching type in response to one message just produces the other, so a user following
+     * the guidance goes in a circle - the messages are the only place they look.
+     */
+    @Test
+    public void theConflictBetweenThemIsReportedAsOneReason() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+
+        assertTrue("the conflict should be reported as its own reason, naming both properties",
+                ((MockProcessContext) runner.getProcessContext()).validate().stream()
+                        .filter(result -> !result.isValid())
+                        .anyMatch(result -> result.getExplanation()
+                                .contains("cannot both be set")));
     }
 
     /** Turning it off must not carry the constraint with it. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -18,12 +18,22 @@ package org.apache.nifi.processors.pulsar.pubsub;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,9 +59,22 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
     }
 
-    /** The defaults have to leave every existing flow exactly as it was. */
+    /**
+     * The defaults have to leave every existing flow exactly as it was, which means matching the client's
+     * own defaults in {@code ConsumerConfigurationData}. Asserted rather than assumed: a later change to any
+     * of these four would silently alter the behaviour of every flow that never sets them, and validity
+     * alone would not notice.
+     */
     @Test
     public void theDefaultsAreTheClientDefaultsAndStayValid() {
+        assertEquals(SubscriptionMode.Durable.name(),
+                AbstractPulsarConsumerProcessor.SUBSCRIPTION_MODE.getDefaultValue());
+        assertEquals("false", AbstractPulsarConsumerProcessor.READ_COMPACTED.getDefaultValue());
+        assertEquals(RegexSubscriptionMode.PersistentOnly.name(),
+                AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE.getDefaultValue());
+        assertEquals("60 sec",
+                AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD.getDefaultValue());
+
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
 
         runner.assertValid();
@@ -348,6 +371,55 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         runner.assertValid();
     }
 
+    /**
+     * A non-durable subscription leaves no cursor, so Earliest has nothing to resume from and re-reads the
+     * topic from the start on every schedule - and on every eviction from the consumer cache. Valid, and
+     * sometimes wanted, but the Read Compacted guidance sends users to Earliest, so the combination is easy
+     * to arrive at without meaning to.
+     */
+    @Test
+    public void aNonDurableSubscriptionAtTheEarliestPositionWarns() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_MODE, "NonDurable");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+
+        runner.assertValid();
+        runner.run(1, false, true);
+
+        assertEquals("exactly one warning is expected at scheduling", 1,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("no cursor for a non-durable subscription"))
+                        .count());
+    }
+
+    @Test
+    public void aDurableSubscriptionAtTheEarliestPositionDoesNotWarn() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+
+        runner.run(1, false, true);
+
+        assertEquals("no warning is expected when the cursor is durable", 0,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("no cursor for a non-durable subscription"))
+                        .count());
+    }
+
+    /** The warning is about the combination: tailing without a cursor is exactly what NonDurable is for. */
+    @Test
+    public void aNonDurableSubscriptionAtTheLatestPositionDoesNotWarn() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_MODE, "NonDurable");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Latest");
+
+        runner.run(1, false, true);
+
+        assertEquals("no warning is expected when tailing", 0,
+                runner.getLogger().getWarnMessages().stream()
+                        .filter(m -> m.getMsg().contains("no cursor for a non-durable subscription"))
+                        .count());
+    }
+
     /** The two Topics Pattern properties are accepted alongside a pattern subscription. */
     @Test
     public void theTopicsPatternPropertiesAreValidWithAPattern() {
@@ -372,5 +444,59 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
         runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "5 sec");
 
         runner.assertValid();
+    }
+
+    /**
+     * Validation is not evidence that a property is applied. These four are the whole point of the change,
+     * and every other test here stops at the canvas - so without this, deleting any of the four calls from
+     * {@code getConsumerBuilder} leaves the suite green.
+     */
+    private void scheduleOnceWithAMessage() {
+        @SuppressWarnings("unchecked")
+        final Message<GenericRecord> message = mock(Message.class);
+        when(message.getData()).thenReturn("mocked message".getBytes(StandardCharsets.UTF_8));
+        mockClientService.setMockMessage(message);
+
+        runner.run(1, true);
+    }
+
+    @Test
+    public void readCompactedReachesTheConsumerBuilder() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+
+        scheduleOnceWithAMessage();
+
+        verify(mockClientService.getMockConsumerBuilder(), times(1)).readCompacted(true);
+    }
+
+    @Test
+    public void subscriptionModeReachesTheConsumerBuilder() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_MODE,
+                SubscriptionMode.NonDurable.name());
+
+        scheduleOnceWithAMessage();
+
+        verify(mockClientService.getMockConsumerBuilder(), times(1))
+                .subscriptionMode(SubscriptionMode.NonDurable);
+    }
+
+    @Test
+    public void theTopicsPatternPropertiesReachTheConsumerBuilder() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.REGEX_SUBSCRIPTION_MODE,
+                RegexSubscriptionMode.AllTopics.name());
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "5 sec");
+
+        scheduleOnceWithAMessage();
+
+        verify(mockClientService.getMockConsumerBuilder(), times(1))
+                .subscriptionTopicsMode(RegexSubscriptionMode.AllTopics);
+        verify(mockClientService.getMockConsumerBuilder(), times(1))
+                .patternAutoDiscoveryPeriod(5, TimeUnit.SECONDS);
     }
 }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -24,8 +24,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.reporting.InitializationException;
@@ -138,15 +141,27 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
      */
     @Test
     public void theConflictBetweenThemIsReportedAsOneReason() {
-        runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
-        runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        for (final String type : new String[] {"Shared", "Key_Shared", "Exclusive", "Failover"}) {
+            runner.setProperty(AbstractPulsarConsumerProcessor.READ_COMPACTED, "true");
+            runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "5");
+            runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, type);
 
-        assertTrue("the conflict should be reported as its own reason, naming both properties",
-                ((MockProcessContext) runner.getProcessContext()).validate().stream()
-                        .filter(result -> !result.isValid())
-                        .anyMatch(result -> result.getExplanation()
-                                .contains("cannot both be set")));
+            final List<String> reasons = ((MockProcessContext) runner.getProcessContext()).validate().stream()
+                    .filter(result -> !result.isValid())
+                    .map(ValidationResult::getExplanation)
+                    .collect(Collectors.toList());
+
+            assertTrue("on " + type + " the conflict should be reported as its own reason, naming both "
+                            + "properties, but the reasons were " + reasons,
+                    reasons.stream().anyMatch(reason -> reason.contains("cannot both be set")));
+
+            // The point of "one reason": no message may name a Subscription Type to move to, because every
+            // such message contradicts the one above. Half one sends the user to Exclusive, the dead letter
+            // rule sends them back to Shared, and alternating never reaches a valid state.
+            assertTrue("on " + type + " no reason may direct the user at a Subscription Type while both are "
+                            + "set, but the reasons were " + reasons,
+                    reasons.stream().noneMatch(reason -> reason.contains("but the Subscription Type is")));
+        }
     }
 
     /** Turning it off must not carry the constraint with it. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarTopicPropertiesTest.java
@@ -253,6 +253,44 @@ public class ConsumePulsarTopicPropertiesTest extends AbstractPulsarProcessorTes
     }
 
     /**
+     * The one value a topic-list flow cannot ignore. The granularity rule is gated on Topics Pattern because
+     * the client reads the value only on the pattern path, but
+     * {@code ConsumerBuilderImpl.patternAutoDiscoveryPeriod} checks "interval needs to be >= 0" when the
+     * consumer is built, for every consumer - and the builder is handed
+     * {@code asTimePeriod(SECONDS).intValue()}, which overflows negative above the int range. So an
+     * unbounded value is the only way a topic-list flow can be failed by this property, and it fails at
+     * every schedule rather than on the canvas. 30000 days is 2,592,000,000 seconds, which is
+     * -1,702,967,296 as an int.
+     */
+    @Test
+    public void aDiscoveryIntervalAboveTheIntRangeIsRejectedEvenWithATopicList() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD, "30000 days");
+
+        runner.assertNotValid();
+    }
+
+    /**
+     * The boundary of the int seconds the client keeps: Integer.MAX_VALUE seconds is representable and one
+     * second more is not. Guards the comparison against being written on the millisecond value, where both
+     * of these would pass.
+     */
+    @Test
+    public void theDiscoveryIntervalBoundaryIsIntegerMaxValueSeconds() {
+        runner.removeProperty(AbstractPulsarConsumerProcessor.TOPICS);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS_PATTERN, "persistent://public/default/tp-.*");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD,
+                Integer.MAX_VALUE + " sec");
+        runner.assertValid();
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.PATTERN_AUTO_DISCOVERY_PERIOD,
+                (Integer.MAX_VALUE + 1L) + " sec");
+        runner.assertNotValid();
+    }
+
+    /**
      * Read Compacted with the default Subscription Initial Position of Latest warns rather than failing
      * validation. On a live topic it does deliver - new messages arrive and are read compacted - so it is
      * unusual, not invalid, and rejecting it would fail a working flow. On an idle topic it delivers


### PR DESCRIPTION
The remaining behaviour tranche of #187 — four consumer settings the Pulsar client has always
supported and no flow could reach. All four default to the client's own default, so no existing
flow changes behaviour.

| Property | The gap it closes |
|---|---|
| *Topics Pattern Match Mode* | a pattern **silently missed non-persistent topics** |
| *Topics Pattern Discovery Interval* | no control over how fast a new matching topic is picked up |
| *Subscription Mode* | `NonDurable` (tailing, no backlog accrual) was unreachable |
| *Read Compacted* | the latest-value-per-key view was unreachable |

### Topics Pattern was half-exposed

*Topics Pattern* has shipped for years, but a pattern matches **persistent topics only** by
default and there was no way to say otherwise — so a pattern that plainly matches a
non-persistent topic consumed nothing, with nothing anywhere explaining why. There was also no
control over the discovery sweep, which is the worst-case delay before a newly created matching
topic is read. These two finish the feature.

### Read Compacted needed a validator

The client refuses it at subscribe time:

> `Read compacted can only be used with exclusive or failover persistent subscriptions`

`Shared` is this processor's **default** subscription type, so the most likely configuration
would validate cleanly and then fail on every schedule. Now rejected up front, as
`CustomPartition` and the dead letter policy are.

### The two single-consumer constraints are mirror images

Worth stating plainly, because nothing else in the codebase does:

- a **compacted read** needs a *single active* consumer → `Exclusive` / `Failover`
- a **dead letter policy** needs *competing* consumers → `Shared` / `Key_Shared`

**No subscription type satisfies both**, so they can never be enabled together. A test pins this
by flipping the subscription type and asserting invalid either way — otherwise it is discovered
by someone who configured both and cannot see why neither works.

### Two decisions worth reviewing

**The pattern properties are set unconditionally**, not guarded on a pattern being in use. The
client reads them only when it has a pattern, and mirroring that condition here would be a second
place to keep in step with the topics/pattern choice above it.

**They are accepted with a topic list rather than rejected.** This deliberately differs from the
dead-letter-topic-without-a-count rejection: a dead letter topic that can never receive a message
misleads someone into waiting for it, whereas a match mode on a subscription doing no matching
misleads nobody — and rejecting it would make both awkward to leave configured while switching
between a list and a pattern.

### Verification

- **359 unit tests** pass (349 before, +10).
- **Integration tests against a real broker**, covering what a mock cannot — a compacted read is
  the broker serving a different view, and what a pattern matches is decided broker-side:
  - a pattern with `NonPersistentOnly` consumes from a non-persistent topic;
  - a compacted read returns only the latest value per key.
- **Both guards mutation-tested:**
  - dropping the Read Compacted validator fails **3 of 10** unit cases;
  - dropping `subscriptionTopicsMode` fails the IT with *"Timed out waiting for the pattern to
    discover the non-persistent topic"* — the reported bug, restated.

The compaction test triggers compaction and waits for the admin CLI to report
`Compaction was a success`. That wait is load-bearing: an uncompacted topic serves its normal
backlog, so without it the assertions would pass while measuring nothing. (My first attempt
matched the wrong string and would have done exactly that.)

### Documentation

All four property descriptions written — those are NiFi's generated docs. Plus a *Choosing what
to consume* section on both consumers' `additionalDetails.html` and in the README, including the
mirror-image constraint.

Closes #187
