### PR TITLE
fix: default the negative ack redelivery delay under the ack timeout, and warn when it is not (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,19 @@ The third row is the one to know about. When the processor cannot write a messag
 **negatively acknowledges** the message, which asks the broker to redeliver it now. Without that
 the message is merely unacknowledged, and the broker cannot tell a consumer that has failed from
 one that is still working: it waits out *Acknowledgment Timeout*, thirty seconds by default and
-never less than ten. Set *Negative Acknowledgment Redelivery Delay* to control how soon; it
-defaults to Pulsar's own one minute.
+never less than ten. *Negative Acknowledgment Redelivery Delay* controls how soon the redelivery
+comes; it defaults to one second, and cannot be set longer than *Acknowledgment Timeout*. The
+reason for that rule: once a message is negatively acknowledged the client stops tracking it for
+the timeout, so the delay is the **only** thing that redelivers it — a delay longer than the timeout
+would make a write failure wait longer than a plain rollback did.
+
+> **Behaviour change since `2.11.0`:** in `2.11.0` the delay defaulted to Pulsar's own one minute,
+> so with *Acknowledgment Timeout* at its 30-second default a message the processor could not write
+> came back after **60 s — twice as long as before negative acknowledgement existed**, not sooner.
+> The default is now one second, so a flow that never set the property redelivers after a write
+> failure in about a second instead of a minute. A flow that had set the property to a value above
+> its *Acknowledgment Timeout* is now invalid and has to lower one or raise the other. To keep the
+> old gap on purpose, set the delay explicitly to a value no longer than the timeout.
 
 A message routed to `parse_failure` is **not** redelivered. It was delivered and handled — the
 flow has its bytes and can route them anywhere, including back to a Pulsar topic — so nacking it

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The bundle version tracks the NiFi platform version it is built for; each releas
 line targets one Pulsar client major. See [VERSIONING.md](VERSIONING.md) for the
 full scheme, branching model, and release process.
 
-Release notes live in [`docs/release-notes/`](docs/release-notes/). `2.11.0` is a
+Release notes live in [`docs/release-notes/`](docs/release-notes/); the notes for the next
+revision on the current line accumulate in [`2.11.0.1`](docs/release-notes/2.11.0.1.md). `2.11.0` is a
 platform bump — see [its notes](docs/release-notes/2.11.0.md). If you are coming from
 `2.9.0` or earlier, read [the `2.10.0` notes](docs/release-notes/2.10.0.md) too: that
 release carries several behaviour changes.
@@ -98,18 +99,23 @@ The third row is the one to know about. When the processor cannot write a messag
 the message is merely unacknowledged, and the broker cannot tell a consumer that has failed from
 one that is still working: it waits out *Acknowledgment Timeout*, thirty seconds by default and
 never less than ten. *Negative Acknowledgment Redelivery Delay* controls how soon the redelivery
-comes; it defaults to one second, and cannot be set longer than *Acknowledgment Timeout*. The
-reason for that rule: once a message is negatively acknowledged the client stops tracking it for
-the timeout, so the delay is the **only** thing that redelivers it — a delay longer than the timeout
-would make a write failure wait longer than a plain rollback did.
+comes; it defaults to five seconds. Keep it under *Acknowledgment Timeout*: once a message is
+negatively acknowledged the client stops tracking it for the timeout, so the delay is the **only**
+thing that redelivers it, and a longer delay makes a write failure wait longer than a plain rollback
+did. A longer delay is still accepted — it can be a deliberate backoff — but the processor logs a
+warning when it starts. Every redelivery also counts against *Max Redelivery Count*, so the delay
+sets how fast a message that keeps failing reaches the dead letter topic.
 
 > **Behaviour change since `2.11.0`:** in `2.11.0` the delay defaulted to Pulsar's own one minute,
 > so with *Acknowledgment Timeout* at its 30-second default a message the processor could not write
 > came back after **60 s — twice as long as before negative acknowledgement existed**, not sooner.
-> The default is now one second, so a flow that never set the property redelivers after a write
-> failure in about a second instead of a minute. A flow that had set the property to a value above
-> its *Acknowledgment Timeout* is now invalid and has to lower one or raise the other. To keep the
-> old gap on purpose, set the delay explicitly to a value no longer than the timeout.
+> The default is now five seconds, so a flow that never set the property redelivers after a write
+> failure in seconds instead of a minute. Two consequences. A flow with *Max Redelivery Count* set
+> now uses up its redeliveries **twelve times faster**: a transient write failure that used to be
+> absorbed by a minute per attempt can now send a perfectly good message to the dead letter topic
+> in seconds, so raise the count — or set the delay back up — to keep the retry window you had. And
+> a delay longer than *Acknowledgment Timeout* still validates, but the processor now logs a warning
+> when it starts; nothing that ran on `2.11.0` stops running.
 
 A message routed to `parse_failure` is **not** redelivered. It was delivered and handled — the
 flow has its bytes and can route them anywhere, including back to a Pulsar topic — so nacking it

--- a/docs/release-notes/2.11.0.1.md
+++ b/docs/release-notes/2.11.0.1.md
@@ -1,0 +1,38 @@
+# 2.11.0.1
+
+Connector revision for **NiFi 2.11.0** against the **Pulsar 4.2.4** client. Java 21. Unreleased;
+this file collects the notes for the next tag on the `2.11.0` line.
+
+## Behaviour changes
+
+**The default *Negative Acknowledgment Redelivery Delay* is five seconds, down from one minute
+(#218).** A negatively acknowledged message is redelivered by that delay and by nothing else: the
+Pulsar client drops it from the acknowledgment-timeout tracker the moment it is nacked. So with the
+one-minute default of `2.11.0` and *Acknowledgment Timeout* at its 30-second default, a message the
+processor could not write came back after sixty seconds — twice as long as before negative
+acknowledgement existed, when the timeout alone redelivered it in thirty. A flow that never set the
+property now redelivers after a write failure in about five seconds.
+
+Two things follow for flows that keep the default.
+
+- Redelivery is what advances *Max Redelivery Count*, so a flow with a dead letter policy uses up
+  its redeliveries about twelve times faster than on `2.11.0`. A transient write failure — a content
+  repository full for ten seconds — that used to be absorbed by a minute per attempt can now push
+  a perfectly good message to the dead letter topic within seconds. Raise *Max Redelivery Count*,
+  or set the delay explicitly, to keep the retry window the flow had.
+- The write-failure error is logged once per redelivery, so during an incident it repeats every
+  five seconds per message rather than every minute.
+
+**A delay longer than *Acknowledgment Timeout* is warned about, not rejected.** The processor logs
+a warning when it is scheduled with that combination, because the timeout no longer applies to a
+nacked message and the flow will wait longer after a write failure than a plain rollback did. It
+stays valid: a long delay is a legitimate poison-message backoff, and a flow that set one on
+`2.11.0` — or pinned the documented one-minute default — still starts after upgrading.
+
+## Upgrading
+
+Drop in the new NARs; NiFi stays on 2.11.0. Nothing needs to change for a flow to keep running.
+Review two things: if a consumer sets *Max Redelivery Count* and relied on the one-minute gap
+between attempts, raise the count or set *Negative Acknowledgment Redelivery Delay* explicitly;
+and if a consumer logs the new warning about the delay exceeding *Acknowledgment Timeout*, decide
+whether that wait is intended.

--- a/docs/release-notes/2.11.0.md
+++ b/docs/release-notes/2.11.0.md
@@ -44,6 +44,9 @@ The processor now negatively acknowledges those messages, so the broker redelive
 once. *Negative Acknowledgment Redelivery Delay* controls how soon; it defaults to Pulsar's own
 one minute, and can be set to redeliver sooner.
 
+> Superseded in [`2.11.0.1`](2.11.0.1.md): the one-minute default made a write failure wait
+> *longer* than before, not shorter, and is now five seconds (#218).
+
 This applies only to messages that never reached the flow. A message written to a FlowFile is
 acknowledged as before, including one routed to `parse_failure` — that message was delivered
 and handled, and redelivering it would hand the same content to the flow twice.

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -206,11 +206,14 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .name("NEGATIVE_ACK_REDELIVERY_DELAY")
             .displayName("Negative Acknowledgment Redelivery Delay")
             .description("How long the broker waits before redelivering a message this processor could not hand "
-                    + "to the flow. A message whose FlowFile could not be written is now negatively acknowledged "
-                    + "rather than left to expire, so its redelivery is governed by this property. The "
-                    + "Acknowledgment Timeout remains the ceiling for a message that was never acted on at all.")
+                    + "to the flow. A message whose FlowFile could not be written is negatively acknowledged "
+                    + "rather than left to expire, and from that moment this delay is the only thing that "
+                    + "redelivers it: a negatively acknowledged message is no longer subject to the Acknowledgment "
+                    + "Timeout. The delay therefore cannot be longer than the Acknowledgment Timeout, and defaults "
+                    + "to well under it. The Acknowledgment Timeout remains the ceiling for a message that was "
+                    + "never acted on at all.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("1 min")
+            .defaultValue("1 sec")
             .required(false)
             .build();
 
@@ -455,6 +458,20 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         if (validationContext.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.SECONDS) < 10) {
            results.add(new ValidationResult.Builder().valid(false).explanation(
                "Acknowledgment Timeout needs to be greater than 10 seconds.").build());
+        }
+
+        // Once a message is negatively acknowledged the client stops tracking it for the Acknowledgment Timeout,
+        // so the redelivery delay is the only thing that brings it back. A delay longer than the timeout would
+        // make a message the processor could not write wait longer than a plain rollback did (#218).
+        final long ackTimeoutMillis = validationContext.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS);
+        final long negativeAckDelayMillis = validationContext.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY)
+                .asTimePeriod(TimeUnit.MILLISECONDS);
+        if (negativeAckDelayMillis > ackTimeoutMillis) {
+            results.add(new ValidationResult.Builder().valid(false).subject(NEGATIVE_ACK_REDELIVERY_DELAY.getDisplayName())
+                .explanation("a negatively acknowledged message is redelivered by this delay alone, so it cannot be "
+                    + "longer than the Acknowledgment Timeout (" + validationContext.getProperty(ACK_TIMEOUT).getValue()
+                    + "); a longer delay would make a message that could not be written wait longer than before")
+                .build());
         }
 
         final boolean deadLetterEnabled = validationContext.getProperty(MAX_REDELIVER_COUNT).isSet();

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -209,11 +209,13 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "to the flow. A message whose FlowFile could not be written is negatively acknowledged "
                     + "rather than left to expire, and from that moment this delay is the only thing that "
                     + "redelivers it: a negatively acknowledged message is no longer subject to the Acknowledgment "
