### PR TITLE
fix: hold one producer per topic under the exclusive access modes (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,18 @@ Pulsar's broker-side deduplication requires.
 *Producer Access Mode* is how you stop two flows writing the same topic. `Shared`, the default,
 lets any number of producers write. `Exclusive` fails at producer creation if another producer
 already holds the topic; `WaitForExclusive` queues until it can take over; `ExclusiveWithFencing`
-evicts the incumbent and takes the topic.
+evicts the incumbent and takes the topic. Under any of the three the processor keeps **one
+producer per topic**, whatever its Concurrent Tasks: a task that needs a topic whose producer is
+busy waits for it instead of opening a second one, so the exclusivity is held against other flows
+and never turned against the processor itself.
+
+> **Behaviour change since `2.11.0`:** in `2.11.0` the publisher pool opened one producer per
+> concurrently held lease, so `PublishPulsarRecord` with more than one Concurrent Task collided
+> with its own producers under the exclusive modes: with `Exclusive` part of the FlowFiles went to
+> `failure` ("Topic has an existing exclusive producer" — its own), with `ExclusiveWithFencing`
+> the producers fenced each other, and with `WaitForExclusive` the second task blocked inside
+> `onTrigger` for good. Those flows now publish everything through the topic's single producer.
+> `Shared` is unchanged: concurrent tasks still get concurrent producers.
 
 *Batch Builder* decides how messages are grouped when *Batching Enabled* is on. `Default` fills a
 batch with whatever is pending, interleaving keys. **`Key based` is required for per-key ordering

--- a/README.md
+++ b/README.md
@@ -188,15 +188,22 @@ already holds the topic; `WaitForExclusive` queues until it can take over; `Excl
 evicts the incumbent and takes the topic. Under any of the three the processor keeps **one
 producer per topic**, whatever its Concurrent Tasks: a task that needs a topic whose producer is
 busy waits for it instead of opening a second one, so the exclusivity is held against other flows
-and never turned against the processor itself.
+and never turned against the processor itself. The topic is the topic as the broker sees it, so
+`my-topic` and `persistent://public/default/my-topic` share one producer. The wait is bounded — five
+seconds — because the task holding the producer may be inside a send that *Send Timeout* `0` lets
+run indefinitely; when it runs out, the FlowFiles of that trigger go **back to the incoming queue**,
+not to `failure`, the processor logs a warning and yields, and they are retried on a later trigger.
+Nothing was attempted for them, so nothing was refused.
 
 > **Behaviour change since `2.11.0`:** in `2.11.0` the publisher pool opened one producer per
 > concurrently held lease, so `PublishPulsarRecord` with more than one Concurrent Task collided
 > with its own producers under the exclusive modes: with `Exclusive` part of the FlowFiles went to
 > `failure` ("Topic has an existing exclusive producer" — its own), with `ExclusiveWithFencing`
 > the producers fenced each other, and with `WaitForExclusive` the second task blocked inside
-> `onTrigger` for good. Those flows now publish everything through the topic's single producer.
-> `Shared` is unchanged: concurrent tasks still get concurrent producers.
+> `onTrigger` for good. Those flows now publish everything through the topic's single producer,
+> and a task that cannot get it within five seconds returns its FlowFiles to the queue and yields
+> rather than failing them or waiting without limit. `Shared` is unchanged: concurrent tasks still
+> get concurrent producers.
 
 *Batch Builder* decides how messages are grouped when *Batching Enabled* is on. `Default` fills a
 batch with whatever is pending, interleaving keys. **`Key based` is required for per-key ordering

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -36,6 +36,7 @@ import org.apache.nifi.processor.*;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pulsar.utils.PropertyMappingUtils;
 import org.apache.nifi.processors.pulsar.utils.PublisherPool;
+import org.apache.nifi.processors.pulsar.utils.PublisherUnavailableException;
 import org.apache.nifi.pulsar.PulsarClientService;
 import org.apache.nifi.pulsar.cache.PulsarConsumerLRUCache;
 import org.apache.pulsar.client.api.CompressionType;
@@ -494,6 +495,25 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
 
     protected synchronized void setPublisherPool(PublisherPool pool) {
         this.publisherPool = pool;
+    }
+
+    /**
+     * The topic's only producer is with another task and did not come back within the pool's wait, so nothing was
+     * attempted for this FlowFile - or for the rest of the batch, which needs the same lease or one just as busy.
+     * They go back to the queue they came from, not to {@code failure}: a FlowFile routed to failure was tried and
+     * refused, and these were not. The yield keeps the next trigger from spinning on the same held producer.
+     */
+    protected void returnToQueueAndYield(final ProcessContext context, final ProcessSession session,
+                                         final FlowFile flowFile, final Iterator<FlowFile> rest,
+                                         final PublisherUnavailableException cause) {
+        int returned = 1;
+        session.transfer(flowFile);
+        while (rest.hasNext()) {
+            session.transfer(rest.next());
+            returned++;
+        }
+        getLogger().warn("{}; {} FlowFile(s) returned to the queue to be retried", cause.getMessage(), returned);
+        context.yield();
     }
 
     protected byte[] getDemarcatorBytes(ProcessContext context, final FlowFile flowFile) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
@@ -37,6 +37,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
 import org.apache.nifi.processors.pulsar.utils.PublishPulsarUtils;
 import org.apache.nifi.processors.pulsar.utils.PublisherLease;
+import org.apache.nifi.processors.pulsar.utils.PublisherUnavailableException;
 
 @SeeAlso({ConsumePulsar.class, ConsumePulsarRecord.class, PublishPulsarRecord.class})
 @Tags({"Apache", "Pulsar", "Put", "Send", "Message", "PubSub"})
@@ -72,7 +73,13 @@ public class PublishPulsar extends AbstractPulsarProducerProcessor<byte[]> {
             final String topicName = context.getProperty(TOPIC).evaluateAttributeExpressions(flowFile).getValue();
             final boolean asyncFlag = (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean());
 
-            PublisherLease lease = obtainPublisherLease(topicName);
+            final PublisherLease lease;
+            try {
+                lease = obtainPublisherLease(topicName);
+            } catch (final PublisherUnavailableException e) {
+                returnToQueueAndYield(context, session, flowFile, itr, e);
+                return;
+            }
 
             if (lease == null) {
                 getLogger().error("Unable to publish to topic {}", new Object[] {topicName});

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
@@ -37,6 +37,7 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processors.pulsar.utils.KeyValueTopicSchema;
 import org.apache.nifi.processors.pulsar.utils.PublishPulsarUtils;
 import org.apache.nifi.processors.pulsar.utils.PublisherLease;
+import org.apache.nifi.processors.pulsar.utils.PublisherUnavailableException;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
@@ -165,7 +166,13 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
             final String topicName = context.getProperty(TOPIC).evaluateAttributeExpressions(flowFile).getValue();
             final boolean asyncFlag = (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean());
 
-            PublisherLease lease = getPublisherPool().obtainPublisher(topicName);
+            final PublisherLease lease;
+            try {
+                lease = getPublisherPool().obtainPublisher(topicName);
+            } catch (final PublisherUnavailableException e) {
+                returnToQueueAndYield(context, session, flowFile, itr, e);
+                return;
+            }
 
             if (lease == null) {
                 getLogger().error("Unable to publish to topic {}", new Object[] {topicName});

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -33,6 +34,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -46,6 +48,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Before this the idle queue was never written to, so every {@code obtainPublisher()} created a new producer, a lease's
  * {@code close()} removed it from an always-empty queue instead of closing it, and {@link #close()} drained that same
  * empty queue: every producer this bundle opened, and its broker connection, was leaked.
+ * <p>
+ * Under an exclusive {@code accessMode} the pool holds <b>one</b> producer per topic instead: a caller whose topic already
+ * has its lease in use waits for that lease to come back rather than creating a second producer. A second producer on a
+ * topic whose first one is exclusive is what the broker refuses ({@code Exclusive}), what fences the first one
+ * ({@code ExclusiveWithFencing}) or what waits for a producer that never closes ({@code WaitForExclusive}), so a
+ * processor with more than one concurrent task was colliding with its own pool (#219).
  */
 public class PublisherPool implements Closeable {
 
@@ -72,6 +80,15 @@ public class PublisherPool implements Closeable {
     /** Every lease created by this pool whose producer is still open, idle or in use. */
     private final Set<PooledPublisherLease> openLeases = ConcurrentHashMap.newKeySet();
 
+    /** Whether {@code accessMode} in the producer configuration is one of the exclusive modes. */
+    private final boolean exclusiveAccess;
+
+    /**
+     * One permit per topic when the access mode is exclusive, held from {@link #obtainPublisher(String)} until the
+     * lease is closed. Fair, so waiting tasks are served in the order they asked.
+     */
+    private final Map<String, Semaphore> topicPermits = new ConcurrentHashMap<>();
+
     private volatile boolean closed = false;
 
     public PublisherPool(ComponentLog logger, Map<String, Object> pulsarProducerProperties, PulsarClient pulsarClient) {
@@ -84,13 +101,25 @@ public class PublisherPool implements Closeable {
         this.pulsarProducerProperties = pulsarProducerProperties;
         this.pulsarClient = pulsarClient;
         this.batcherBuilder = batcherBuilder;
+        this.exclusiveAccess = isExclusive(pulsarProducerProperties.get("accessMode"));
     }
 
     /**
-     * Returns a lease for the topic: an idle one if available, otherwise a newly created producer.
+     * The processor puts the {@link ProducerAccessMode} itself into the map; a configuration that does not
+     * mention the mode gets the client default, {@code Shared}.
+     */
+    private static boolean isExclusive(final Object accessMode) {
+        return accessMode != null && !ProducerAccessMode.Shared.name().equals(String.valueOf(accessMode));
+    }
+
+    /**
+     * Returns a lease for the topic: an idle one if available, otherwise a newly created producer. Under an
+     * exclusive access mode the topic has a single lease, and a caller who finds it in use waits until it is
+     * returned rather than getting a second producer.
      *
      * @param topicName the topic to publish to
-     * @return the lease, or {@code null} when the topic is blank or the producer cannot be created
+     * @return the lease, or {@code null} when the topic is blank, the producer cannot be created, or the thread
+     *         was interrupted while waiting for an exclusive topic's lease
      * @throws IllegalStateException if the pool has been closed
      */
     public PublisherLease obtainPublisher(String topicName) {
@@ -102,16 +131,36 @@ public class PublisherPool implements Closeable {
             return null;
         }
 
-        final PooledPublisherLease idle = idleLeasesFor(topicName).poll();
-        if (idle != null) {
-            return idle;
+        final Semaphore permit = exclusiveAccess ? topicPermits.computeIfAbsent(topicName, t -> new Semaphore(1, true)) : null;
+        if (permit != null) {
+            // Exclusive access means one producer on the topic, and the pool honours that from the inside: the
+            // second task wanting this topic waits for its lease to be returned instead of creating a producer the
+            // broker would refuse, fence the first one with, or hold waiting for a producer that never closes. The
+            // wait is on a sibling task's trigger, which the lease's own send timeout bounds.
+            try {
+                permit.acquire();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
         }
 
         try {
-            return createLease(topicName);
+            final PooledPublisherLease idle = idleLeasesFor(topicName).poll();
+            final PooledPublisherLease lease = idle != null ? idle : createLease(topicName);
+            lease.leased.set(true);
+            return lease;
         } catch (PulsarClientException pcEx) {
             logger.error("Unable to create producer", pcEx);
+            if (permit != null) {
+                permit.release();
+            }
             return null;
+        } catch (final RuntimeException e) {
+            if (permit != null) {
+                permit.release();
+            }
+            throw e;
         }
     }
 
@@ -195,6 +244,9 @@ public class PublisherPool implements Closeable {
         private final String topicName;
         private final AtomicBoolean producerClosed = new AtomicBoolean(false);
 
+        /** True while handed out by {@link #obtainPublisher(String)}; a close on a lease that is not out is ignored. */
+        private final AtomicBoolean leased = new AtomicBoolean(false);
+
         private PooledPublisherLease(final Producer producer, final String topicName,
                                      final Schema<byte[]> topicSchema) {
             super(producer, logger, topicSchema);
@@ -203,11 +255,21 @@ public class PublisherPool implements Closeable {
 
         @Override
         public void close() {
+            if (!leased.compareAndSet(true, false)) {
+                // closed twice: returning it again would put the same producer in the idle queue twice and, under
+                // exclusive access, hand the topic to two tasks at once
+                return;
+            }
+
             if (PublisherPool.this.isClosed()) {
                 closeProducer();
             } else {
                 // return the producer to the pool; PublisherPool.close() closes it later because it stays in openLeases
                 idleLeasesFor(topicName).offer(this);
+            }
+
+            if (exclusiveAccess) {
+                topicPermits.get(topicName).release();
             }
         }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherPool.java
@@ -25,8 +25,10 @@ import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
 
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -84,10 +87,22 @@ public class PublisherPool implements Closeable {
     private final boolean exclusiveAccess;
 
     /**
+     * How long {@link #obtainPublisher(String)} waits for an exclusive topic's only lease before giving up with a
+     * {@link PublisherUnavailableException}. The wait is on a sibling task's trigger, and that trigger may be
+     * stuck for as long as its send is allowed to take - indefinitely with <i>Send Timeout</i> {@code 0}, which
+     * broker-side deduplication requires - so the wait cannot be unbounded: a task parked in {@code onTrigger}
+     * holds a flow thread and an uncommitted session, and stopping the processor does not free it.
+     */
+    public static final Duration DEFAULT_EXCLUSIVE_LEASE_WAIT = Duration.ofSeconds(5);
+
+    /**
      * One permit per topic when the access mode is exclusive, held from {@link #obtainPublisher(String)} until the
-     * lease is closed. Fair, so waiting tasks are served in the order they asked.
+     * lease is closed. Fair, so waiting tasks are served in the order they asked. Keyed by the topic's
+     * fully-qualified name, so two spellings of one topic share a permit.
      */
     private final Map<String, Semaphore> topicPermits = new ConcurrentHashMap<>();
+
+    private final Duration exclusiveLeaseWait;
 
     private volatile boolean closed = false;
 
@@ -97,11 +112,21 @@ public class PublisherPool implements Closeable {
 
     public PublisherPool(ComponentLog logger, Map<String, Object> pulsarProducerProperties, PulsarClient pulsarClient,
                          BatcherBuilder batcherBuilder) {
+        this(logger, pulsarProducerProperties, pulsarClient, batcherBuilder, DEFAULT_EXCLUSIVE_LEASE_WAIT);
+    }
+
+    /**
+     * @param exclusiveLeaseWait how long to wait for an exclusive topic's lease that another task holds; see
+     *                           {@link #DEFAULT_EXCLUSIVE_LEASE_WAIT}
+     */
+    public PublisherPool(ComponentLog logger, Map<String, Object> pulsarProducerProperties, PulsarClient pulsarClient,
+                         BatcherBuilder batcherBuilder, Duration exclusiveLeaseWait) {
         this.logger = logger;
         this.pulsarProducerProperties = pulsarProducerProperties;
         this.pulsarClient = pulsarClient;
         this.batcherBuilder = batcherBuilder;
         this.exclusiveAccess = isExclusive(pulsarProducerProperties.get("accessMode"));
+        this.exclusiveLeaseWait = exclusiveLeaseWait;
     }
 
     /**
@@ -114,12 +139,14 @@ public class PublisherPool implements Closeable {
 
     /**
      * Returns a lease for the topic: an idle one if available, otherwise a newly created producer. Under an
-     * exclusive access mode the topic has a single lease, and a caller who finds it in use waits until it is
-     * returned rather than getting a second producer.
+     * exclusive access mode the topic has a single lease, and a caller who finds it in use waits - for at most
+     * the pool's exclusive lease wait - until it is returned rather than getting a second producer.
      *
-     * @param topicName the topic to publish to
-     * @return the lease, or {@code null} when the topic is blank, the producer cannot be created, or the thread
-     *         was interrupted while waiting for an exclusive topic's lease
+     * @param topicName the topic to publish to, in any of the spellings Pulsar accepts
+     * @return the lease, or {@code null} when the topic is blank or the producer cannot be created
+     * @throws PublisherUnavailableException if the topic's only lease is held by another task and was not returned
+     *         within the wait, or the wait was interrupted; nothing was attempted for the caller, who should return
+     *         the FlowFile to its queue and yield rather than route it to failure
      * @throws IllegalStateException if the pool has been closed
      */
     public PublisherLease obtainPublisher(String topicName) {
@@ -131,23 +158,35 @@ public class PublisherPool implements Closeable {
             return null;
         }
 
-        final Semaphore permit = exclusiveAccess ? topicPermits.computeIfAbsent(topicName, t -> new Semaphore(1, true)) : null;
+        // Permits and idle leases are keyed by the fully-qualified name, so "my-topic" and
+        // "persistent://public/default/my-topic" - the same topic to the broker - share one producer. With
+        // Expression Language deriving the topic from an attribute, both spellings of a topic in one flow is
+        // ordinary, and keying by the raw string would give the topic two producers, which is #219 again.
+        final String topicKey = qualified(topicName);
+
+        final Semaphore permit = exclusiveAccess ? topicPermits.computeIfAbsent(topicKey, t -> new Semaphore(1, true)) : null;
         if (permit != null) {
             // Exclusive access means one producer on the topic, and the pool honours that from the inside: the
             // second task wanting this topic waits for its lease to be returned instead of creating a producer the
             // broker would refuse, fence the first one with, or hold waiting for a producer that never closes. The
-            // wait is on a sibling task's trigger, which the lease's own send timeout bounds.
+            // wait is bounded, because it is on a sibling task's trigger and that may take as long as a send may.
+            final boolean acquired;
             try {
-                permit.acquire();
+                acquired = permit.tryAcquire(exclusiveLeaseWait.toMillis(), TimeUnit.MILLISECONDS);
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return null;
+                throw new PublisherUnavailableException("Interrupted while waiting for the exclusive producer on topic "
+                        + topicName + " to be returned by another task", e);
+            }
+            if (!acquired) {
+                throw new PublisherUnavailableException("The exclusive producer on topic " + topicName + " was still held "
+                        + "by another task after " + exclusiveLeaseWait.toMillis() + " ms");
             }
         }
 
         try {
-            final PooledPublisherLease idle = idleLeasesFor(topicName).poll();
-            final PooledPublisherLease lease = idle != null ? idle : createLease(topicName);
+            final PooledPublisherLease idle = idleLeasesFor(topicKey).poll();
+            final PooledPublisherLease lease = idle != null ? idle : createLease(topicName, topicKey);
             lease.leased.set(true);
             return lease;
         } catch (PulsarClientException pcEx) {
@@ -164,11 +203,23 @@ public class PublisherPool implements Closeable {
         }
     }
 
+    /**
+     * The topic's fully-qualified name - {@code persistent://tenant/namespace/topic} - or the name as given when it
+     * is not one the client can parse, in which case producer creation fails on it as before.
+     */
+    static String qualified(final String topicName) {
+        try {
+            return TopicName.get(topicName).toString();
+        } catch (final IllegalArgumentException e) {
+            return topicName;
+        }
+    }
+
     private Queue<PooledPublisherLease> idleLeasesFor(final String topicName) {
         return idleLeases.computeIfAbsent(topicName, topic -> new ConcurrentLinkedQueue<>());
     }
 
-    private PooledPublisherLease createLease(String topicName) throws PulsarClientException {
+    private PooledPublisherLease createLease(final String topicName, final String topicKey) throws PulsarClientException {
         final Map<String, Object> properties = new HashMap<>(pulsarProducerProperties);
 
         // AUTO_PRODUCE_BYTES makes the broker validate the payload against whatever schema the topic
@@ -192,7 +243,7 @@ public class PublisherPool implements Closeable {
 
         final Producer producer = producerBuilder.create();
 
-        final PooledPublisherLease lease = new PooledPublisherLease(producer, topicName, topicSchema);
+        final PooledPublisherLease lease = new PooledPublisherLease(producer, topicKey, topicSchema);
         openLeases.add(lease);
 
         if (isClosed()) {
@@ -241,16 +292,17 @@ public class PublisherPool implements Closeable {
      * A lease whose {@code close()} returns the producer to the pool while the pool is open and closes it afterwards.
      */
     private final class PooledPublisherLease extends PublisherLease {
-        private final String topicName;
+        /** The fully-qualified topic name the pool keys its permits and idle queues by. */
+        private final String topicKey;
         private final AtomicBoolean producerClosed = new AtomicBoolean(false);
 
         /** True while handed out by {@link #obtainPublisher(String)}; a close on a lease that is not out is ignored. */
         private final AtomicBoolean leased = new AtomicBoolean(false);
 
-        private PooledPublisherLease(final Producer producer, final String topicName,
+        private PooledPublisherLease(final Producer producer, final String topicKey,
                                      final Schema<byte[]> topicSchema) {
             super(producer, logger, topicSchema);
-            this.topicName = topicName;
+            this.topicKey = topicKey;
         }
 
         @Override
@@ -261,15 +313,20 @@ public class PublisherPool implements Closeable {
                 return;
             }
 
-            if (PublisherPool.this.isClosed()) {
-                closeProducer();
-            } else {
-                // return the producer to the pool; PublisherPool.close() closes it later because it stays in openLeases
-                idleLeasesFor(topicName).offer(this);
-            }
-
-            if (exclusiveAccess) {
-                topicPermits.get(topicName).release();
+            try {
+                if (PublisherPool.this.isClosed()) {
+                    closeProducer();
+                } else {
+                    // return the producer to the pool; PublisherPool.close() closes it later because it stays in openLeases
+                    idleLeasesFor(topicKey).offer(this);
+                }
+            } finally {
+                // Whatever closing the producer did - PublisherLease.close() catches PulsarClientException only - the
+                // permit goes back. It is the topic's one and only, so losing it here would block the topic for every
+                // later task for the life of the pool.
+                if (exclusiveAccess) {
+                    topicPermits.get(topicKey).release();
+                }
             }
         }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherUnavailableException.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherUnavailableException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+/**
+ * Thrown by {@link PublisherPool#obtainPublisher(String)} when a topic's only producer - under an exclusive access
+ * mode there is exactly one - is held by another task and did not come back within the pool's wait, or the wait
+ * was interrupted. Nothing was attempted for the caller's FlowFile: it should go back to its queue for a later
+ * trigger, not to {@code failure}.
+ */
+public class PublisherUnavailableException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public PublisherUnavailableException(final String message) {
+        super(message);
+    }
+
+    public PublisherUnavailableException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
@@ -41,7 +41,10 @@
     <i>Producer Access Mode</i> is how you stop two flows writing the same topic. <code>Shared</code>, the
     default, lets any number of producers write. <code>Exclusive</code> fails at producer creation if another
     producer already holds the topic, <code>WaitForExclusive</code> queues until it can take over, and
-    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic.
+    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic. Under any of the three the
+    processor keeps one producer per topic whatever its Concurrent Tasks: a task that needs a topic whose
+    producer is busy waits for it instead of opening a second one, so the exclusivity is held against other
+    flows and never turned against the processor itself.
 </p>
 <p>
     <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
@@ -44,7 +44,12 @@
     <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic. Under any of the three the
     processor keeps one producer per topic whatever its Concurrent Tasks: a task that needs a topic whose
     producer is busy waits for it instead of opening a second one, so the exclusivity is held against other
-    flows and never turned against the processor itself.
+    flows and never turned against the processor itself. The topic is the topic as the broker sees it -
+    <code>my-topic</code> and <code>persistent://public/default/my-topic</code> share one producer. The wait
+    is bounded to five seconds, because the task holding the producer may be inside a send that <i>Send
+    Timeout</i> <code>0</code> lets run indefinitely; when it runs out, the FlowFiles of that trigger go back
+    to the incoming queue rather than to <code>failure</code> - nothing was attempted for them - the processor
+    logs a warning and yields, and they are retried on a later trigger.
 </p>
 <p>
     <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -41,7 +41,10 @@
     <i>Producer Access Mode</i> is how you stop two flows writing the same topic. <code>Shared</code>, the
     default, lets any number of producers write. <code>Exclusive</code> fails at producer creation if another
     producer already holds the topic, <code>WaitForExclusive</code> queues until it can take over, and
-    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic.
+    <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic. Under any of the three the
+    processor keeps one producer per topic whatever its Concurrent Tasks: a task that needs a topic whose
+    producer is busy waits for it instead of opening a second one, so the exclusivity is held against other
+    flows and never turned against the processor itself.
 </p>
 <p>
     <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -44,7 +44,12 @@
     <code>ExclusiveWithFencing</code> evicts the incumbent and takes the topic. Under any of the three the
     processor keeps one producer per topic whatever its Concurrent Tasks: a task that needs a topic whose
     producer is busy waits for it instead of opening a second one, so the exclusivity is held against other
-    flows and never turned against the processor itself.
+    flows and never turned against the processor itself. The topic is the topic as the broker sees it -
+    <code>my-topic</code> and <code>persistent://public/default/my-topic</code> share one producer. The wait
+    is bounded to five seconds, because the task holding the producer may be inside a send that <i>Send
+    Timeout</i> <code>0</code> lets run indefinitely; when it runs out, the FlowFiles of that trigger go back
+    to the incoming queue rather than to <code>failure</code> - nothing was attempted for them - the processor
+    logs a warning and yields, and they are retried on a later trigger.
 </p>
 <p>
     <i>Hashing Scheme</i> picks the hash used to turn a message key into a partition on a partitioned topic.

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarExclusiveAccessIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarExclusiveAccessIT.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * An exclusive <i>Producer Access Mode</i> on a {@code PublishPulsarRecord} that runs more than one concurrent task,
+ * against a real broker. Nothing else writes the topic, so the only producer the processor can ever collide with
+ * is its own: before #219 the pool opened one producer per concurrent lease, and the broker refused the second
+ * ({@code Exclusive}), let it fence the first ({@code ExclusiveWithFencing}) or held it waiting for a producer that
+ * never closed ({@code WaitForExclusive}).
+ * <p>
+ * The invariant is the same for all three: every FlowFile succeeds, none fails, every record reaches the topic,
+ * and the run finishes.
+ */
+public class PublishPulsarExclusiveAccessIT extends AbstractPulsarIT {
+
+    private static final int FLOWFILES = 10;
+
+    /**
+     * One record per FlowFile, padded to 600 KB so the 1 MB size-based filter hands each trigger exactly one
+     * FlowFile: that is what makes the two tasks publish at the same time instead of one task draining the
+     * queue in a single trigger.
+     */
+    private static final String PADDING = "x".repeat(600_000);
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final MockRecordParser reader = new MockRecordParser();
+        reader.addSchemaField("id", RecordFieldType.STRING);
+        reader.addSchemaField("reading", RecordFieldType.INT);
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("id, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setThreadCount(2);
+    }
+
+    @Test(timeout = 120_000)
+    public void twoTasksShareTheExclusiveProducer() throws Exception {
+        twoTasksPublishEverything(ProducerAccessMode.Exclusive);
+    }
+
+    @Test(timeout = 120_000)
+    public void twoTasksDoNotFenceEachOther() throws Exception {
+        twoTasksPublishEverything(ProducerAccessMode.ExclusiveWithFencing);
+    }
+
+    /** The timeout is the assertion here: before the fix the second task never returned from producer creation. */
+    @Test(timeout = 120_000)
+    public void twoTasksDoNotWaitForEachOtherForever() throws Exception {
+        twoTasksPublishEverything(ProducerAccessMode.WaitForExclusive);
+    }
+
+    private void twoTasksPublishEverything(final ProducerAccessMode mode) throws Exception {
+        final String topic = "persistent://public/default/exclusive-" + mode.name().toLowerCase() + "-" + System.nanoTime();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.ACCESS_MODE, mode.name());
+
+        // Everything is queued up front, so that while more than one FlowFile is waiting both tasks find work
+        // in the same trigger round and publish concurrently. (MockProcessSession briefly removes a FlowFile
+        // the size filter rejected while it is being put back, so a task can also find the queue empty for an
+        // instant and yield; the loop simply runs another round until the queue is drained.)
+        final Set<String> expectedIds = new HashSet<>();
+        for (int n = 0; n < FLOWFILES; n++) {
+            final String id = "sensor-" + n;
+            expectedIds.add(id);
+            runner.enqueue((id + PADDING + "," + n).getBytes(UTF_8));
+        }
+
+        boolean initialize = true;
+        int rounds = 0;
+        while (runner.getQueueSize().getObjectCount() > 0 && rounds++ < FLOWFILES * 2) {
+            // 60 s run wait: the default 5 s is not a bound a task that queues behind its sibling's lease and then
+            // publishes a 600 KB message itself is guaranteed to meet.
+            runner.run(2, false, initialize, 60_000);
+            initialize = false;
+        }
+
+        runner.assertTransferCount(PublishPulsarRecord.REL_FAILURE, 0);
+        runner.assertTransferCount(PublishPulsarRecord.REL_SUCCESS, FLOWFILES);
+        assertEquals("every FlowFile must have been processed", 0, runner.getQueueSize().getObjectCount());
+
+        final Set<String> receivedIds = new HashSet<>();
+        try (Consumer<byte[]> consumer = getClient().newConsumer(Schema.BYTES)
+                .topic(topic).subscriptionName("exclusive-check")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe()) {
+            Message<byte[]> msg;
+            while (receivedIds.size() < expectedIds.size() && (msg = consumer.receive(10, TimeUnit.SECONDS)) != null) {
+                // the writer emits one (possibly quoted) "<id>,<reading>" per record; the id is what precedes the padding
+                final String value = new String(msg.getValue(), UTF_8).replace("\"", "");
+                receivedIds.add(value.substring(0, value.indexOf('x')));
+                consumer.acknowledge(msg);
+            }
+        }
+        assertEquals(mode + ": every record must have reached the topic exactly through the one producer",
+                expectedIds, receivedIds);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarHeldProducerTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarHeldProducerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.processors.pulsar.utils.PublisherPool;
+import org.apache.nifi.processors.pulsar.utils.PublisherUnavailableException;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Test;
+
+/**
+ * Under an exclusive access mode a topic has one producer, and a task that finds it held by another task waits a
+ * bounded time for it. When the wait runs out nothing has been attempted for the FlowFile, so it must not go to
+ * {@code failure} - that is where FlowFiles the broker refused go. It goes back to the queue for a later trigger,
+ * with the rest of the batch, and the processor yields so the retry is not immediate (#219).
+ */
+public class PublishPulsarHeldProducerTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    private void runWithAHeldProducer(final Processor publisher) throws InitializationException {
+        runner = TestRunners.newTestRunner(publisher);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, "held-topic");
+        if (publisher instanceof PublishPulsarRecord) {
+            final MockRecordParser reader = new MockRecordParser();
+            reader.addSchemaField("name", RecordFieldType.STRING);
+            runner.addControllerService("reader", reader);
+            runner.enableControllerService(reader);
+            final MockRecordWriter writer = new MockRecordWriter("name");
+            runner.addControllerService("writer", writer);
+            runner.enableControllerService(writer);
+            runner.setProperty(PublishPulsarRecord.RECORD_READER, "reader");
+            runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "writer");
+        }
+
+        runner.enqueue("first");
+        runner.enqueue("second");
+        runner.enqueue("third");
+        runner.run(1, false, true);
+    }
+
+    private static PublisherPool aPoolWhoseProducerIsHeld() {
+        final PublisherPool pool = mock(PublisherPool.class);
+        when(pool.obtainPublisher(anyString()))
+                .thenThrow(new PublisherUnavailableException("The exclusive producer on topic held-topic was still held by another task after 5000 ms"));
+        return pool;
+    }
+
+    private void assertNothingFailedAndEverythingIsBackInTheQueue() {
+        runner.assertTransferCount(AbstractPulsarProducerProcessor.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPulsarProducerProcessor.REL_SUCCESS, 0);
+        assertEquals("every FlowFile of the batch goes back to the queue, since none was attempted",
+                3, runner.getQueueSize().getObjectCount());
+        assertTrue("the processor yields so the next trigger does not spin on the held producer", runner.isYieldCalled());
+        assertEquals(1, runner.getLogger().getWarnMessages().size());
+        assertEquals(0, runner.getLogger().getErrorMessages().size());
+    }
+
+    @Test
+    public void publishPulsarReturnsTheBatchToTheQueueAndYields() throws InitializationException {
+        runWithAHeldProducer(new PublishPulsar() {
+            @Override
+            protected PublisherPool createPublisherPool(final ProcessContext context) {
+                return aPoolWhoseProducerIsHeld();
+            }
+        });
+
+        assertNothingFailedAndEverythingIsBackInTheQueue();
+    }
+
+    @Test
+    public void publishPulsarRecordReturnsTheBatchToTheQueueAndYields() throws InitializationException {
+        runWithAHeldProducer(new PublishPulsarRecord() {
+            @Override
+            protected PublisherPool createPublisherPool(final ProcessContext context) {
+                return aPoolWhoseProducerIsHeld();
+            }
+        });
+
+        assertNothingFailedAndEverythingIsBackInTheQueue();
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolExclusiveAccessTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolExclusiveAccessTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Under an exclusive <i>Producer Access Mode</i> the pool must hold <b>one</b> producer per topic. The pool
+ * otherwise creates a producer for every lease that is in use at the same time, and a second producer on a
+ * topic whose first producer is exclusive is exactly what the broker refuses ({@code Exclusive}), fences the
+ * first one with ({@code ExclusiveWithFencing}) or parks forever waiting for a producer that never closes
+ * ({@code WaitForExclusive}). With more than one concurrent task, {@code PublishPulsarRecord} was competing
+ * against its own pooled producers (#219).
+ * <p>
+ * So a second caller for the same topic waits until the topic's lease is returned and is then handed that same
+ * lease, and the mocked builder sees exactly one {@code create()}.
+ */
+public class PublisherPoolExclusiveAccessTest {
+
+    private static final String TOPIC = "persistent://public/default/exclusive";
+
+    private PulsarClient client;
+    private ProducerBuilder<byte[]> builder;
+    private final ExecutorService otherTask = Executors.newSingleThreadExecutor();
+
+    @Before
+    public void setUp() throws PulsarClientException {
+        client = mock(PulsarClient.class);
+        builder = mock(ProducerBuilder.class, RETURNS_SELF);
+        when(client.newProducer(any(Schema.class))).thenReturn(builder);
+        doAnswer(invocation -> builder).when(builder).topic(anyString());
+        doAnswer(invocation -> {
+            final Producer<byte[]> producer = mock(Producer.class);
+            when(producer.getTopic()).thenReturn(TOPIC);
+            return producer;
+        }).when(builder).create();
+    }
+
+    @After
+    public void tearDown() {
+        otherTask.shutdownNow();
+    }
+
+    private PublisherPool poolWith(final ProducerAccessMode accessMode) {
+        return new PublisherPool(mock(ComponentLog.class), Map.of("accessMode", accessMode), client);
+    }
+
+    /**
+     * The invariant for every exclusive mode: however many tasks ask for the topic at once, the broker sees one
+     * producer, and the second task gets that producer once the first is done with it.
+     */
+    @Test
+    public void aSecondTaskWaitsForTheTopicsOnlyProducerInsteadOfCreatingAnother() throws Exception {
+        for (final ProducerAccessMode mode : new ProducerAccessMode[] {
+                ProducerAccessMode.Exclusive, ProducerAccessMode.WaitForExclusive, ProducerAccessMode.ExclusiveWithFencing}) {
+            setUp();
+            final PublisherPool pool = poolWith(mode);
+
+            final PublisherLease held = pool.obtainPublisher(TOPIC);
+            final CompletableFuture<PublisherLease> waiting = CompletableFuture.supplyAsync(() -> pool.obtainPublisher(TOPIC), otherTask);
+
+            try {
+                waiting.get(300, TimeUnit.MILLISECONDS);
+                throw new AssertionError(mode + ": the second task was handed a lease while the topic's producer was "
+                        + "still in use - a second producer was created on an exclusive topic");
+            } catch (final TimeoutException expected) {
+                // the second task is waiting, as it should be
+            }
+            verify(builder, times(1)).create();
+
+            held.close();
+            final PublisherLease handedOver = waiting.get(5, TimeUnit.SECONDS);
+
+            assertSame(mode + ": the waiting task must receive the lease that was just returned", held, handedOver);
+            verify(builder, times(1)).create();
+            assertEquals(mode.toString(), 1, pool.getOpenProducerCount());
+            pool.close();
+        }
+    }
+
+    /** {@code Shared} keeps the existing behaviour: concurrent leases mean concurrent producers. */
+    @Test
+    public void sharedAccessStillCreatesAProducerPerConcurrentLease() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Shared);
+
+        final PublisherLease first = pool.obtainPublisher(TOPIC);
+        final PublisherLease second = pool.obtainPublisher(TOPIC);
+
+        assertNotSame(first, second);
+        verify(builder, times(2)).create();
+    }
+
+    /** A configuration that never mentions the access mode is Pulsar's default, {@code Shared}. */
+    @Test
+    public void anAbsentAccessModeIsShared() throws Exception {
+        final PublisherPool pool = new PublisherPool(mock(ComponentLog.class), Collections.emptyMap(), client);
+
+        pool.obtainPublisher(TOPIC);
+        pool.obtainPublisher(TOPIC);
+
+        verify(builder, times(2)).create();
+    }
+
+    /**
+     * Returning the same lease twice must not hand the topic to two tasks: the second close is ignored, so the
+     * idle queue holds the lease once and a later pair of callers is still serialised.
+     */
+    @Test
+    public void closingALeaseTwiceReleasesTheTopicOnce() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Exclusive);
+
+        final PublisherLease lease = pool.obtainPublisher(TOPIC);
+        lease.close();
+        lease.close();
+        assertEquals(1, pool.getIdleProducerCount());
+
+        final PublisherLease again = pool.obtainPublisher(TOPIC);
+        assertSame(lease, again);
+        final CompletableFuture<PublisherLease> waiting = CompletableFuture.supplyAsync(() -> pool.obtainPublisher(TOPIC), otherTask);
+        Thread.sleep(200);
+        assertFalse("a second task got the topic while its only lease was in use", waiting.isDone());
+
+        again.close();
+        assertSame(lease, waiting.get(5, TimeUnit.SECONDS));
+        verify(builder, times(1)).create();
+    }
+
+    /** A producer the client refuses to create must not leave the topic locked for the next caller. */
+    @Test
+    public void aFailedCreationReleasesTheTopic() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Exclusive);
+        doAnswer(invocation -> {
+            throw new PulsarClientException("broker refused");
+        }).when(builder).create();
+
+        assertTrue("obtainPublisher returns null when the producer cannot be created", pool.obtainPublisher(TOPIC) == null);
+
+        final CompletableFuture<PublisherLease> next = CompletableFuture.supplyAsync(() -> pool.obtainPublisher(TOPIC), otherTask);
+        // null again (creation still fails), but promptly: the topic was not left locked by the first failure
+        assertTrue(next.get(5, TimeUnit.SECONDS) == null);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolExclusiveAccessTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/utils/PublisherPoolExclusiveAccessTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_SELF;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -168,6 +170,83 @@ public class PublisherPoolExclusiveAccessTest {
         again.close();
         assertSame(lease, waiting.get(5, TimeUnit.SECONDS));
         verify(builder, times(1)).create();
+    }
+
+    /**
+     * The permit is per topic, not per spelling. {@code exclusive} and {@code persistent://public/default/exclusive}
+     * are one topic to the broker, and with Expression Language deriving the topic from an attribute both spellings
+     * in one flow is ordinary; two permits would give the topic two producers, which is #219 again.
+     */
+    @Test
+    public void twoSpellingsOfOneTopicShareItsOnlyProducer() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Exclusive);
+
+        final PublisherLease held = pool.obtainPublisher("exclusive");
+        final CompletableFuture<PublisherLease> waiting = CompletableFuture.supplyAsync(
+                () -> pool.obtainPublisher("persistent://public/default/exclusive"), otherTask);
+        Thread.sleep(300);
+        assertFalse("the fully-qualified spelling got its own producer while the short spelling's was in use",
+                waiting.isDone());
+        verify(builder, times(1)).create();
+
+        held.close();
+        assertSame("the waiting spelling receives the lease the other spelling returned", held, waiting.get(5, TimeUnit.SECONDS));
+        verify(builder, times(1)).create();
+    }
+
+    /** The same normalisation feeds the idle queues, so a Shared pool reuses across spellings too. */
+    @Test
+    public void anIdleProducerIsReusedUnderEitherSpelling() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Shared);
+
+        final PublisherLease first = pool.obtainPublisher("persistent://public/default/exclusive");
+        first.close();
+
+        assertSame(first, pool.obtainPublisher("exclusive"));
+        verify(builder, times(1)).create();
+    }
+
+    /**
+     * The wait for a held producer is bounded. It is a wait on another task's trigger, which with Send Timeout 0
+     * can take forever; an unbounded wait parks a flow thread in onTrigger with an uncommitted session, and
+     * stopping the processor does not free it. When the wait runs out the caller gets an exception it can turn
+     * into "back to the queue", not a null it would turn into "failure".
+     */
+    @Test(timeout = 10_000)
+    public void aTaskDoesNotWaitForeverForAHeldProducer() throws Exception {
+        final PublisherPool pool = new PublisherPool(mock(ComponentLog.class), Map.of("accessMode", ProducerAccessMode.Exclusive),
+                client, null, Duration.ofMillis(200));
+
+        final PublisherLease held = pool.obtainPublisher(TOPIC);
+        final long before = System.nanoTime();
+        try {
+            pool.obtainPublisher(TOPIC);
+            fail("a second task was handed a lease while the topic's producer was in use");
+        } catch (final PublisherUnavailableException expected) {
+            final long waitedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - before);
+            assertTrue("gave up after " + waitedMillis + " ms, before the wait elapsed", waitedMillis >= 200);
+            assertTrue("kept waiting for " + waitedMillis + " ms, well past the 200 ms wait", waitedMillis < 2000);
+        }
+        verify(builder, times(1)).create();
+
+        // giving up did not consume the permit: once the holder is done, the topic is available again
+        held.close();
+        assertSame(held, pool.obtainPublisher(TOPIC));
+    }
+
+    /** Interruption while waiting is the same outcome for the caller, and the interrupt is kept for whoever set it. */
+    @Test(timeout = 10_000)
+    public void interruptionWhileWaitingIsReportedAndPreserved() throws Exception {
+        final PublisherPool pool = poolWith(ProducerAccessMode.Exclusive);
+        pool.obtainPublisher(TOPIC);
+
+        Thread.currentThread().interrupt();
+        try {
+            pool.obtainPublisher(TOPIC);
+            fail("an interrupted task was handed a lease");
+        } catch (final PublisherUnavailableException expected) {
+            assertTrue("the interrupt flag was swallowed", Thread.interrupted());
+        }
     }
 
     /** A producer the client refuses to create must not leave the topic locked for the next caller. */


### PR DESCRIPTION
Closes #219.

`PublisherPool` created a producer for every lease that was in use at the same time. Under an exclusive *Producer Access Mode* that is the one thing the broker will not accept, so a `PublishPulsarRecord` with more than one concurrent task — and nobody else on the topic — collided with its own pool: `Exclusive` sent half of the FlowFiles to `failure` ("Topic has an existing exclusive producer" — its own), `ExclusiveWithFencing` had the pool's producers fence each other, and `WaitForExclusive` parked the second task inside `ProducerBuilderImpl.create()` for good.

> **Revised after review** (second commit): the wait for a held producer is bounded and its expiry sends the batch back to the queue rather than to `failure`; permits are keyed by the fully-qualified topic name; the permit release sits in a `finally`. Details in the review thread.

### What changed

- **`PublisherPool`** — when `accessMode` in the producer configuration is anything but `Shared`, the pool holds **one lease per topic**, the topic being `TopicName.get(name).toString()` so that `my-topic` and `persistent://public/default/my-topic` share it. A caller who finds the topic's lease in use waits (a fair per-topic `Semaphore`, `tryAcquire`) for at most `DEFAULT_EXCLUSIVE_LEASE_WAIT` = 5 s and is then handed the same producer; when the wait runs out or is interrupted it throws `PublisherUnavailableException` (new), which **`PublishPulsar` and `PublishPulsarRecord`** turn into "this FlowFile and the rest of the batch go back to the incoming queue, warn, `yield()`" — nothing was attempted for them, so `failure` is the wrong route. A creation that fails releases the topic so the next caller is not locked out, and the release on lease close is in a `finally`. A lease closed twice is now ignored instead of being queued twice — under exclusive access a double return would have handed the topic to two tasks at once, and under `Shared` it put the same producer in the idle queue twice. `Shared` is otherwise unchanged: concurrent tasks still get concurrent producers.
- **`PublisherPoolExclusiveAccessTest`** (new, mocked client, 9 cases) — for each of the three exclusive modes: the second task waits while the first holds the lease, receives that same lease once it is returned, and the builder sees exactly one `create()`. Plus: `Shared` still creates per concurrent lease, an absent `accessMode` is `Shared`, a double close releases the topic once, a failed creation does not leave the topic locked, the two spellings of one topic share its only producer (exclusive) and its idle lease (shared), the wait is bounded and giving up does not consume the permit, interruption is reported and the flag preserved.
- **`PublishPulsarHeldProducerTest`** (new) — both publishers, a pool whose producer is held: three FlowFiles enqueued, none in `success` or `failure`, all three back in the queue, `yield()` called, one warning, no error.
- **`PublishPulsarExclusiveAccessIT`** (new, real broker) — `PublishPulsarRecord` with two concurrent tasks, ten FlowFiles, all three modes: every FlowFile reaches `success`, none reaches `failure`, every record is on the topic, and the run finishes (the `WaitForExclusive` case is guarded by a timeout, which is the assertion there). Each FlowFile carries one 600 KB record so the 1 MB size-based filter hands a single FlowFile to each trigger and the two tasks genuinely publish at the same time.
- **README** — the *Producer Access Mode* paragraph says the processor keeps one producer per topic under the exclusive modes, with a *Behaviour change since `2.11.0`* callout; both publishers' `additionalDetails.html` say the same.

### Fails first

Unit tests on `main` (`00a6eb8`):

```
Tests run: 5, Failures: 2, Errors: 0, Skipped: 0 -- in PublisherPoolExclusiveAccessTest
  aSecondTaskWaitsForTheTopicsOnlyProducerInsteadOfCreatingAnother:
    Exclusive: the second task was handed a lease while the topic's producer was still in use
    - a second producer was created on an exclusive topic
  closingALeaseTwiceReleasesTheTopicOnce: expected:<1> but was:<2>
```

The IT on `main`, against `apachepulsar/pulsar:4.2.4`:

```
Tests run: 3, Failures: 2, Errors: 1, Skipped: 0, Time elapsed: 129.5 s -- in PublishPulsarExclusiveAccessIT
  twoTasksShareTheExclusiveProducer     -- expected: <0> but was: <5>   (FlowFiles in failure)
  twoTasksDoNotFenceEachOther           -- expected: <0> but was: <5>
  twoTasksDoNotWaitForEachOtherForever  -- TestTimedOutException: test timed out after 120000 milliseconds
```

With the fix:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.17 s -- in PublishPulsarExclusiveAccessIT
```

Second commit, the new tests against the pool as it was after the first commit (raw-string keys, unbounded `acquire()`) and against routing to `failure`:

```
Tests run: 9, Failures: 2, Errors: 1 -- in PublisherPoolExclusiveAccessTest
  twoSpellingsOfOneTopicShareItsOnlyProducer: the fully-qualified spelling got its own producer while the
    short spelling's was in use
  anIdleProducerIsReusedUnderEitherSpelling: expected same:<...PooledPublisherLease@6438a7fe> was not:<...@4f5f6e45>
  aTaskDoesNotWaitForeverForAHeldProducer: TestTimedOut test timed out after 10000 milliseconds
Tests run: 2, Failures: 2 -- in PublishPulsarHeldProducerTest
  publishPulsarReturnsTheBatchToTheQueueAndYields: expected: <0> but was: <3>          (FlowFiles in failure)
  publishPulsarRecordReturnsTheBatchToTheQueueAndYields: expected: <0> but was: <3>
```

### Verification

- `mvn test` on the current head: **360/360** (349 + 9 + 2).
- Second commit: `PublishPulsar*IT` (8 classes, 25 tests) and `NiFiRoundTripIT` against a real broker: 26 pass; the 2 errors are the podman `execInContainer` broken pipe described below, in `PublishPulsarRoutingModeIT.roundRobinSpreadsUnkeyedMessagesOverEveryPartition` and `NiFiRoundTripIT.bytesSurviveTheRoundTrip`, thrown from `ExecCreateCmd` before any processor runs, reproducible here on every run today. The other tests in both classes pass.
- First commit: `mvn -B -ntp verify -Dgpg.skip=true -pl nifi-pulsar-processors -am` (the CI command) against a real broker via Testcontainers on rootless podman: 354 unit, **74 integration tests, 71 pass in the full run**. The 3 errors are `java.io.IOException: Broken pipe` from podman's exec endpoint inside `execInContainer` (`pulsar-admin` creating partitioned topics), thrown before any processor runs — an environment problem here, not the tests. Re-running those classes on their own, `ConsumePulsarRecordIT`, `NiFiRoundTripIT` and `PublishPulsarRoutingModeIT` all pass, so every integration test has passed against the branch at least once; CI's Docker should not see the exec issue at all.

### Not done

- The 5 s wait is a constant, not a property. It is the bound on a sibling's trigger, and the retry costs one yield; if a flow needs to tune it that can become a property later without changing the behaviour on expiry.
- The `finally` around the permit release has no test. `PublisherLease.close()` catches `PulsarClientException`, and the client's `flush()`/`close()` throw nothing else, so there is no path today that reaches the `finally` with an exception; the change is defensive.
- `WaitForExclusive` against an **external** holder still blocks inside `create()` until that holder disconnects — that is the mode's contract ("queues until it can take over") and is unchanged. What this PR removes is the case where the holder was the processor itself.
- `PublishPulsar` was not affected (it shares one `currentLease` across tasks) and is not changed beyond going through the same pool code.
- The access mode is read from the configuration map at pool construction; the processor puts the `ProducerAccessMode` enum there, and a string with the same name is accepted too, but I did not add a test for the string form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d1wTGSM2aku8nyMyX7yhG