-                    + "Timeout. The delay therefore cannot be longer than the Acknowledgment Timeout, and defaults "
-                    + "to well under it. The Acknowledgment Timeout remains the ceiling for a message that was "
-                    + "never acted on at all.")
+                    + "Timeout. The default is therefore kept under the shortest Acknowledgment Timeout allowed, "
+                    + "and a delay longer than the Acknowledgment Timeout is logged as a warning when the processor "
+                    + "starts. Each redelivery also counts against Max Redelivery Count, so a shorter delay reaches "
+                    + "the dead letter topic sooner. The Acknowledgment Timeout remains the ceiling for a message "
+                    + "that was never acted on at all.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("1 sec")
+            .defaultValue("5 sec")
             .required(false)
             .build();
 
@@ -460,20 +462,6 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                "Acknowledgment Timeout needs to be greater than 10 seconds.").build());
         }
 
-        // Once a message is negatively acknowledged the client stops tracking it for the Acknowledgment Timeout,
-        // so the redelivery delay is the only thing that brings it back. A delay longer than the timeout would
-        // make a message the processor could not write wait longer than a plain rollback did (#218).
-        final long ackTimeoutMillis = validationContext.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS);
-        final long negativeAckDelayMillis = validationContext.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY)
-                .asTimePeriod(TimeUnit.MILLISECONDS);
-        if (negativeAckDelayMillis > ackTimeoutMillis) {
-            results.add(new ValidationResult.Builder().valid(false).subject(NEGATIVE_ACK_REDELIVERY_DELAY.getDisplayName())
-                .explanation("a negatively acknowledged message is redelivered by this delay alone, so it cannot be "
-                    + "longer than the Acknowledgment Timeout (" + validationContext.getProperty(ACK_TIMEOUT).getValue()
-                    + "); a longer delay would make a message that could not be written wait longer than before")
-                .build());
-        }
-
         final boolean deadLetterEnabled = validationContext.getProperty(MAX_REDELIVER_COUNT).isSet();
         final String subscriptionType = validationContext.getProperty(SUBSCRIPTION_TYPE).getValue();
 
@@ -498,6 +486,8 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
 
     @OnScheduled
     public void init(ProcessContext context) {
+        warnIfNegativeAckDelayExceedsAckTimeout(context);
+
         // Record the size only. Replacing the cache here would abandon the consumers the previous one
         // holds without closing them, and the broker then refuses the replacement consumer on an
         // Exclusive subscription with "Exclusive consumer is already connected". The cache is built
@@ -512,6 +502,24 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         }
 
         setPulsarClientService(context.getProperty(PULSAR_CLIENT_SERVICE).asControllerService(PulsarClientService.class));
+    }
+
+    /**
+     * Once a message is negatively acknowledged the client stops tracking it for the Acknowledgment Timeout, so
+     * the redelivery delay is the only thing that brings it back. A delay longer than the timeout therefore makes
+     * a message the processor could not write wait longer than a plain rollback did (#218). That can be a
+     * deliberate backoff, so it is allowed - but it is worth a warning, because nothing else connects the two.
+     */
+    private void warnIfNegativeAckDelayExceedsAckTimeout(final ProcessContext context) {
+        final long ackTimeoutMillis = context.getProperty(ACK_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS);
+        final long negativeAckDelayMillis = context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY).asTimePeriod(TimeUnit.MILLISECONDS);
+        if (negativeAckDelayMillis > ackTimeoutMillis) {
+            getLogger().warn("{} ({}) is longer than {} ({}). A negatively acknowledged message is redelivered by that "
+                    + "delay alone, so a message this processor cannot write will wait longer than it would have with "
+                    + "no negative acknowledgement at all. Lower the delay unless the longer wait is intended.",
+                    NEGATIVE_ACK_REDELIVERY_DELAY.getDisplayName(), context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY).getValue(),
+                    ACK_TIMEOUT.getDisplayName(), context.getProperty(ACK_TIMEOUT).getValue());
+        }
     }
 
     @OnUnscheduled

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -49,7 +49,10 @@
     the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
     tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
     seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
-    soon redelivery happens, and defaults to Pulsar's own one minute.
+    soon redelivery happens. It defaults to one second and cannot be longer than <i>Acknowledgment Timeout</i>:
+    once a message is negatively acknowledged the client stops tracking it for the timeout, so this delay is
+    the only thing that redelivers it, and a longer delay would make a write failure wait longer than a plain
+    rollback did.
 </p>
 <p>
     When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -49,10 +49,12 @@
     the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
     tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
     seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
-    soon redelivery happens. It defaults to one second and cannot be longer than <i>Acknowledgment Timeout</i>:
+    soon redelivery happens. It defaults to five seconds and should stay under <i>Acknowledgment Timeout</i>:
     once a message is negatively acknowledged the client stops tracking it for the timeout, so this delay is
-    the only thing that redelivers it, and a longer delay would make a write failure wait longer than a plain
-    rollback did.
+    the only thing that redelivers it, and a longer delay makes a write failure wait longer than a plain
+    rollback did. A longer delay is accepted - it can be a deliberate backoff - but is logged as a warning when
+    the processor starts. Every redelivery also counts against <i>Max Redelivery Count</i>, so a shorter delay
+    reaches the dead letter topic sooner; raise the count if a transient failure must be survived.
 </p>
 <p>
     When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -49,7 +49,10 @@
     the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
     tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
     seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
-    soon redelivery happens, and defaults to Pulsar's own one minute.
+    soon redelivery happens. It defaults to one second and cannot be longer than <i>Acknowledgment Timeout</i>:
+    once a message is negatively acknowledged the client stops tracking it for the timeout, so this delay is
+    the only thing that redelivers it, and a longer delay would make a write failure wait longer than a plain
+    rollback did.
 </p>
 <p>
     When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -49,10 +49,12 @@
     the broker to redeliver it now. Without that the message is merely unacknowledged, and the broker cannot
     tell a consumer that has failed from one still working: it waits out <i>Acknowledgment Timeout</i>, thirty
     seconds by default and never less than ten. <i>Negative Acknowledgment Redelivery Delay</i> controls how
-    soon redelivery happens. It defaults to one second and cannot be longer than <i>Acknowledgment Timeout</i>:
+    soon redelivery happens. It defaults to five seconds and should stay under <i>Acknowledgment Timeout</i>:
     once a message is negatively acknowledged the client stops tracking it for the timeout, so this delay is
-    the only thing that redelivers it, and a longer delay would make a write failure wait longer than a plain
-    rollback did.
+    the only thing that redelivers it, and a longer delay makes a write failure wait longer than a plain
+    rollback did. A longer delay is accepted - it can be a deliberate backoff - but is logged as a warning when
+    the processor starts. Every redelivery also counts against <i>Max Redelivery Count</i>, so a shorter delay
+    reaches the dead letter topic sooner; raise the count if a transient failure must be survived.
 </p>
 <p>
     When the failure is the Pulsar client itself, no negative acknowledgement is sent: the call that would

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
@@ -65,8 +65,8 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
         runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
-        // Redeliver as soon as the broker will, so the test does not wait on the one-minute default.
-        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "1 sec");
+        // Negative Acknowledgment Redelivery Delay is deliberately left at its default: the redelivery
+        // test is about what a flow that never set it gets, so the default is the value under test.
         // The floor the validator allows. The point of the redelivery test is that it completes well
         // inside this, which is the only thing that could have redelivered the message before.
         runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "10 sec");
@@ -76,6 +76,10 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
      * A message the processor could not write is redelivered promptly, rather than after the Acknowledgment
      * Timeout. The assertion is the timing: the redelivery has to arrive inside the timeout that would
      * otherwise have been the only thing to produce it.
+     * <p>
+     * Runs at the default Negative Acknowledgment Redelivery Delay on purpose. A nacked message is redelivered
+     * by that delay alone - the client drops it from the acknowledgment-timeout tracker - so with a default
+     * longer than the timeout this test fails, and a default flow waits longer than it did before (#218).
      */
     @Test
     public void aMessageThatCouldNotBeWrittenIsRedeliveredWithoutWaitingOutTheAckTimeout() throws Exception {
@@ -83,12 +87,16 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nack-sub");
 
+        // Subscribe on an empty topic first. Publishing before the initialising pass let that pass - which
+        // runs with a healthy session - consume the message itself, and the test then passed without any
+        // negative acknowledgement ever happening.
+        runner.run(1, false, true);
         publish(topic, "payload");
 
-        // First pass: the content repository rejects the write, so the batch is rolled back and nacked.
-        runner.run(1, false, true);
-        final long nackedAt = System.nanoTime();
-        ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
+        // First real pass: the content repository rejects the write, so the batch is rolled back and nacked.
+        // Repeated until the message has actually arrived in the receiver queue and been refused.
+        final long nackedAt = failWriteOfNextMessage();
+        runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
 
         // Second pass with a healthy session: the broker should hand the message back.
         await("the negatively acknowledged message to be redelivered", () -> {
@@ -148,6 +156,22 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
             assertNotNull("the poison message never reached the dead letter topic", deadLettered);
             assertEquals("poison", new String(deadLettered.getValue(), UTF_8));
         }
+    }
+
+    /**
+     * Triggers the processor with a session that cannot be written until the message is received and refused,
+     * so the returned instant is when it was negatively acknowledged - not when the test happened to run.
+     */
+    private long failWriteOfNextMessage() throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (System.nanoTime() < deadline) {
+            ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
+            if (!runner.getLogger().getErrorMessages().isEmpty()) {
+                return System.nanoTime();
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("the message never reached the pass whose write fails");
     }
 
     private static String topic(final String name) {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarDeadLetterIT.java
@@ -65,10 +65,12 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
         runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
-        // Negative Acknowledgment Redelivery Delay is deliberately left at its default: the redelivery
-        // test is about what a flow that never set it gets, so the default is the value under test.
-        // The floor the validator allows. The point of the redelivery test is that it completes well
-        // inside this, which is the only thing that could have redelivered the message before.
+        // Negative Acknowledgment Redelivery Delay is deliberately not set here. The redelivery test is about
+        // what a flow that never set it gets, so there the default is the value under test; the dead letter
+        // test sets it explicitly, because its pace depends on the delay and not on whatever the default is.
+
+        // Acknowledgment Timeout at the floor the validator allows. The point of the redelivery test is that
+        // it completes well inside this, which is the only thing that could have redelivered the message before.
         runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "10 sec");
     }
 
@@ -127,6 +129,9 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "dlq-sub");
         runner.setProperty(AbstractPulsarConsumerProcessor.MAX_REDELIVER_COUNT, "2");
         runner.setProperty(AbstractPulsarConsumerProcessor.DEAD_LETTER_TOPIC, deadLetterTopic);
+        // Explicit, because this test is not about the default: each redelivery has to happen inside the
+        // receive window of the polling loop below, whatever the default is set to.
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "1 sec");
 
         // Subscribe to the dead letter topic before anything is published to it, so the message cannot be
         // missed by a subscription that starts at the latest position.
@@ -158,20 +163,35 @@ public class ConsumePulsarDeadLetterIT extends AbstractPulsarIT {
         }
     }
 
+    /** What the processor logs when a received message could not be written and was rolled back and nacked. */
+    private static final String WRITE_FAILED = "Unable to write the received messages";
+
     /**
      * Triggers the processor with a session that cannot be written until the message is received and refused,
      * so the returned instant is when it was negatively acknowledged - not when the test happened to run.
+     * <p>
+     * "Refused" is a new write-failure error logged by one of these passes. The logger's error list is
+     * cumulative for the whole test and other errors are possible - a client hiccup during the initialising
+     * pass is logged and swallowed - so an unspecific "any error" check could return before the message was
+     * ever received, and the test would then pass without a negative acknowledgement having happened.
      */
     private long failWriteOfNextMessage() throws InterruptedException {
+        final long writeFailuresBefore = writeFailuresLogged();
         final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
         while (System.nanoTime() < deadline) {
             ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
-            if (!runner.getLogger().getErrorMessages().isEmpty()) {
+            if (writeFailuresLogged() > writeFailuresBefore) {
                 return System.nanoTime();
             }
             Thread.sleep(100);
         }
         throw new AssertionError("the message never reached the pass whose write fails");
+    }
+
+    private long writeFailuresLogged() {
+        return runner.getLogger().getErrorMessages().stream()
+                .filter(message -> message.getMsg().contains(WRITE_FAILED))
+                .count();
     }
 
     private static String topic(final String name) {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAckDelayTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAckDelayTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.FormatUtils;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A negatively acknowledged message is redelivered by <i>Negative Acknowledgment Redelivery Delay</i> and by
+ * nothing else: the Pulsar client drops it from the acknowledgment-timeout tracker the moment it is nacked
+ * ({@code ConsumerImpl.negativeAcknowledge}). So the delay is the whole story for a message the processor could
+ * not write, and <i>Acknowledgment Timeout</i> is not a ceiling for it.
+ * <p>
+ * Two things follow, and both are pinned here. The default delay has to be shorter than the shortest
+ * <i>Acknowledgment Timeout</i> the validator accepts, or a default flow waits longer after a write failure
+ * than it did before negative acknowledgement existed (#218). And a configured delay longer than the timeout
+ * is rejected, so a tuned flow cannot reintroduce the same inversion.
+ */
+public class ConsumePulsarNegativeAckDelayTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/nack-delay";
+
+    /** The floor {@code customValidate} enforces on Acknowledgment Timeout, in seconds. */
+    private static final long ACK_TIMEOUT_FLOOR_SECONDS = 10;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+    }
+
+    /**
+     * The invariant behind the default: whatever Acknowledgment Timeout a valid flow has, a nacked message
+     * comes back sooner than an unacknowledged one would have. That holds only if the default delay is
+     * below the timeout's floor.
+     */
+    @Test
+    public void theDefaultDelayIsShorterThanTheShortestAllowedAcknowledgmentTimeout() {
+        final long defaultDelayMillis = FormatUtils.getTimeDuration(
+                AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY.getDefaultValue(), TimeUnit.MILLISECONDS);
+
+        assertTrue("the default Negative Acknowledgment Redelivery Delay (" + defaultDelayMillis + " ms) is not shorter "
+                        + "than the " + ACK_TIMEOUT_FLOOR_SECONDS + " s floor of Acknowledgment Timeout, so a write "
+                        + "failure would stall longer than the timeout it was meant to beat",
+                defaultDelayMillis < TimeUnit.SECONDS.toMillis(ACK_TIMEOUT_FLOOR_SECONDS));
+    }
+
+    /** Defaults only, which is what every flow created before the property existed looks like. */
+    @Test
+    public void theDefaultsAreValid() {
+        runner.assertValid();
+    }
+
+    @Test
+    public void aDelayShorterThanTheAcknowledgmentTimeoutIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30 sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "5 sec");
+
+        runner.assertValid();
+    }
+
+    /** Equal is allowed: the nack then buys nothing, but it takes nothing away either. */
+    @Test
+    public void aDelayEqualToTheAcknowledgmentTimeoutIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30 sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "30 sec");
+
+        runner.assertValid();
+    }
+
+    /**
+     * Longer than the timeout is the inversion: the timeout no longer applies to a nacked message, so this
+     * configuration makes a write failure wait longer than a plain rollback would have.
+     */
+    @Test
+    public void aDelayLongerThanTheAcknowledgmentTimeoutIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30 sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "1 min");
+
+        runner.assertNotValid();
+    }
+
+    /** The rule compares durations, not the strings: "30 sec" and "30000 millis" are the same timeout. */
+    @Test
+    public void theComparisonIsOnDurationsNotOnTheWrittenValues() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30000 millis");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "31 sec");
+
+        runner.assertNotValid();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAckDelayTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarNegativeAckDelayTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
@@ -24,6 +25,7 @@ import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.FormatUtils;
+import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.junit.Before;
@@ -38,7 +40,8 @@ import org.junit.Test;
  * Two things follow, and both are pinned here. The default delay has to be shorter than the shortest
  * <i>Acknowledgment Timeout</i> the validator accepts, or a default flow waits longer after a write failure
  * than it did before negative acknowledgement existed (#218). And a configured delay longer than the timeout
- * is rejected, so a tuned flow cannot reintroduce the same inversion.
+ * is allowed - it may be a deliberate backoff, and rejecting it would stop an upgraded flow from starting - but
+ * it is called out with a warning when the processor is scheduled, so the inversion is at least visible.
  */
 public class ConsumePulsarNegativeAckDelayTest extends AbstractPulsarProcessorTest<GenericRecord> {
 
@@ -96,14 +99,33 @@ public class ConsumePulsarNegativeAckDelayTest extends AbstractPulsarProcessorTe
 
     /**
      * Longer than the timeout is the inversion: the timeout no longer applies to a nacked message, so this
-     * configuration makes a write failure wait longer than a plain rollback would have.
+     * configuration makes a write failure wait longer than a plain rollback would have. It stays valid - a flow
+     * that set it on 2.11.0 must still start after an upgrade, and a long delay is a legitimate poison-message
+     * backoff - but the processor says so when it is scheduled.
      */
     @Test
-    public void aDelayLongerThanTheAcknowledgmentTimeoutIsRejected() {
+    public void aDelayLongerThanTheAcknowledgmentTimeoutIsValidButWarnsWhenScheduled() {
         runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30 sec");
         runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "1 min");
 
-        runner.assertNotValid();
+        runner.assertValid();
+        runner.run(1, false, true);
+
+        final LogMessage warning = theSingleWarning();
+        assertTrue("the warning does not name both properties: " + warning.getMsg(),
+                warning.getMsg().contains("Negative Acknowledgment Redelivery Delay")
+                        && warning.getMsg().contains("Acknowledgment Timeout"));
+    }
+
+    /** No warning for the configurations the rule accepts, or it would be noise on every start. */
+    @Test
+    public void noWarningWhenTheDelayIsWithinTheAcknowledgmentTimeout() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30 sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "30 sec");
+
+        runner.run(1, false, true);
+
+        assertEquals(0, runner.getLogger().getWarnMessages().size());
     }
 
     /** The rule compares durations, not the strings: "30 sec" and "30000 millis" are the same timeout. */
@@ -112,6 +134,14 @@ public class ConsumePulsarNegativeAckDelayTest extends AbstractPulsarProcessorTe
         runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "30000 millis");
         runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "31 sec");
 
-        runner.assertNotValid();
+        runner.run(1, false, true);
+
+        theSingleWarning();
+    }
+
+    private LogMessage theSingleWarning() {
+        assertEquals("expected exactly one warning about the delay, got " + runner.getLogger().getWarnMessages(),
+                1, runner.getLogger().getWarnMessages().size());
+        return runner.getLogger().getWarnMessages().get(0);
     }
 }


### PR DESCRIPTION
Closes #218.

A negatively acknowledged message is redelivered by *Negative Acknowledgment Redelivery Delay* **alone**: `ConsumerImpl.negativeAcknowledge` (checked on `pulsar-client` 4.2.4) adds the message to the `NegativeAcksTracker` and removes it from the `UnAckedMessageTracker` — "since we did receive an 'ack'". So from the nack onward *Acknowledgment Timeout* no longer applies to that message. With the delay defaulting to `1 min` and the timeout to `30 sec`, a flow that never set the property waited **60 s** after a write failure on `main` where `v2.10.0.1` waited 30 s (measured in #218) — the opposite of what #216 set out to do.

> **Revised after review** (second commit): the default is `5 sec` rather than `1 sec`, a delay longer than the timeout is warned about at scheduling rather than rejected at validation, the IT's write-failure detection is specific and monotonic, and there are release notes. Details in the review thread.

### What changed

- **`AbstractPulsarConsumerProcessor`** — the delay defaults to `5 sec`, under the `10 sec` floor the validator puts on *Acknowledgment Timeout*, so the invariant "a nacked message comes back sooner than an unacknowledged one would have" holds for every valid flow — without collapsing the *Max Redelivery Count* budget the way `1 sec` would have (60× faster than `2.11.0`; now 12×, called out in the docs). A configured delay longer than *Acknowledgment Timeout* stays **valid** — a flow that set one on `2.11.0` must still start after upgrading, and a long delay is a legitimate poison-message backoff — but the processor logs a warning naming both properties when it is scheduled. NiFi's `ValidationResult` has no warning level, so `@OnScheduled` is where that lives. The property description now says that the delay is the only thing governing a nacked message and that each redelivery counts against *Max Redelivery Count*.
- **`ConsumePulsarDeadLetterIT`** — the redelivery timing test runs at the **default** delay, since the default is what the claim is about. It subscribes *before* publishing: with the message published first, the initialising pass (which runs with a healthy session) could consume it, the failing pass then received nothing, and the test passed with no negative acknowledgement ever happening — that is how it stayed green with a one-minute default. The failing pass is repeated until a **new** `"Unable to write the received messages"` error has been logged (count snapshotted before the loop), so an unrelated error from an earlier pass cannot end the loop early. The dead letter test sets the delay explicitly to `1 sec`, since its pace depends on the delay and it is not the test of the default.
- **`ConsumePulsarNegativeAckDelayTest`** (new, 7 cases) — pins the default-below-floor invariant, that shorter/equal/longer all validate, that longer produces exactly one warning on scheduling naming both properties, that within-timeout produces none, and that the comparison is on durations rather than strings.
- **Docs** — README *Failure handling and redelivery* states the new default, the warning and the effect on *Max Redelivery Count*, with a *Behaviour change since `2.11.0`* callout; both consumers' `additionalDetails.html` say the same. New `docs/release-notes/2.11.0.1.md` (the next connector revision under VERSIONING.md) carries the behaviour change and an *Upgrading* section; `2.11.0.md` keeps its text as the record of that release, with a one-line pointer at the change.

### Fails first

Unit tests on `main` (`00a6eb8`), first version of the test class — 3 of the 6 cases fail:

```
Tests run: 6, Failures: 3, Errors: 0, Skipped: 0 -- in ConsumePulsarNegativeAckDelayTest
  theDefaultDelayIsShorterThanTheShortestAllowedAcknowledgmentTimeout:
    the default Negative Acknowledgment Redelivery Delay (60000 ms) is not shorter than the 10 s floor of
    Acknowledgment Timeout, so a write failure would stall longer than the timeout it was meant to beat
  aDelayLongerThanTheAcknowledgmentTimeoutIsRejected:
    Processor appears to be valid but expected it to be invalid ==> expected: <false> but was: <true>
  theComparisonIsOnDurationsNotOnTheWrittenValues:
    Processor appears to be valid but expected it to be invalid ==> expected: <false> but was: <true>
```

(The two "rejected" cases are now "warns when scheduled"; on `main` they fail the same way, with no warning logged.)

The reordered IT on `main`, at the default delay — both tests fail, and the second one shows the dead letter policy is hit by the same default (redelivery count advances once a minute):

```
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 106.6 s -- in ConsumePulsarDeadLetterIT
  aMessageThatCouldNotBeWrittenIsRedeliveredWithoutWaitingOutTheAckTimeout -- 31.11 s
    java.lang.AssertionError: Timed out after 30s waiting for: the negatively acknowledged message to be redelivered
  aRepeatedlyUndeliverableMessageEndsUpOnTheDeadLetterTopic -- 60.08 s
    java.lang.AssertionError: the poison message never reached the dead letter topic
```

With the fix as it stands (`5 sec` default):

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.60 s -- in ConsumePulsarDeadLetterIT
```

### Verification

- `mvn test` on the current head: **356/356** (349 + 7).
- First commit: `mvn -B -ntp verify -Dgpg.skip=true -pl nifi-pulsar-processors -am` (the CI command) against a real broker via Testcontainers on rootless podman: **71 integration tests, 68 pass in the full run**. The 3 errors are `java.io.IOException: Broken pipe` from podman's exec endpoint inside `execInContainer` (`pulsar-admin` creating partitioned topics), thrown before any processor runs — an environment problem here, not the tests. Re-running those classes on their own, `ConsumePulsarRecordIT`, `NiFiRoundTripIT` and `PublishPulsarRoutingModeIT` all pass.
- Second commit: `ConsumePulsarDeadLetterIT` 2/2 against a real broker; the other ITs were not re-run since the change touches only the default value, `@OnScheduled` and this IT.

### Not done

- Nothing about *which* rollback sites nack, or about `parse_failure`, changes.
- The comparison uses the configured values directly; neither property supports Expression Language, so there is nothing to evaluate at validation time.
- The warning is logged once per scheduling, not on a timer; a flow that runs for weeks with the inverted configuration has one line in the log to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d1wTGSM2aku8nyMyX7yhG
