### PR TITLE
feat: set an ordering key independently of the message key (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,14 @@ FlowFile:
 | Message field | Comes from |
 |---|---|
 | key | the *Message Key* property; if that is not set, the FlowFile attribute `msg.key` |
-| ordering key | the *Ordering Key* property; nothing is set when it is blank |
+| ordering key | the *Ordering Key* property (`PublishPulsar` only); nothing is set when it is blank |
 | properties | the attributes named by *Mapped Message Properties* (`<property>[=<attribute>]`) |
 
 `PublishPulsarRecord` takes the key from the record field named by *Message Key Field* instead, and
-the ordering key from the field named by *Ordering Key Field*.
+the ordering key from the field named by *Ordering Key Field*; it has no FlowFile-level *Ordering
+Key*. Both fields are converted the same way — text as UTF-8, an Avro `bytes` field as its bytes, a
+nested record as the Record Writer writes it — so naming one field under both properties gives the
+same key twice, and a blank value means no ordering key.
 
 The two keys serve different concerns. The **message key** decides which partition a message is
 routed to and is the key topic compaction keeps the latest value for. The **ordering key** decides

--- a/README.md
+++ b/README.md
@@ -152,14 +152,20 @@ FlowFile:
 
 `PublishPulsarRecord` takes the key from the record field named by *Message Key Field* instead, and
 the ordering key from the field named by *Ordering Key Field*; it has no FlowFile-level *Ordering
-Key*. Both fields are converted the same way — text as UTF-8, an Avro `bytes` field as its bytes, a
-nested record as the Record Writer writes it — so naming one field under both properties gives the
-same key twice, and a blank value means no ordering key.
+Key*. Both fields yield the same bytes — text as UTF-8, an Avro `bytes` field as its bytes, a nested
+record as the Record Writer writes it — so naming one field under both properties keys and orders by
+the same value. A **binary** field travels as a binary message key (Pulsar's `keyBytes`: base64 on
+the wire, flagged as such, so two different byte strings are always two different keys) and as the
+raw ordering key; a text field is the text under both. A blank value means no ordering key. A field
+name that is not in the records' schema is warned about once per FlowFile, since it would otherwise
+set no key for any record without a sign of the typo.
 
 > **Behaviour change since `2.11.0`:** *Message Key Field* naming an Avro `bytes` field used to
 > publish the **identity hash of the array** (`[Ljava.lang.Object;@5cf57368`) as the key — a
 > different value for every record, so records that shared a key were spread over partitions at
-> random and nothing was ever compacted away (#226). The key is now the field's bytes. A flow that
+> random and nothing was ever compacted away (#226). The key is now the field's bytes, sent as a
+> binary key rather than decoded into text — a charset decode would map every invalid byte sequence
+> to the same replacement character and could merge two different keys. A flow that
 > keys by an Avro `bytes` field will see its messages start landing on the partition their key
 > hashes to, and a compacted topic fed that way will start keeping one message per key.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Key*. Both fields are converted the same way — text as UTF-8, an Avro `bytes` 
 nested record as the Record Writer writes it — so naming one field under both properties gives the
 same key twice, and a blank value means no ordering key.
 
+> **Behaviour change since `2.11.0`:** *Message Key Field* naming an Avro `bytes` field used to
+> publish the **identity hash of the array** (`[Ljava.lang.Object;@5cf57368`) as the key — a
+> different value for every record, so records that shared a key were spread over partitions at
+> random and nothing was ever compacted away (#226). The key is now the field's bytes. A flow that
+> keys by an Avro `bytes` field will see its messages start landing on the partition their key
+> hashes to, and a compacted topic fed that way will start keeping one message per key.
+
 The two keys serve different concerns. The **message key** decides which partition a message is
 routed to and is the key topic compaction keeps the latest value for. The **ordering key** decides
 which consumer of a `Key_Shared` subscription receives the message, and takes precedence over the

--- a/README.md
+++ b/README.md
@@ -147,9 +147,20 @@ FlowFile:
 | Message field | Comes from |
 |---|---|
 | key | the *Message Key* property; if that is not set, the FlowFile attribute `msg.key` |
+| ordering key | the *Ordering Key* property; nothing is set when it is blank |
 | properties | the attributes named by *Mapped Message Properties* (`<property>[=<attribute>]`) |
 
-`PublishPulsarRecord` takes the key from the record field named by *Message Key Field* instead.
+`PublishPulsarRecord` takes the key from the record field named by *Message Key Field* instead, and
+the ordering key from the field named by *Ordering Key Field*.
+
+The two keys serve different concerns. The **message key** decides which partition a message is
+routed to and is the key topic compaction keeps the latest value for. The **ordering key** decides
+which consumer of a `Key_Shared` subscription receives the message, and takes precedence over the
+message key there. With no ordering key set Pulsar falls back to the message key, so the two are the
+same value — which is what every flow got before *Ordering Key* existed, and still gets when it is
+left blank. Set it when the unit you route and compact by is not the unit you need ordered delivery
+for: route and compact by tenant, order per session. Pair it with *Batch Builder* = `Key based` if
+batching is on, or a batch spanning several keys is dispatched as one unit.
 
 > **Behaviour change since `2.9.0`:** the *Message Key* property has always documented the
 > `msg.key` fallback, but it was never implemented — `getMessageKey()` read the property and

--- a/docs/release-notes/2.11.0.2.md
+++ b/docs/release-notes/2.11.0.2.md
@@ -22,9 +22,17 @@ the message key exactly as before, so existing flows are byte-for-byte unchanged
 `Byte` instead, which that branch does not match, so the value fell through to `toString()` and the
 key became `[Ljava.lang.Object;@5cf57368` — different for every record. Records that shared a key
 were routed to partitions at random, and a compacted topic fed that way never superseded anything,
-without a single error. Both shapes are now unboxed to the field's bytes. A flow keying by an Avro
-`bytes` field will see its messages start landing on the partition the key hashes to; see the
-behaviour-change note in the README's *Publisher message metadata* section.
+without a single error. Both shapes are now unboxed to the field's bytes and sent as a **binary key**
+(Pulsar's `keyBytes`: base64 on the wire, flagged as such), not decoded into text — a charset decode
+maps every invalid byte sequence to the same replacement character and could merge two different keys
+into one. Text keys are read as UTF-8 on every node rather than in the platform default charset. A
+flow keying by an Avro `bytes` field will see its messages start landing on the partition the key
+hashes to; see the behaviour-change note in the README's *Publisher message metadata* section.
+
+**A misspelt *Message Key Field* or *Ordering Key Field* is warned about.** A field the records do not
+have yields null for every record, exactly like a field that is present and null, so a typo used to set
+no key and say nothing; the processor now logs a warning once per FlowFile naming the property, the
+field and the schema's fields.
 
 ## Upgrading
 

--- a/docs/release-notes/2.11.0.2.md
+++ b/docs/release-notes/2.11.0.2.md
@@ -1,0 +1,33 @@
+# 2.11.0.2
+
+Connector revision for **NiFi 2.11.0** against the **Pulsar 4.2.4** client. Java 21. Unreleased —
+these are the notes for the next tag on the `2.11.0` line.
+
+## New
+
+**An ordering key, independent of the message key (#196).** `PublishPulsar` gains *Ordering Key*
+and `PublishPulsarRecord` gains *Ordering Key Field*. The message key still decides the partition
+and is what topic compaction keeps the latest value for; the ordering key decides which consumer of
+a `Key_Shared` subscription receives the message, and takes precedence over the message key there.
+Set it when the unit you route and compact by is not the unit you need ordered delivery for — route
+and compact by tenant, order per session. Unset, or blank, nothing is set and Pulsar falls back to
+the message key exactly as before, so existing flows are byte-for-byte unchanged. Pair it with
+*Batch Builder* = `Key based` when batching is on.
+
+## Fixes
+
+**`PublishPulsarRecord` published an identity hash as the key for an Avro `bytes` field (#226).**
+*Message Key Field* converts the field's value to the message key, and had a branch for the boxed
+`Byte[]` the Record API was expected to produce. NiFi's `AvroTypeUtil` produces an `Object[]` of
+`Byte` instead, which that branch does not match, so the value fell through to `toString()` and the
+key became `[Ljava.lang.Object;@5cf57368` — different for every record. Records that shared a key
+were routed to partitions at random, and a compacted topic fed that way never superseded anything,
+without a single error. Both shapes are now unboxed to the field's bytes. A flow keying by an Avro
+`bytes` field will see its messages start landing on the partition the key hashes to; see the
+behaviour-change note in the README's *Publisher message metadata* section.
+
+## Upgrading
+
+Drop in the new NARs; NiFi stays on 2.11.0. No configuration change is required. If a
+`PublishPulsarRecord` keys by an Avro `bytes` field, expect partition assignment and compaction to
+start following the key from the first message published after the upgrade.

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -327,6 +327,20 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
+    public static final PropertyDescriptor ORDERING_KEY = new PropertyDescriptor.Builder()
+            .name("ORDERING_KEY")
+            .displayName("Ordering Key")
+            .description("Pulsar's ordering key for the message, set independently of the Message Key. The message "
+                    + "key routes the message to a partition and drives topic compaction; the ordering key decides "
+                    + "which consumer of a Key_Shared subscription receives the message and takes precedence over the "
+                    + "message key there. Set it when the unit you compact or route by (a tenant, a device) is not the "
+                    + "unit you need ordered delivery for (a session, a transaction). When not specified no ordering "
+                    + "key is set and Pulsar falls back to the message key, as before.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
     protected static final List<PropertyDescriptor> PROPERTIES;
     protected static final Set<Relationship> RELATIONSHIPS;
 
@@ -354,6 +368,7 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         descriptorList.add(BATCHER_BUILDER);
         descriptorList.add(MAPPED_MESSAGE_PROPERTIES);
         descriptorList.add(MESSAGE_KEY);
+        descriptorList.add(ORDERING_KEY);
 
         PROPERTIES = Collections.unmodifiableList(descriptorList);
 
@@ -519,6 +534,15 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
     protected byte[] getDemarcatorBytes(ProcessContext context, final FlowFile flowFile) {
         return context.getProperty(MESSAGE_DEMARCATOR).isSet() ? context.getProperty(MESSAGE_DEMARCATOR)
                 .evaluateAttributeExpressions(flowFile).getValue().getBytes(StandardCharsets.UTF_8) : null;
+    }
+
+    /**
+     * The ordering key for the FlowFile's messages, or {@code null} when the property is unset or evaluates to
+     * nothing - in which case no ordering key is set and Pulsar's own fallback to the message key applies.
+     */
+    protected byte[] getOrderingKey(ProcessContext context, final FlowFile flowFile) {
+        final String orderingKey = context.getProperty(ORDERING_KEY).evaluateAttributeExpressions(flowFile).getValue();
+        return StringUtils.isBlank(orderingKey) ? null : orderingKey.getBytes(StandardCharsets.UTF_8);
     }
 
     protected String getMessageKey(ProcessContext context, final FlowFile flowFile) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarProducerProcessor.java
@@ -327,20 +327,6 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    public static final PropertyDescriptor ORDERING_KEY = new PropertyDescriptor.Builder()
-            .name("ORDERING_KEY")
-            .displayName("Ordering Key")
-            .description("Pulsar's ordering key for the message, set independently of the Message Key. The message "
-                    + "key routes the message to a partition and drives topic compaction; the ordering key decides "
-                    + "which consumer of a Key_Shared subscription receives the message and takes precedence over the "
-                    + "message key there. Set it when the unit you compact or route by (a tenant, a device) is not the "
-                    + "unit you need ordered delivery for (a session, a transaction). When not specified no ordering "
-                    + "key is set and Pulsar falls back to the message key, as before.")
-            .required(false)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .build();
-
     protected static final List<PropertyDescriptor> PROPERTIES;
     protected static final Set<Relationship> RELATIONSHIPS;
 
@@ -368,7 +354,6 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
         descriptorList.add(BATCHER_BUILDER);
         descriptorList.add(MAPPED_MESSAGE_PROPERTIES);
         descriptorList.add(MESSAGE_KEY);
-        descriptorList.add(ORDERING_KEY);
 
         PROPERTIES = Collections.unmodifiableList(descriptorList);
 
@@ -534,15 +519,6 @@ public abstract class AbstractPulsarProducerProcessor<T> extends AbstractProcess
     protected byte[] getDemarcatorBytes(ProcessContext context, final FlowFile flowFile) {
         return context.getProperty(MESSAGE_DEMARCATOR).isSet() ? context.getProperty(MESSAGE_DEMARCATOR)
                 .evaluateAttributeExpressions(flowFile).getValue().getBytes(StandardCharsets.UTF_8) : null;
-    }
-
-    /**
-     * The ordering key for the FlowFile's messages, or {@code null} when the property is unset or evaluates to
-     * nothing - in which case no ordering key is set and Pulsar's own fallback to the message key applies.
-     */
-    protected byte[] getOrderingKey(ProcessContext context, final FlowFile flowFile) {
-        final String orderingKey = context.getProperty(ORDERING_KEY).evaluateAttributeExpressions(flowFile).getValue();
-        return StringUtils.isBlank(orderingKey) ? null : orderingKey.getBytes(StandardCharsets.UTF_8);
     }
 
     protected String getMessageKey(ProcessContext context, final FlowFile flowFile) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
@@ -18,10 +18,13 @@ package org.apache.nifi.processors.pulsar.pubsub;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.TriggerWhenEmpty;
@@ -30,10 +33,13 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
 import org.apache.nifi.processors.pulsar.utils.PublishPulsarUtils;
 import org.apache.nifi.processors.pulsar.utils.PublisherLease;
@@ -51,8 +57,50 @@ import org.apache.nifi.processors.pulsar.utils.PublisherUnavailableException;
 @SupportsBatching
 public class PublishPulsar extends AbstractPulsarProducerProcessor<byte[]> {
 
+    /**
+     * Lives here rather than on the base class because only this processor reads it: {@link PublishPulsarRecord}
+     * takes its ordering key per record, from <i>Ordering Key Field</i>, and a FlowFile-level property it never
+     * consulted would sit in its UI promising something it does not do.
+     */
+    public static final PropertyDescriptor ORDERING_KEY = new PropertyDescriptor.Builder()
+            .name("ORDERING_KEY")
+            .displayName("Ordering Key")
+            .description("Pulsar's ordering key for the message, set independently of the Message Key. The message "
+                    + "key routes the message to a partition and drives topic compaction; the ordering key decides "
+                    + "which consumer of a Key_Shared subscription receives the message and takes precedence over the "
+                    + "message key there. Set it when the unit you compact or route by (a tenant, a device) is not the "
+                    + "unit you need ordered delivery for (a session, a transaction). When not specified no ordering "
+                    + "key is set and Pulsar falls back to the message key, as before.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES;
+
+    static {
+        final List<PropertyDescriptor> properties = new ArrayList<>(AbstractPulsarProducerProcessor.PROPERTIES);
+        properties.add(ORDERING_KEY);
+        PROPERTIES = Collections.unmodifiableList(properties);
+    }
+
     // Current lease to reuse for consecutive FlowFiles with the same topic
     private volatile PublisherLease currentLease = null;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    /**
+     * The ordering key for the FlowFile's messages, or {@code null} when the property is unset or evaluates to
+     * nothing - in which case no ordering key is set and Pulsar's own fallback to the message key applies.
+     */
+    protected byte[] getOrderingKey(ProcessContext context, final FlowFile flowFile) {
+        final String orderingKey = context.getProperty(ORDERING_KEY).evaluateAttributeExpressions(flowFile).getValue();
+        return StringUtils.isBlank(orderingKey) ? null : orderingKey.getBytes(StandardCharsets.UTF_8);
+    }
+
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsar.java
@@ -91,6 +91,7 @@ public class PublishPulsar extends AbstractPulsarProducerProcessor<byte[]> {
 
                     lease.publish(flowFile, in,
                             getMessageKey(context, flowFile),
+                            getOrderingKey(context, flowFile),
                             getMappedMessageProperties(context, flowFile),
                             getDemarcatorBytes(context, flowFile), asyncFlag);
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarRecord.java
@@ -128,6 +128,20 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
             .required(false)
             .build();
 
+    public static final PropertyDescriptor ORDERING_KEY_FIELD = new PropertyDescriptor.Builder()
+            .name("ordering-key-field")
+            .displayName("Ordering Key Field")
+            .description("The name of a field in the Input Records whose value becomes the Pulsar ordering key of the "
+                    + "record's message, independently of the Message Key Field. The message key routes and compacts; "
+                    + "the ordering key decides which consumer of a Key_Shared subscription receives the message and "
+                    + "takes precedence over the message key there. A record whose field is null or empty is sent "
+                    + "without an ordering key. When not specified no ordering key is set and Pulsar falls back to the "
+                    + "message key, as before.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
+            .required(false)
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTIES;
 
     static {
@@ -136,6 +150,7 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
         properties.add(RECORD_WRITER);
         properties.add(MESSAGE_SCHEMA_STRATEGY);
         properties.add(MESSAGE_KEY_FIELD);
+        properties.add(ORDERING_KEY_FIELD);
         properties.add(KEY_VALUE_KEY_FIELD);
         properties.add(KEY_VALUE_VALUE_FIELD);
         properties.addAll(AbstractPulsarProducerProcessor.PROPERTIES);
@@ -186,6 +201,8 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
 
                 final String messageKeyField = context.getProperty(MESSAGE_KEY_FIELD)
                         .evaluateAttributeExpressions(flowFile).getValue();
+                final String orderingKeyField = context.getProperty(ORDERING_KEY_FIELD)
+                        .evaluateAttributeExpressions(flowFile).getValue();
 
                 final boolean useTopicSchema = SCHEMA_FROM_TOPIC.getValue()
                         .equals(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
@@ -200,7 +217,7 @@ public class PublishPulsarRecord extends AbstractPulsarProducerProcessor<byte[]>
                             final RecordSet recordSet = reader.createRecordSet();
 
                             final RecordSchema schema = writerFactory.getSchema(flowFile.getAttributes(), recordSet.getSchema());
-                            lease.publish(flowFile, recordSet, writerFactory, schema, messageKeyField,
+                            lease.publish(flowFile, recordSet, writerFactory, schema, messageKeyField, orderingKeyField,
                                     getMappedMessageProperties(context, flowFile), asyncFlag, useTopicSchema,
                                     context.getProperty(KEY_VALUE_KEY_FIELD).evaluateAttributeExpressions().getValue(),
                                     context.getProperty(KEY_VALUE_VALUE_FIELD).evaluateAttributeExpressions().getValue());

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -189,6 +189,16 @@ public class PublisherLease implements Closeable {
 
     public void publish(final FlowFile flowFile, final InputStream flowFileContent, final String messageKey,
                         Map<String, String> messageProperties, final byte[] demarcatorBytes, boolean async) throws IOException {
+        publish(flowFile, flowFileContent, messageKey, null, messageProperties, demarcatorBytes, async);
+    }
+
+    /**
+     * @param orderingKey Pulsar's ordering key for every message of the FlowFile, or {@code null} to set none, in
+     *                    which case the broker falls back to the message key
+     */
+    public void publish(final FlowFile flowFile, final InputStream flowFileContent, final String messageKey,
+                        final byte[] orderingKey, Map<String, String> messageProperties, final byte[] demarcatorBytes,
+                        boolean async) throws IOException {
 
         byte[] messageContent;
         List<CompletableFuture<MessageId>> futureList = new ArrayList<>();
@@ -197,16 +207,16 @@ public class PublisherLease implements Closeable {
             messageContent = new byte[(int) flowFile.getSize()];
             StreamUtils.fillBuffer(flowFileContent, messageContent);
             futureList.add(async ?
-                    sendAsync(producer, messageKey, messageProperties, messageContent) :
-                    send(producer, messageKey, messageProperties, messageContent));
+                    sendAsync(producer, messageKey, orderingKey, messageProperties, messageContent) :
+                    send(producer, messageKey, orderingKey, messageProperties, messageContent));
 
         } else {
             try (final StreamDemarcator demarcator = new StreamDemarcator(flowFileContent, demarcatorBytes, Integer.MAX_VALUE)) {
 
                 while ((messageContent = demarcator.nextToken()) != null) {
                     futureList.add(async ?
-                            sendAsync(producer, messageKey, messageProperties, messageContent) :
-                            send(producer, messageKey, messageProperties, messageContent));
+                            sendAsync(producer, messageKey, orderingKey, messageProperties, messageContent) :
+                            send(producer, messageKey, orderingKey, messageProperties, messageContent));
 
                     if (futureList.size() > 99) {
                         producer.flush();
@@ -248,6 +258,18 @@ public class PublisherLease implements Closeable {
                         final RecordSchema schema, final String messageKeyField, Map<String, String> messageProperties,
                         boolean async, boolean useTopicSchema, final String keyValueKeyField,
                         final String keyValueValueField) throws IOException {
+        publish(flowFile, recordSet, writerFactory, schema, messageKeyField, null, messageProperties, async, useTopicSchema,
+                keyValueKeyField, keyValueValueField);
+    }
+
+    /**
+     * @param orderingKeyField the record field whose value becomes the message's ordering key, or {@code null} to set
+     *                         none; a record whose field is null or empty gets no ordering key either
+     */
+    public void publish(final FlowFile flowFile, final RecordSet recordSet, final RecordSetWriterFactory writerFactory,
+                        final RecordSchema schema, final String messageKeyField, final String orderingKeyField,
+                        Map<String, String> messageProperties, boolean async, boolean useTopicSchema,
+                        final String keyValueKeyField, final String keyValueValueField) throws IOException {
 
         final TopicSchema resolvedSchema = useTopicSchema ? getTopicSchema() : null;
 
@@ -288,6 +310,8 @@ public class PublisherLease implements Closeable {
 
                 final byte[] messageContent;
                 final String messageKey;
+                final byte[] orderingKey = orderingKeyField == null || orderingKeyField.isEmpty()
+                        ? null : getOrderingKey(record.getValue(orderingKeyField));
 
                 if (keyValueSchema != null) {
                     final KeyValueTopicSchema.EncodedKeyValue encoded =
@@ -310,8 +334,8 @@ public class PublisherLease implements Closeable {
                         }
 
                         futureList.add(async
-                                ? sendAsyncWithKeyBytes(producer, encoded.getMessageKey(), messageProperties, messageContent)
-                                : sendWithKeyBytes(producer, encoded.getMessageKey(), messageProperties, messageContent));
+                                ? sendAsyncWithKeyBytes(producer, encoded.getMessageKey(), orderingKey, messageProperties, messageContent)
+                                : sendWithKeyBytes(producer, encoded.getMessageKey(), orderingKey, messageProperties, messageContent));
 
                         if (futureList.size() > 100) {
                             producer.flush();
@@ -340,8 +364,8 @@ public class PublisherLease implements Closeable {
                 messageKey = getMessageKey(flowFile, writerFactory, record.getValue(messageKeyField));
 
                 futureList.add(async ?
-                        sendAsync(producer, messageKey, messageProperties, messageContent) :
-                        send(producer, messageKey, messageProperties, messageContent));
+                        sendAsync(producer, messageKey, orderingKey, messageProperties, messageContent) :
+                        send(producer, messageKey, orderingKey, messageProperties, messageContent));
 
                 if (futureList.size() > 100) {
                     producer.flush();
@@ -580,11 +604,38 @@ public class PublisherLease implements Closeable {
         return producer.newMessage().properties(properties).keyBytes(keyBytes).value(value).sendAsync();
     }
 
+    /**
+     * The variants taking an ordering key hand a message without one to the original methods, so a subclass that
+     * overrides those (tests do, to control the futures) keeps seeing every message that has no ordering key.
+     */
+    protected CompletableFuture<MessageId> sendAsyncWithKeyBytes(Producer producer, byte[] keyBytes, byte[] orderingKey,
+                                                                 Map<String, String> properties, byte[] value) {
+        if (orderingKey == null) {
+            return sendAsyncWithKeyBytes(producer, keyBytes, properties, value);
+        }
+        return producer.newMessage().properties(properties).keyBytes(keyBytes).orderingKey(orderingKey).value(value).sendAsync();
+    }
+
     protected CompletableFuture<MessageId> sendWithKeyBytes(Producer producer, byte[] keyBytes, Map<String, String> properties, byte[] value)
             throws PulsarClientException {
         try {
             return CompletableFuture.completedFuture(
                     producer.newMessage().properties(properties).keyBytes(keyBytes).value(value).send());
+        } catch (final PulsarClientException e) {
+            final CompletableFuture<MessageId> failed = new CompletableFuture<>();
+            failed.completeExceptionally(e);
+            return failed;
+        }
+    }
+
+    protected CompletableFuture<MessageId> sendWithKeyBytes(Producer producer, byte[] keyBytes, byte[] orderingKey,
+                                                            Map<String, String> properties, byte[] value) throws PulsarClientException {
+        if (orderingKey == null) {
+            return sendWithKeyBytes(producer, keyBytes, properties, value);
+        }
+        try {
+            return CompletableFuture.completedFuture(
+                    producer.newMessage().properties(properties).keyBytes(keyBytes).orderingKey(orderingKey).value(value).send());
         } catch (final PulsarClientException e) {
             final CompletableFuture<MessageId> failed = new CompletableFuture<>();
             failed.completeExceptionally(e);
@@ -602,6 +653,37 @@ public class PublisherLease implements Closeable {
     }
 
     /**
+     * Sets the ordering key when there is one. Left unset, the broker falls back to the message key, which is what
+     * every message carried before the ordering key could be given separately (#196).
+     */
+    protected CompletableFuture<MessageId> sendAsync(Producer producer, String key, byte[] orderingKey, Map<String, String> properties, byte[] value) {
+        if (orderingKey == null) {
+            return sendAsync(producer, key, properties, value);
+        }
+        TypedMessageBuilder tmb = producer.newMessage().properties(properties).orderingKey(orderingKey).value(value);
+
+        if (key != null) {
+            tmb = tmb.key(key);
+        }
+        return tmb.sendAsync();
+    }
+
+    /**
+     * The ordering key a record field yields: bytes as they are, anything else as its UTF-8 string form, and no
+     * key at all for a null or empty value.
+     */
+    private static byte[] getOrderingKey(final Object fieldValue) {
+        if (fieldValue == null) {
+            return null;
+        }
+        if (fieldValue instanceof byte[]) {
+            return ((byte[]) fieldValue).length == 0 ? null : (byte[]) fieldValue;
+        }
+        final String asString = fieldValue.toString();
+        return asString.isEmpty() ? null : asString.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
      * Sends one message and waits for it, on the calling thread.
      * <p>
      * This used to wrap the blocking send in {@code CompletableFuture.supplyAsync()}, handing every message
@@ -616,6 +698,25 @@ public class PublisherLease implements Closeable {
      */
     protected CompletableFuture<MessageId> send(Producer producer, String key, Map<String, String> properties, byte[] value) {
         TypedMessageBuilder tmb = producer.newMessage().properties(properties).value(value);
+
+        if (key != null) {
+            tmb = tmb.key(key);
+        }
+
+        try {
+            return CompletableFuture.completedFuture(tmb.send());
+        } catch (final PulsarClientException e) {
+            final CompletableFuture<MessageId> failed = new CompletableFuture<>();
+            failed.completeExceptionally(e);
+            return failed;
+        }
+    }
+
+    protected CompletableFuture<MessageId> send(Producer producer, String key, byte[] orderingKey, Map<String, String> properties, byte[] value) {
+        if (orderingKey == null) {
+            return send(producer, key, properties, value);
+        }
+        TypedMessageBuilder tmb = producer.newMessage().properties(properties).orderingKey(orderingKey).value(value);
 
         if (key != null) {
             tmb = tmb.key(key);

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -302,6 +302,12 @@ public class PublisherLease implements Closeable {
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
 
+        // Once per FlowFile: a key field the records do not have yields null for every record, which is
+        // indistinguishable from a field that is present and null, so a misspelt name fails in silence. For
+        // the ordering key the only observable effect is dispatch on a multi-consumer subscription.
+        warnIfNotAField(recordSet.getSchema(), messageKeyField, "Message Key Field");
+        warnIfNotAField(recordSet.getSchema(), orderingKeyField, "Ordering Key Field");
+
         Record record;
         List<CompletableFuture<MessageId>> futureList = new ArrayList<>();
 
@@ -310,7 +316,6 @@ public class PublisherLease implements Closeable {
                 baos.reset();
 
                 final byte[] messageContent;
-                final String messageKey;
                 final byte[] orderingKey = orderingKeyField == null || orderingKeyField.isEmpty()
                         ? null : getOrderingKey(flowFile, writerFactory, record.getValue(orderingKeyField));
 
@@ -362,11 +367,26 @@ public class PublisherLease implements Closeable {
 
                     messageContent = baos.toByteArray();
                 }
-                messageKey = getMessageKey(flowFile, writerFactory, record.getValue(messageKeyField));
+                final Object keyValue = messageKeyField == null || messageKeyField.isEmpty() ? null : record.getValue(messageKeyField);
+                final byte[] messageKey = keyBytes(flowFile, writerFactory, keyValue);
 
-                futureList.add(async ?
-                        sendAsync(producer, messageKey, orderingKey, messageProperties, messageContent) :
-                        send(producer, messageKey, orderingKey, messageProperties, messageContent));
+                if (messageKey != null && isBinary(keyValue)) {
+                    // A byte field is a binary key and travels as one: keyBytes() carries the bytes as they are
+                    // (base64 on the wire, flagged as such), so two different values are always two different
+                    // keys. Decoding them into a String would go through a charset, and a charset maps every
+                    // invalid sequence to the same replacement character - two different UUIDs could become one
+                    // key, route to one partition and supersede each other on a compacted topic.
+                    futureList.add(async
+                            ? sendAsyncWithKeyBytes(producer, messageKey, orderingKey, messageProperties, messageContent)
+                            : sendWithKeyBytes(producer, messageKey, orderingKey, messageProperties, messageContent));
+                } else {
+                    // Text, a number, a nested record the writer serialised: a text key, always read as UTF-8 so
+                    // that every node of a cluster derives the same key from the same record.
+                    final String textKey = messageKey == null ? null : new String(messageKey, StandardCharsets.UTF_8);
+                    futureList.add(async
+                            ? sendAsync(producer, textKey, orderingKey, messageProperties, messageContent)
+                            : send(producer, textKey, orderingKey, messageProperties, messageContent));
+                }
 
                 if (futureList.size() > 100) {
                     producer.flush();
@@ -732,16 +752,12 @@ public class PublisherLease implements Closeable {
         }
     }
 
-    private String getMessageKey(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
-                                 final Object keyValue) throws IOException, SchemaNotFoundException {
-        final byte[] messageKey = keyBytes(flowFile, writerFactory, keyValue);
-        return (messageKey == null) ? null : new String(messageKey);
-    }
-
     /**
      * The bytes a record field contributes as a key. Shared by the message key and the ordering key, so a field
-     * of any type means the same thing under either property: bytes as they are, an array of boxed bytes unboxed,
-     * a nested record serialised with the FlowFile's writer, anything else as its UTF-8 string.
+     * of any type yields the same bytes under either property: bytes as they are, an array of boxed bytes unboxed,
+     * a nested record serialised with the FlowFile's writer, anything else as its UTF-8 string. What the caller
+     * does with them differs by necessity - the ordering key is always bytes, the message key is bytes for a
+     * binary field ({@link #isBinary}) and UTF-8 text otherwise - but the value is the same.
      */
     private byte[] keyBytes(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
                             final Object keyValue) throws IOException, SchemaNotFoundException {
@@ -774,10 +790,30 @@ public class PublisherLease implements Closeable {
         }
     }
 
-    /** True for an array whose every element is a {@link Byte} - a byte string in the Record API's clothing. */
+    private void warnIfNotAField(final RecordSchema recordSchema, final String fieldName, final String property) {
+        if (fieldName == null || fieldName.isEmpty() || recordSchema == null || recordSchema.getField(fieldName).isPresent()) {
+            return;
+        }
+        logger.warn("{} names '{}', which is not a field of the records' schema (fields: {}); every record of this "
+                + "FlowFile is sent as if the field were null", property, fieldName, recordSchema.getFieldNames());
+    }
+
+    /** Whether a key field's value is binary - a {@code byte[]}, or the boxed form the Record API uses for one. */
+    static boolean isBinary(final Object value) {
+        return value instanceof byte[] || (value instanceof Object[] && isBoxedBytes((Object[]) value));
+    }
+
+    /**
+     * True for an array whose every element is a {@link Byte} - a byte string in the Record API's clothing. An
+     * empty array is bytes only when it is declared as such: an empty {@code array<string>} field is also an
+     * empty {@code Object[]}, and must not turn into an empty key.
+     */
     private static boolean isBoxedBytes(final Object[] array) {
         if (array instanceof Byte[]) {
             return true;
+        }
+        if (array.length == 0) {
+            return false;
         }
         for (final Object element : array) {
             if (!(element instanceof Byte)) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.pulsar.utils;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.avro.AvroTypeUtil;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -311,7 +312,7 @@ public class PublisherLease implements Closeable {
                 final byte[] messageContent;
                 final String messageKey;
                 final byte[] orderingKey = orderingKeyField == null || orderingKeyField.isEmpty()
-                        ? null : getOrderingKey(record.getValue(orderingKeyField));
+                        ? null : getOrderingKey(flowFile, writerFactory, record.getValue(orderingKeyField));
 
                 if (keyValueSchema != null) {
                     final KeyValueTopicSchema.EncodedKeyValue encoded =
@@ -669,18 +670,18 @@ public class PublisherLease implements Closeable {
     }
 
     /**
-     * The ordering key a record field yields: bytes as they are, anything else as its UTF-8 string form, and no
-     * key at all for a null or empty value.
+     * The ordering key a record field yields, converted exactly as {@link #getMessageKey} converts the message key
+     * field - so the same field named by either property gives the same bytes. Null, blank text and empty byte
+     * arrays mean no ordering key.
      */
-    private static byte[] getOrderingKey(final Object fieldValue) {
-        if (fieldValue == null) {
+    private byte[] getOrderingKey(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
+                                  final Object fieldValue) throws IOException, SchemaNotFoundException {
+        if (fieldValue instanceof CharSequence && StringUtils.isBlank((CharSequence) fieldValue)) {
+            // blank is "no ordering key", as it is for PublishPulsar's Ordering Key property
             return null;
         }
-        if (fieldValue instanceof byte[]) {
-            return ((byte[]) fieldValue).length == 0 ? null : (byte[]) fieldValue;
-        }
-        final String asString = fieldValue.toString();
-        return asString.isEmpty() ? null : asString.getBytes(StandardCharsets.UTF_8);
+        final byte[] key = keyBytes(flowFile, writerFactory, fieldValue);
+        return key == null || key.length == 0 ? null : key;
     }
 
     /**
@@ -733,21 +734,32 @@ public class PublisherLease implements Closeable {
 
     private String getMessageKey(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
                                  final Object keyValue) throws IOException, SchemaNotFoundException {
-        final byte[] messageKey;
+        final byte[] messageKey = keyBytes(flowFile, writerFactory, keyValue);
+        return (messageKey == null) ? null : new String(messageKey);
+    }
+
+    /**
+     * The bytes a record field contributes as a key. Shared by the message key and the ordering key, so a field
+     * of any type means the same thing under either property: bytes as they are, an array of boxed bytes unboxed,
+     * a nested record serialised with the FlowFile's writer, anything else as its UTF-8 string.
+     */
+    private byte[] keyBytes(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
+                            final Object keyValue) throws IOException, SchemaNotFoundException {
         if (keyValue == null) {
-            messageKey = null;
+            return null;
         } else if (keyValue instanceof byte[]) {
-            messageKey = (byte[]) keyValue;
-        } else if (keyValue instanceof Byte[]) {
+            return (byte[]) keyValue;
+        } else if (keyValue instanceof Object[] && isBoxedBytes((Object[]) keyValue)) {
             // This case exists because in our Record API we currently don't have a BYTES type, we use an Array of type
-            // Byte, which creates a Byte[] instead of a byte[]. We should address this in the future, but we should
-            // account for the log here.
-            final Byte[] bytes = (Byte[]) keyValue;
+            // Byte. Depending on the reader that is a Byte[] or - from AvroTypeUtil, which is what an AvroReader hands
+            // us for an Avro "bytes" field - an Object[] whose elements are Bytes. Either way toString() would be an
+            // identity hash, different for every record, so unbox to the content.
+            final Object[] bytes = (Object[]) keyValue;
             final byte[] bytesPrimitive = new byte[bytes.length];
             for (int i = 0; i < bytes.length; i++) {
-                bytesPrimitive[i] = bytes[i];
+                bytesPrimitive[i] = (Byte) bytes[i];
             }
-            messageKey = bytesPrimitive;
+            return bytesPrimitive;
         } else if (keyValue instanceof Record) {
             final Record keyRecord = (Record) keyValue;
             try (final ByteArrayOutputStream os = new ByteArrayOutputStream(1024)) {
@@ -755,13 +767,24 @@ public class PublisherLease implements Closeable {
                     writerKey.write(keyRecord);
                     writerKey.flush();
                 }
-                messageKey = os.toByteArray();
+                return os.toByteArray();
             }
         } else {
-            final String keyString = keyValue.toString();
-            messageKey = keyString.getBytes(StandardCharsets.UTF_8);
+            return keyValue.toString().getBytes(StandardCharsets.UTF_8);
         }
-        return (messageKey == null) ? null : new String(messageKey);
+    }
+
+    /** True for an array whose every element is a {@link Byte} - a byte string in the Record API's clothing. */
+    private static boolean isBoxedBytes(final Object[] array) {
+        if (array instanceof Byte[]) {
+            return true;
+        }
+        for (final Object element : array) {
+            if (!(element instanceof Byte)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsar/additionalDetails.html
@@ -65,6 +65,14 @@
     batch at a time, so a batch spanning several keys hands one consumer messages belonging to another
     consumer's key range. It has no effect when batching is off.
 </p>
+<p>
+    <i>Ordering Key</i> sets Pulsar's ordering key on every message of the FlowFile, independently of
+    <i>Message Key</i>. The message key decides the partition and is what topic compaction keeps the latest
+    value for; the ordering key decides which consumer of a <code>Key_Shared</code> subscription receives the
+    message and takes precedence over the message key there. Left blank, no ordering key is set and Pulsar falls
+    back to the message key, as before. Set it when the unit you route and compact by (a tenant, a device) is not
+    the unit you need ordered delivery for (a session, a transaction).
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -65,6 +65,14 @@
     batch at a time, so a batch spanning several keys hands one consumer messages belonging to another
     consumer's key range. It has no effect when batching is off.
 </p>
+<p>
+    <i>Ordering Key Field</i> names the record field whose value becomes Pulsar's ordering key of the record's
+    message, independently of <i>Message Key Field</i>. The message key decides the partition and is what topic
+    compaction keeps the latest value for; the ordering key decides which consumer of a <code>Key_Shared</code>
+    subscription receives the message and takes precedence over the message key there. A record whose field is
+    null or empty is sent without an ordering key, and with the property blank none is ever set, so Pulsar falls
+    back to the message key as before.
+</p>
 <br/>
 <h3>Support</h3>
 <p>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -70,8 +70,12 @@
     message, independently of <i>Message Key Field</i>. The message key decides the partition and is what topic
     compaction keeps the latest value for; the ordering key decides which consumer of a <code>Key_Shared</code>
     subscription receives the message and takes precedence over the message key there. A record whose field is
-    null or empty is sent without an ordering key, and with the property blank none is ever set, so Pulsar falls
-    back to the message key as before.
+    null or blank is sent without an ordering key, and with the property blank none is ever set, so Pulsar falls
+    back to the message key as before. The field is converted exactly as <i>Message Key Field</i> is - text as
+    UTF-8, an Avro <code>bytes</code> field as its bytes, a nested record as the Record Writer writes it - so the
+    same field named under both properties gives the same key. This processor has no FlowFile-level
+    <i>Ordering Key</i>; that property belongs to <code>PublishPulsar</code>, whose messages have no records to
+    take it from.
 </p>
 <br/>
 <h3>Support</h3>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord/additionalDetails.html
@@ -71,11 +71,13 @@
     compaction keeps the latest value for; the ordering key decides which consumer of a <code>Key_Shared</code>
     subscription receives the message and takes precedence over the message key there. A record whose field is
     null or blank is sent without an ordering key, and with the property blank none is ever set, so Pulsar falls
-    back to the message key as before. The field is converted exactly as <i>Message Key Field</i> is - text as
-    UTF-8, an Avro <code>bytes</code> field as its bytes, a nested record as the Record Writer writes it - so the
-    same field named under both properties gives the same key. This processor has no FlowFile-level
-    <i>Ordering Key</i>; that property belongs to <code>PublishPulsar</code>, whose messages have no records to
-    take it from.
+    back to the message key as before. The field yields the same bytes as it would under <i>Message Key
+    Field</i> - text as UTF-8, an Avro <code>bytes</code> field as its bytes, a nested record as the Record Writer
+    writes it - so the same field named under both properties keys and orders by the same value. A binary field
+    travels as a binary message key (base64 on the wire, flagged as such, so different byte strings stay different
+    keys) and as the raw ordering key. A field name that is not in the records' schema is warned about once per
+    FlowFile. This processor has no FlowFile-level <i>Ordering Key</i>; that property belongs to
+    <code>PublishPulsar</code>, whose messages have no records to take it from.
 </p>
 <br/>
 <h3>Support</h3>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
+import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.Test;
+
+/**
+ * The ordering key against a real broker: it has to reach the message, and on a {@code Key_Shared}
+ * subscription it has to be what decides which consumer receives the message - the message key routes and
+ * compacts, the ordering key orders, and when both are set the broker hashes the ordering key.
+ * <p>
+ * The dispatch test publishes messages that all carry <b>distinct</b> message keys and <b>one</b> ordering key
+ * to a two-consumer Key_Shared subscription. Without an ordering key the distinct message keys spread the
+ * messages over both consumers; with it, every message lands on the same consumer, in publish order. Batching
+ * is off so each message is dispatched on its own key rather than as part of a mixed-key batch.
+ */
+public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
+
+    private static final int MESSAGES = 40;
+
+    private TestRunner publishPulsar() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "false");
+        return runner;
+    }
+
+    private TestRunner publishPulsarRecord() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+
+        final MockRecordParser reader = new MockRecordParser();
+        reader.addSchemaField("tenant", RecordFieldType.STRING);
+        reader.addSchemaField("session", RecordFieldType.STRING);
+        reader.addSchemaField("seq", RecordFieldType.INT);
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("tenant, session, seq");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.BATCHING_ENABLED, "false");
+        return runner;
+    }
+
+    private static String topic(final String name) {
+        return "persistent://public/default/ordering-key-" + name + "-" + System.nanoTime();
+    }
+
+    @Test
+    public void theOrderingKeyReachesTheMessageAlongsideTheMessageKey() throws Exception {
+        final String topic = topic("plain");
+        final TestRunner runner = publishPulsar();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${session}");
+
+        try (Consumer<byte[]> consumer = subscribe(topic, "plain-check", SubscriptionType.Exclusive)) {
+            runner.enqueue("payload".getBytes(UTF_8), java.util.Map.of("session", "session-7"));
+            runner.run(1, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+
+            final Message<byte[]> message = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull(message);
+            assertEquals("tenant-a", message.getKey());
+            assertTrue("the message must carry an ordering key", message.hasOrderingKey());
+            assertArrayEquals("session-7".getBytes(UTF_8), message.getOrderingKey());
+        }
+    }
+
+    /** Unset is the existing behaviour: no ordering key on the message, so Pulsar falls back to the message key. */
+    @Test
+    public void noOrderingKeyIsSetWhenThePropertyIsUnset() throws Exception {
+        final String topic = topic("unset");
+        final TestRunner runner = publishPulsar();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
+
+        try (Consumer<byte[]> consumer = subscribe(topic, "unset-check", SubscriptionType.Exclusive)) {
+            runner.enqueue("payload".getBytes(UTF_8));
+            runner.run(1, true);
+
+            final Message<byte[]> message = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull(message);
+            assertEquals("tenant-a", message.getKey());
+            assertFalse(message.hasOrderingKey());
+        }
+    }
+
+    /**
+     * Distinct message keys, one ordering key: Key_Shared must hash the ordering key, so a single consumer
+     * receives everything, in order. The control run - same message keys, no ordering key - has to spread over
+     * both consumers, or the assertion above would also hold for a broker that ignored the ordering key.
+     */
+    @Test
+    public void keySharedDispatchFollowsTheOrderingKeyNotTheMessageKey() throws Exception {
+        // control: no ordering key, distinct message keys spread over both consumers
+        final String controlTopic = topic("control");
+        final TestRunner control = publishPulsar();
+        control.setProperty(AbstractPulsarProducerProcessor.TOPIC, controlTopic);
+        control.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "${key}");
+        final Distribution spread = publishToTwoKeySharedConsumers(control, controlTopic, false);
+        assertTrue("control: " + MESSAGES + " distinct message keys with no ordering key should reach both "
+                + "consumers, but landed " + spread, spread.first > 0 && spread.second > 0);
+
+        // the same distinct message keys, plus one ordering key for all of them
+        final String topic = topic("dispatch");
+        final TestRunner runner = publishPulsar();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "${key}");
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-1");
+        final Distribution together = publishToTwoKeySharedConsumers(runner, topic, true);
+        assertTrue("one ordering key must keep every message on one consumer, but they landed " + together,
+                together.first == 0 || together.second == 0);
+        assertEquals("every message must have arrived", MESSAGES, together.first + together.second);
+        assertTrue("messages sharing the ordering key must arrive in publish order", together.inOrder);
+    }
+
+    @Test
+    public void publishPulsarRecordTakesTheOrderingKeyFromARecordField() throws Exception {
+        final String topic = topic("record");
+        final TestRunner runner = publishPulsarRecord();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tenant");
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
+
+        try (Consumer<byte[]> consumer = subscribe(topic, "record-check", SubscriptionType.Exclusive)) {
+            runner.enqueue("acme,s-1,1\nglobex,s-2,2".getBytes(UTF_8));
+            runner.run(1, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+
+            final Message<byte[]> first = consumer.receive(30, TimeUnit.SECONDS);
+            final Message<byte[]> second = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull(first);
+            assertNotNull(second);
+            assertEquals("acme", first.getKey());
+            assertArrayEquals("s-1".getBytes(UTF_8), first.getOrderingKey());
+            assertEquals("globex", second.getKey());
+            assertArrayEquals("s-2".getBytes(UTF_8), second.getOrderingKey());
+        }
+    }
+
+    private Consumer<byte[]> subscribe(final String topic, final String subscription, final SubscriptionType type)
+            throws Exception {
+        return getClient().newConsumer(Schema.BYTES)
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionType(type)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+    }
+
+    private static final class Distribution {
+        int first;
+        int second;
+        boolean inOrder = true;
+
+        @Override
+        public String toString() {
+            return first + " on the first consumer and " + second + " on the second";
+        }
+    }
+
+    /**
+     * Publishes {@link #MESSAGES} FlowFiles whose {@code key} attribute is distinct per message, then drains a
+     * two-consumer Key_Shared subscription and reports how the messages were distributed.
+     */
+    private Distribution publishToTwoKeySharedConsumers(final TestRunner runner, final String topic,
+                                                        final boolean expectOrderingKey) throws Exception {
+        try (Consumer<byte[]> first = subscribe(topic, "key-shared", SubscriptionType.Key_Shared);
+             Consumer<byte[]> second = subscribe(topic, "key-shared", SubscriptionType.Key_Shared)) {
+
+            for (int n = 0; n < MESSAGES; n++) {
+                runner.enqueue(String.valueOf(n).getBytes(UTF_8), java.util.Map.of("key", "device-" + n));
+            }
+            runner.run(MESSAGES, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, MESSAGES);
+
+            // Everything is published by now, so each consumer is drained in turn until it has been quiet for
+            // a second; the outer loop only repeats if the broker was still dispatching.
+            final Distribution distribution = new Distribution();
+            final List<Integer> firstOrder = new ArrayList<>();
+            final List<Integer> secondOrder = new ArrayList<>();
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+            while (firstOrder.size() + secondOrder.size() < MESSAGES && System.nanoTime() < deadline) {
+                drain(first, firstOrder, expectOrderingKey);
+                drain(second, secondOrder, expectOrderingKey);
+            }
+            distribution.first = firstOrder.size();
+            distribution.second = secondOrder.size();
+            distribution.inOrder = isAscending(firstOrder) && isAscending(secondOrder);
+            return distribution;
+        }
+    }
+
+    private static void drain(final Consumer<byte[]> consumer, final List<Integer> received, final boolean expectOrderingKey)
+            throws Exception {
+        Message<byte[]> message;
+        while ((message = consumer.receive(1, TimeUnit.SECONDS)) != null) {
+            received.add(Integer.parseInt(new String(message.getValue(), UTF_8)));
+            assertEquals(expectOrderingKey, message.hasOrderingKey());
+            consumer.acknowledge(message);
+        }
+    }
+
+    private static boolean isAscending(final List<Integer> values) {
+        for (int i = 1; i < values.size(); i++) {
+            if (values.get(i) < values.get(i - 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
@@ -37,6 +37,7 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -99,7 +100,7 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
         final TestRunner runner = publishPulsar();
         runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
         runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${session}");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "${session}");
 
         try (Consumer<byte[]> consumer = subscribe(topic, "plain-check", SubscriptionType.Exclusive)) {
             runner.enqueue("payload".getBytes(UTF_8), java.util.Map.of("session", "session-7"));
@@ -146,6 +147,7 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
         control.setProperty(AbstractPulsarProducerProcessor.TOPIC, controlTopic);
         control.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "${key}");
         final Distribution spread = publishToTwoKeySharedConsumers(control, controlTopic, false);
+        assertEquals("control: every message must have arrived", MESSAGES, spread.first + spread.second);
         assertTrue("control: " + MESSAGES + " distinct message keys with no ordering key should reach both "
                 + "consumers, but landed " + spread, spread.first > 0 && spread.second > 0);
 
@@ -154,7 +156,7 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
         final TestRunner runner = publishPulsar();
         runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
         runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "${key}");
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-1");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "session-1");
         final Distribution together = publishToTwoKeySharedConsumers(runner, topic, true);
         assertTrue("one ordering key must keep every message on one consumer, but they landed " + together,
                 together.first == 0 || together.second == 0);
@@ -188,12 +190,25 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
 
     private Consumer<byte[]> subscribe(final String topic, final String subscription, final SubscriptionType type)
             throws Exception {
-        return getClient().newConsumer(Schema.BYTES)
+        return subscribe(topic, subscription, type, null);
+    }
+
+    /**
+     * A consumer with a fixed name where it matters: Key_Shared places consumers on its hash ring by consumer
+     * name, so with auto-generated names the split of a fixed set of keys over two consumers would differ from
+     * run to run. Named, it is the same split every time.
+     */
+    private Consumer<byte[]> subscribe(final String topic, final String subscription, final SubscriptionType type,
+                                       final String consumerName) throws Exception {
+        final ConsumerBuilder<byte[]> builder = getClient().newConsumer(Schema.BYTES)
                 .topic(topic)
                 .subscriptionName(subscription)
                 .subscriptionType(type)
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscribe();
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
+        if (consumerName != null) {
+            builder.consumerName(consumerName);
+        }
+        return builder.subscribe();
     }
 
     private static final class Distribution {
@@ -213,8 +228,8 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
      */
     private Distribution publishToTwoKeySharedConsumers(final TestRunner runner, final String topic,
                                                         final boolean expectOrderingKey) throws Exception {
-        try (Consumer<byte[]> first = subscribe(topic, "key-shared", SubscriptionType.Key_Shared);
-             Consumer<byte[]> second = subscribe(topic, "key-shared", SubscriptionType.Key_Shared)) {
+        try (Consumer<byte[]> first = subscribe(topic, "key-shared", SubscriptionType.Key_Shared, "first");
+             Consumer<byte[]> second = subscribe(topic, "key-shared", SubscriptionType.Key_Shared, "second")) {
 
             for (int n = 0; n < MESSAGES; n++) {
                 runner.enqueue(String.valueOf(n).getBytes(UTF_8), java.util.Map.of("key", "device-" + n));
@@ -223,7 +238,8 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
             runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, MESSAGES);
 
             // Everything is published by now, so each consumer is drained in turn until it has been quiet for
-            // a second; the outer loop only repeats if the broker was still dispatching.
+            // a second; the outer loop only repeats if the broker was still dispatching. The callers assert the
+            // total, so a slow broker fails loudly rather than yielding a verdict on a partial sample.
             final Distribution distribution = new Distribution();
             final List<Integer> firstOrder = new ArrayList<>();
             final List<Integer> secondOrder = new ArrayList<>();

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/PublishPulsarOrderingKeyIT.java
@@ -23,10 +23,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.nifi.avro.AvroReader;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
 import org.apache.nifi.processors.pulsar.pubsub.PublishPulsar;
 import org.apache.nifi.processors.pulsar.pubsub.PublishPulsarRecord;
@@ -37,8 +44,9 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -158,10 +166,76 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
         runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "${key}");
         runner.setProperty(PublishPulsar.ORDERING_KEY, "session-1");
         final Distribution together = publishToTwoKeySharedConsumers(runner, topic, true);
+        // arrival first: a partial drain would otherwise pass the single-consumer check vacuously and fail
+        // one line later with a count mismatch, which misreads a delivery problem as a dispatch one
+        assertEquals("every message must have arrived", MESSAGES, together.first + together.second);
         assertTrue("one ordering key must keep every message on one consumer, but they landed " + together,
                 together.first == 0 || together.second == 0);
-        assertEquals("every message must have arrived", MESSAGES, together.first + together.second);
         assertTrue("messages sharing the ordering key must arrive in publish order", together.inOrder);
+    }
+
+    /**
+     * A binary key field (an Avro {@code bytes} field, which NiFi reads as boxed bytes) is sent through
+     * {@code keyBytes()}: on the wire the key is base64 and flagged as such, and a consumer gets the bytes back
+     * exactly. Decoding them into a String first would have gone through a charset and could have merged two
+     * different values into one key (#226).
+     */
+    @Test
+    public void aBinaryMessageKeyFieldArrivesAsTheSameBytes() throws Exception {
+        final String topic = topic("binary-key");
+        final TestRunner runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        final AvroReader reader = new AvroReader();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+        final MockRecordWriter writer = new MockRecordWriter("id, session");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        runner.setProperty(AbstractPulsarProducerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, topic);
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "session");
+
+        // two keys that are different bytes but the same text once decoded as UTF-8
+        final byte[] first = {(byte) 0xFF, (byte) 0xFE, 0x01};
+        final byte[] second = {(byte) 0xFE, (byte) 0xFF, 0x01};
+
+        try (Consumer<byte[]> consumer = subscribe(topic, "binary-check", SubscriptionType.Exclusive)) {
+            runner.enqueue(avroRecords(first, second));
+            runner.run(1, true);
+            runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+
+            final Message<byte[]> one = consumer.receive(30, TimeUnit.SECONDS);
+            final Message<byte[]> two = consumer.receive(30, TimeUnit.SECONDS);
+            assertNotNull(one);
+            assertNotNull(two);
+            assertTrue("a binary key travels base64-encoded and flagged", one.hasBase64EncodedKey() && two.hasBase64EncodedKey());
+            assertArrayEquals(first, one.getKeyBytes());
+            assertArrayEquals(second, two.getKeyBytes());
+            assertFalse("two different byte strings must stay two different keys", one.getKey().equals(two.getKey()));
+        }
+    }
+
+    private static final org.apache.avro.Schema BINARY_KEY_SCHEMA = new org.apache.avro.Schema.Parser().parse(
+            "{\"type\":\"record\",\"name\":\"Event\",\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"session\",\"type\":\"bytes\"}]}");
+
+    /** An Avro data file with one record per session, the session being the record's binary key. */
+    private static byte[] avroRecords(final byte[]... sessions) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(BINARY_KEY_SCHEMA))) {
+            writer.create(BINARY_KEY_SCHEMA, out);
+            int id = 0;
+            for (final byte[] session : sessions) {
+                final GenericRecord record = new GenericData.Record(BINARY_KEY_SCHEMA);
+                record.put("id", id++);
+                record.put("session", ByteBuffer.wrap(session));
+                writer.append(record);
+            }
+        }
+        return out.toByteArray();
     }
 
     @Test
@@ -190,25 +264,32 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
 
     private Consumer<byte[]> subscribe(final String topic, final String subscription, final SubscriptionType type)
             throws Exception {
-        return subscribe(topic, subscription, type, null);
-    }
-
-    /**
-     * A consumer with a fixed name where it matters: Key_Shared places consumers on its hash ring by consumer
-     * name, so with auto-generated names the split of a fixed set of keys over two consumers would differ from
-     * run to run. Named, it is the same split every time.
-     */
-    private Consumer<byte[]> subscribe(final String topic, final String subscription, final SubscriptionType type,
-                                       final String consumerName) throws Exception {
-        final ConsumerBuilder<byte[]> builder = getClient().newConsumer(Schema.BYTES)
+        return getClient().newConsumer(Schema.BYTES)
                 .topic(topic)
                 .subscriptionName(subscription)
                 .subscriptionType(type)
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
-        if (consumerName != null) {
-            builder.consumerName(consumerName);
-        }
-        return builder.subscribe();
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+    }
+
+    /**
+     * A Key_Shared consumer that owns an explicit half of the key hash space. With the default AUTO_SPLIT policy
+     * the broker places consumers on a consistent-hash ring whose shape - point count, hash function, the sticky
+     * key implementation in use - has moved within the 4.x line, so which half of a fixed key set each consumer
+     * gets is a broker detail, and a future image bump could hand every key to one consumer and fail the control
+     * run with no product regression behind it. A sticky hash range pins it: a key's consumer is decided by
+     * {@code hash(key) % 65536} against the ranges declared here, on any broker.
+     */
+    private Consumer<byte[]> subscribeKeyShared(final String topic, final String consumerName, final Range hashRange)
+            throws Exception {
+        return getClient().newConsumer(Schema.BYTES)
+                .topic(topic)
+                .subscriptionName("key-shared")
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .consumerName(consumerName)
+                .keySharedPolicy(KeySharedPolicy.stickyHashRange().ranges(hashRange))
+                .subscribe();
     }
 
     private static final class Distribution {
@@ -228,8 +309,9 @@ public class PublishPulsarOrderingKeyIT extends AbstractPulsarIT {
      */
     private Distribution publishToTwoKeySharedConsumers(final TestRunner runner, final String topic,
                                                         final boolean expectOrderingKey) throws Exception {
-        try (Consumer<byte[]> first = subscribe(topic, "key-shared", SubscriptionType.Key_Shared, "first");
-             Consumer<byte[]> second = subscribe(topic, "key-shared", SubscriptionType.Key_Shared, "second")) {
+        // the two halves of Key_Shared's 65536-slot hash space
+        try (Consumer<byte[]> first = subscribeKeyShared(topic, "first", Range.of(0, 32767));
+             Consumer<byte[]> second = subscribeKeyShared(topic, "second", Range.of(32768, 65535))) {
 
             for (int n = 0; n < MESSAGES; n++) {
                 runner.enqueue(String.valueOf(n).getBytes(UTF_8), java.util.Map.of("key", "device-" + n));

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarLeaseReuseTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.nifi.processors.pulsar.pubsub;
 
+import java.io.InputStream;
+
+import org.apache.nifi.flowfile.FlowFile;
+
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
 import org.apache.nifi.processors.pulsar.utils.PublisherLease;
@@ -274,7 +278,7 @@ public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byt
         
         // Verify the lease was obtained and used
         verify(mockPublisherPool, times(1)).obtainPublisher("test-topic");
-        verify(mockLease1, times(1)).publish(any(), any(), any(), any(), any(), anyBoolean());
+        verify(mockLease1, times(1)).publish(any(FlowFile.class), any(InputStream.class), any(), any(), any(), any(), anyBoolean());
         
         // Verify FlowFile was transferred successfully
         runner.assertAllFlowFilesTransferred(AbstractPulsarProducerProcessor.REL_SUCCESS, 1);
@@ -299,7 +303,7 @@ public class PublishPulsarLeaseReuseTest extends AbstractPulsarProcessorTest<byt
 
         // Verify the lease was obtained only once and reused
         verify(mockPublisherPool, times(1)).obtainPublisher("test-topic");
-        verify(mockLease1, times(3)).publish(any(), any(), any(), any(), any(), anyBoolean());
+        verify(mockLease1, times(3)).publish(any(FlowFile.class), any(InputStream.class), any(), any(), any(), any(), anyBoolean());
         verify(mockLease1, never()).close(); // Should not be closed during processing
         
         // Verify all FlowFiles were transferred successfully

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.pubsub;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
+import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * The ordering key is a separate concern from the message key: the message key routes to a partition and
+ * drives compaction, the ordering key decides Key_Shared dispatch and takes precedence there when set. Until
+ * #196 the publishers could only set the message key, so the two were forced to be the same value.
+ * <p>
+ * <i>Ordering Key</i> on {@code PublishPulsar} and <i>Ordering Key Field</i> on {@code PublishPulsarRecord}
+ * mirror the <i>Message Key</i> / <i>Message Key Field</i> pair. Unset, nothing is put on the message and
+ * Pulsar's own fallback to the message key applies, so no existing flow changes.
+ */
+public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<byte[]> {
+
+    private static final String TOPIC = "persistent://public/default/ordering";
+
+    private void publishPulsarRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, TOPIC);
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    private void publishPulsarRecordRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+
+        final MockRecordParser reader = new MockRecordParser();
+        reader.addSchemaField("tenant", RecordFieldType.STRING);
+        reader.addSchemaField("session", RecordFieldType.STRING);
+        reader.addSchemaField("reading", RecordFieldType.INT);
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("tenant, session, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, TOPIC);
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    private TypedMessageBuilder<byte[]> builder() {
+        return mockClientService.getMockTypedMessageBuilder();
+    }
+
+    private List<String> orderingKeysSent(final int expectedMessages) {
+        final ArgumentCaptor<byte[]> orderingKeys = ArgumentCaptor.forClass(byte[].class);
+        verify(builder(), times(expectedMessages)).orderingKey(orderingKeys.capture());
+        return orderingKeys.getAllValues().stream().map(bytes -> new String(bytes, UTF_8)).toList();
+    }
+
+    // --- PublishPulsar -------------------------------------------------------------------------------------
+
+    @Test
+    public void publishPulsarPutsTheOrderingKeyOnTheMessage() throws Exception {
+        publishPulsarRunner();
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-7");
+
+        runner.enqueue("payload".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+        verify(builder(), times(1)).key("tenant-a");
+        assertEquals(List.of("session-7"), orderingKeysSent(1));
+    }
+
+    @Test
+    public void publishPulsarEvaluatesTheOrderingKeyAgainstFlowFileAttributes() throws Exception {
+        publishPulsarRunner();
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${session.id}");
+
+        runner.enqueue("payload".getBytes(UTF_8), Map.of("session.id", "s-42"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+        assertEquals(List.of("s-42"), orderingKeysSent(1));
+    }
+
+    /** Every demarcated message of a FlowFile carries the FlowFile's ordering key, as it does the message key. */
+    @Test
+    public void publishPulsarAppliesTheOrderingKeyToEveryDemarcatedMessage() throws Exception {
+        publishPulsarRunner();
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-7");
+
+        runner.enqueue("one\ntwo\nthree".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+        assertEquals(Arrays.asList("session-7", "session-7", "session-7"), orderingKeysSent(3));
+    }
+
+    /** Unset is the existing behaviour: nothing is set, and Pulsar falls back to the message key on its own. */
+    @Test
+    public void publishPulsarSetsNoOrderingKeyWhenThePropertyIsUnset() throws Exception {
+        publishPulsarRunner();
+        runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
+
+        runner.enqueue("payload".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+        verify(builder(), never()).orderingKey(any());
+    }
+
+    /** An attribute the expression does not find is not an ordering key. */
+    @Test
+    public void publishPulsarSetsNoOrderingKeyWhenTheExpressionIsEmpty() throws Exception {
+        publishPulsarRunner();
+        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${missing.attribute}");
+
+        runner.enqueue("payload".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsar.REL_SUCCESS, 1);
+        verify(builder(), never()).orderingKey(any());
+    }
+
+    // --- PublishPulsarRecord -------------------------------------------------------------------------------
+
+    @Test
+    public void publishPulsarRecordTakesTheOrderingKeyFromTheNamedField() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tenant");
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
+
+        runner.enqueue("acme,s-1,10\nacme,s-2,11\nglobex,s-1,12".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), times(2)).key("acme");
+        verify(builder(), times(1)).key("globex");
+        assertEquals(Arrays.asList("s-1", "s-2", "s-1"), orderingKeysSent(3));
+    }
+
+    /** A record whose field is null gets no ordering key; the other records of the FlowFile still do. */
+    @Test
+    public void publishPulsarRecordSkipsTheOrderingKeyForARecordWithoutTheField() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
+
+        runner.enqueue("acme,s-1,10\nacme,,11".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        assertEquals(List.of("s-1"), orderingKeysSent(1));
+    }
+
+    @Test
+    public void publishPulsarRecordSetsNoOrderingKeyWhenTheFieldIsNotConfigured() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tenant");
+
+        runner.enqueue("acme,s-1,10".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), never()).orderingKey(any());
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.pulsar.pubsub;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordParser;
 import org.apache.nifi.processors.pulsar.pubsub.mocks.MockRecordWriter;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.junit.Test;
@@ -94,6 +96,7 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
             + "{\"name\":\"tenant\",\"type\":\"string\"},"
             + "{\"name\":\"session\",\"type\":\"bytes\"},"
             + "{\"name\":\"label\",\"type\":\"string\"},"
+            + "{\"name\":\"tags\",\"type\":{\"type\":\"array\",\"items\":\"string\"}},"
             + "{\"name\":\"reading\",\"type\":\"int\"}]}");
 
     /**
@@ -118,21 +121,32 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
         runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
     }
 
-    /** An Avro data file with one record per (session, label) pair; every record has the same tenant and reading. */
-    private static byte[] avroRecords(final Object[]... sessionAndLabel) throws Exception {
+    /**
+     * An Avro data file with one record per (session, label[, tags]) tuple; every record has the same tenant and
+     * reading. The session is a {@code String} (its UTF-8 bytes) or a {@code byte[]} (as given), the tags default
+     * to an empty array.
+     */
+    private static byte[] avroRecords(final Object[]... sessionLabelTags) throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(AVRO_SCHEMA))) {
             writer.create(AVRO_SCHEMA, out);
-            for (final Object[] pair : sessionAndLabel) {
+            for (final Object[] tuple : sessionLabelTags) {
                 final GenericRecord record = new GenericData.Record(AVRO_SCHEMA);
                 record.put("tenant", "acme");
-                record.put("session", ByteBuffer.wrap(((String) pair[0]).getBytes(UTF_8)));
-                record.put("label", pair[1]);
+                record.put("session", ByteBuffer.wrap(tuple[0] instanceof byte[] ? (byte[]) tuple[0] : ((String) tuple[0]).getBytes(UTF_8)));
+                record.put("label", tuple[1]);
+                record.put("tags", tuple.length > 2 ? Arrays.asList((String[]) tuple[2]) : List.of());
                 record.put("reading", 1);
                 writer.append(record);
             }
         }
         return out.toByteArray();
+    }
+
+    private List<byte[]> keyBytesSent(final int expectedMessages) {
+        final ArgumentCaptor<byte[]> keys = ArgumentCaptor.forClass(byte[].class);
+        verify(builder(), times(expectedMessages)).keyBytes(keys.capture());
+        return keys.getAllValues();
     }
 
     private TypedMessageBuilder<byte[]> builder() {
@@ -245,11 +259,13 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
 
     /**
      * The whole point of an ordering key is that every message carrying the same value lands on the same consumer.
-     * A {@code Byte[]} - what an Avro {@code bytes} field arrives as - must therefore be unboxed to its content, as
-     * the message key already is; {@code toString()} on it is an identity hash that differs for every message.
+     * A boxed byte array - what an Avro {@code bytes} field arrives as - must therefore be unboxed to its content,
+     * as the message key is; {@code toString()} on it is an identity hash that differs for every message. And the
+     * same field under both properties gives the same bytes: as the ordering key directly, as the message key
+     * through {@code keyBytes()}.
      */
     @Test
-    public void publishPulsarRecordUnboxesAnAvroBytesFieldLikeTheMessageKeyDoes() throws Exception {
+    public void publishPulsarRecordUnboxesAnAvroBytesFieldUnderBothProperties() throws Exception {
         publishPulsarRecordRunnerWithAvroInput();
         runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "session");
         runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
@@ -258,10 +274,106 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
-        verify(builder(), times(2)).key("s-1");
-        verify(builder(), times(1)).key("s-2");
+        final List<String> messageKeys = keyBytesSent(3).stream().map(bytes -> new String(bytes, UTF_8)).toList();
+        assertEquals(Arrays.asList("s-1", "s-1", "s-2"), messageKeys);
         assertEquals("the ordering key must be the field's content, identical for the two s-1 records",
                 Arrays.asList("s-1", "s-1", "s-2"), orderingKeysSent(3));
+        verify(builder(), never()).key(any());
+    }
+
+    /**
+     * A binary key travels as bytes, not as text decoded through a charset. Decoding maps every invalid sequence to
+     * the same replacement character, so two different byte strings can become one key - here {@code FF FE 01} and
+     * {@code FE FF 01}, both "\uFFFD\uFFFD\u0001" under UTF-8 - and on a compacted topic one would supersede the
+     * other. With {@code keyBytes()} they stay two keys.
+     */
+    @Test
+    public void aBinaryMessageKeyFieldIsSentAsKeyBytesSoDifferentValuesStayDifferentKeys() throws Exception {
+        publishPulsarRecordRunnerWithAvroInput();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "session");
+        final byte[] first = {(byte) 0xFF, (byte) 0xFE, 0x01};
+        final byte[] second = {(byte) 0xFE, (byte) 0xFF, 0x01};
+        assertEquals("the two keys must be indistinguishable once decoded, or the test proves nothing",
+                new String(first, UTF_8), new String(second, UTF_8));
+
+        runner.enqueue(avroRecords(new Object[] {first, "a"}, new Object[] {second, "b"}));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        final List<byte[]> sent = keyBytesSent(2);
+        assertArrayEquals(first, sent.get(0));
+        assertArrayEquals(second, sent.get(1));
+        verify(builder(), never()).key(any());
+    }
+
+    /**
+     * An empty {@code array<string>} is also an empty {@code Object[]}, and must not be mistaken for an empty byte
+     * string: every record whose array is empty would otherwise get the key {@code ""} and they would all
+     * supersede each other on a compacted topic.
+     */
+    @Test
+    public void anEmptyArrayFieldIsNotABinaryKey() throws Exception {
+        publishPulsarRecordRunnerWithAvroInput();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tags");
+
+        runner.enqueue(avroRecords(new Object[] {"s-1", "a", new String[0]}, new Object[] {"s-2", "b", new String[0]}));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), never()).keyBytes(any());
+        verify(builder(), never()).key("");
+    }
+
+    /**
+     * A field the records do not have yields null for every record, exactly like a field that is present and
+     * null - so a misspelt name would set no ordering key and nothing would say so. It is warned about once per
+     * FlowFile.
+     */
+    @Test
+    public void aMisspelledOrderingKeyFieldIsWarnedAboutOncePerFlowFile() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "sessionId");
+
+        runner.enqueue("acme,s-1,10\nacme,s-2,11\nglobex,s-3,12".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), never()).orderingKey(any());
+        assertEquals(1, runner.getLogger().getWarnMessages().size());
+        final LogMessage warning = runner.getLogger().getWarnMessages().get(0);
+        final String rendered = String.format(warning.getMsg().replace("{}", "%s"), warning.getArgs());
+        assertTrue(rendered, rendered.contains("Ordering Key Field") && rendered.contains("sessionId") && rendered.contains("session"));
+    }
+
+    /** The same gap existed for Message Key Field; the same warning closes it. */
+    @Test
+    public void aMisspelledMessageKeyFieldIsWarnedAboutOncePerFlowFile() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tenantId");
+
+        runner.enqueue("acme,s-1,10\nglobex,s-2,11".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), never()).key(any());
+        assertEquals(1, runner.getLogger().getWarnMessages().size());
+        final LogMessage warning = runner.getLogger().getWarnMessages().get(0);
+        final String rendered = String.format(warning.getMsg().replace("{}", "%s"), warning.getArgs());
+        assertTrue(rendered, rendered.contains("Message Key Field") && rendered.contains("tenantId"));
+    }
+
+    /** A correctly named field produces no warning, or the warning would be noise on every FlowFile. */
+    @Test
+    public void aFieldThatExistsProducesNoWarning() throws Exception {
+        publishPulsarRecordRunner();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "tenant");
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
+
+        runner.enqueue("acme,s-1,10".getBytes(UTF_8));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        assertEquals(0, runner.getLogger().getWarnMessages().size());
     }
 
     /** Blank means no ordering key on both processors: PublishPulsar's property already said so via isBlank. */

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/PublishPulsarOrderingKeyTest.java
@@ -18,14 +18,25 @@ package org.apache.nifi.processors.pulsar.pubsub;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.nifi.avro.AvroReader;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarProcessorTest;
 import org.apache.nifi.processors.pulsar.AbstractPulsarProducerProcessor;
@@ -79,6 +90,51 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
         runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
     }
 
+    private static final Schema AVRO_SCHEMA = new Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Reading\",\"fields\":["
+            + "{\"name\":\"tenant\",\"type\":\"string\"},"
+            + "{\"name\":\"session\",\"type\":\"bytes\"},"
+            + "{\"name\":\"label\",\"type\":\"string\"},"
+            + "{\"name\":\"reading\",\"type\":\"int\"}]}");
+
+    /**
+     * An Avro reader, because that is where a {@code Byte[]} comes from: NiFi's {@code AvroTypeUtil} turns an Avro
+     * {@code bytes} field into a {@code Byte[]}, not a {@code byte[]}.
+     */
+    private void publishPulsarRecordRunnerWithAvroInput() throws InitializationException {
+        runner = TestRunners.newTestRunner(PublishPulsarRecord.class);
+
+        final AvroReader reader = new AvroReader();
+        runner.addControllerService("record-reader", reader);
+        runner.enableControllerService(reader);
+
+        final MockRecordWriter writer = new MockRecordWriter("tenant, session, label, reading");
+        runner.addControllerService("record-writer", writer);
+        runner.enableControllerService(writer);
+
+        runner.setProperty(PublishPulsarRecord.RECORD_READER, "record-reader");
+        runner.setProperty(PublishPulsarRecord.RECORD_WRITER, "record-writer");
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarProducerProcessor.TOPIC, TOPIC);
+        runner.setProperty(AbstractPulsarProducerProcessor.ASYNC_ENABLED, "false");
+    }
+
+    /** An Avro data file with one record per (session, label) pair; every record has the same tenant and reading. */
+    private static byte[] avroRecords(final Object[]... sessionAndLabel) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>(AVRO_SCHEMA))) {
+            writer.create(AVRO_SCHEMA, out);
+            for (final Object[] pair : sessionAndLabel) {
+                final GenericRecord record = new GenericData.Record(AVRO_SCHEMA);
+                record.put("tenant", "acme");
+                record.put("session", ByteBuffer.wrap(((String) pair[0]).getBytes(UTF_8)));
+                record.put("label", pair[1]);
+                record.put("reading", 1);
+                writer.append(record);
+            }
+        }
+        return out.toByteArray();
+    }
+
     private TypedMessageBuilder<byte[]> builder() {
         return mockClientService.getMockTypedMessageBuilder();
     }
@@ -95,7 +151,7 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
     public void publishPulsarPutsTheOrderingKeyOnTheMessage() throws Exception {
         publishPulsarRunner();
         runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_KEY, "tenant-a");
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-7");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "session-7");
 
         runner.enqueue("payload".getBytes(UTF_8));
         runner.run();
@@ -108,7 +164,7 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
     @Test
     public void publishPulsarEvaluatesTheOrderingKeyAgainstFlowFileAttributes() throws Exception {
         publishPulsarRunner();
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${session.id}");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "${session.id}");
 
         runner.enqueue("payload".getBytes(UTF_8), Map.of("session.id", "s-42"));
         runner.run();
@@ -122,7 +178,7 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
     public void publishPulsarAppliesTheOrderingKeyToEveryDemarcatedMessage() throws Exception {
         publishPulsarRunner();
         runner.setProperty(AbstractPulsarProducerProcessor.MESSAGE_DEMARCATOR, "\n");
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "session-7");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "session-7");
 
         runner.enqueue("one\ntwo\nthree".getBytes(UTF_8));
         runner.run();
@@ -148,7 +204,7 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
     @Test
     public void publishPulsarSetsNoOrderingKeyWhenTheExpressionIsEmpty() throws Exception {
         publishPulsarRunner();
-        runner.setProperty(AbstractPulsarProducerProcessor.ORDERING_KEY, "${missing.attribute}");
+        runner.setProperty(PublishPulsar.ORDERING_KEY, "${missing.attribute}");
 
         runner.enqueue("payload".getBytes(UTF_8));
         runner.run();
@@ -185,6 +241,51 @@ public class PublishPulsarOrderingKeyTest extends AbstractPulsarProcessorTest<by
 
         runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
         assertEquals(List.of("s-1"), orderingKeysSent(1));
+    }
+
+    /**
+     * The whole point of an ordering key is that every message carrying the same value lands on the same consumer.
+     * A {@code Byte[]} - what an Avro {@code bytes} field arrives as - must therefore be unboxed to its content, as
+     * the message key already is; {@code toString()} on it is an identity hash that differs for every message.
+     */
+    @Test
+    public void publishPulsarRecordUnboxesAnAvroBytesFieldLikeTheMessageKeyDoes() throws Exception {
+        publishPulsarRecordRunnerWithAvroInput();
+        runner.setProperty(PublishPulsarRecord.MESSAGE_KEY_FIELD, "session");
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "session");
+
+        runner.enqueue(avroRecords(new Object[] {"s-1", "first"}, new Object[] {"s-1", "second"}, new Object[] {"s-2", "third"}));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        verify(builder(), times(2)).key("s-1");
+        verify(builder(), times(1)).key("s-2");
+        assertEquals("the ordering key must be the field's content, identical for the two s-1 records",
+                Arrays.asList("s-1", "s-1", "s-2"), orderingKeysSent(3));
+    }
+
+    /** Blank means no ordering key on both processors: PublishPulsar's property already said so via isBlank. */
+    @Test
+    public void publishPulsarRecordTreatsABlankFieldAsNoOrderingKey() throws Exception {
+        publishPulsarRecordRunnerWithAvroInput();
+        runner.setProperty(PublishPulsarRecord.ORDERING_KEY_FIELD, "label");
+
+        runner.enqueue(avroRecords(new Object[] {"s-1", "   "}, new Object[] {"s-1", "keyed"}));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(PublishPulsarRecord.REL_SUCCESS, 1);
+        assertEquals(List.of("keyed"), orderingKeysSent(1));
+    }
+
+    /**
+     * Only PublishPulsar reads <i>Ordering Key</i>; PublishPulsarRecord takes its ordering key per record from
+     * <i>Ordering Key Field</i>. A property the processor never reads must not appear in its UI.
+     */
+    @Test
+    public void onlyPublishPulsarOffersTheFlowFileLevelOrderingKey() {
+        assertTrue(new PublishPulsar().getPropertyDescriptors().contains(PublishPulsar.ORDERING_KEY));
+        assertFalse(new PublishPulsarRecord().getPropertyDescriptors().contains(PublishPulsar.ORDERING_KEY));
+        assertTrue(new PublishPulsarRecord().getPropertyDescriptors().contains(PublishPulsarRecord.ORDERING_KEY_FIELD));
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -259,6 +259,7 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
             when(mockProducer.isConnected()).thenReturn(true);
             when(mockProducer.newMessage()).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.key(anyString())).thenReturn(mockTypedMessageBuilder);
+            when(mockTypedMessageBuilder.orderingKey(any(byte[].class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.properties((Map<String, String>) any(Map.class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.value((T) any(byte[].class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.send()).thenReturn(mockMessageId);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/mocks/MockPulsarClientService.java
@@ -259,6 +259,7 @@ public class MockPulsarClientService<T> extends AbstractControllerService implem
             when(mockProducer.isConnected()).thenReturn(true);
             when(mockProducer.newMessage()).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.key(anyString())).thenReturn(mockTypedMessageBuilder);
+            when(mockTypedMessageBuilder.keyBytes(any(byte[].class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.orderingKey(any(byte[].class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.properties((Map<String, String>) any(Map.class))).thenReturn(mockTypedMessageBuilder);
             when(mockTypedMessageBuilder.value((T) any(byte[].class))).thenReturn(mockTypedMessageBuilder);


### PR DESCRIPTION
Closes #196. Closes #226.

The publishers could only set the message key, so partition routing, compaction and `Key_Shared` dispatch were forced onto one value. Pulsar keeps them apart: the message key routes and compacts, the ordering key decides `Key_Shared` dispatch and takes precedence there when set. This adds the pair the issue proposes, and nothing else.

> **Revised after review** (second commit): the ordering key field is converted through the same helper as the message key field (so an Avro `bytes` field is its content, not an identity hash), blank means no key on both processors, *Ordering Key* is offered by `PublishPulsar` only, and the IT's control run is deterministic. **Third commit:** the *Message Key Field* fix that fell out of the shared helper is filed as #226, closed here, and carried as its own entry in the release notes with a README behaviour-change callout. **Fourth commit (second review):** a binary key field is sent as key bytes rather than decoded text, an empty array is not a byte string, a key field the schema lacks is warned about, and the IT's `Key_Shared` consumers own explicit sticky hash ranges. Details in the review thread.

### What changed

- **`PublishPulsar`** — *Ordering Key*, Expression Language against FlowFile attributes, mirroring *Message Key*. Blank (or an expression that resolves to nothing) means no ordering key is set, so Pulsar falls back to the message key exactly as before. No `msg.orderingKey` attribute fallback — an expression covers that case without inventing a second convention. The property lives on this processor, not the base class: `PublishPulsarRecord` never reads it, and would otherwise show it.
- **`PublishPulsarRecord`** — *Ordering Key Field*, mirroring *Message Key Field*. A record whose field is null or blank is sent without an ordering key; other records of the same FlowFile still carry theirs. The field yields the same bytes as it would under *Message Key Field* — `byte[]` as is, an array of boxed bytes unboxed (an empty array only if it is a `Byte[]`), a nested `Record` serialised with the FlowFile's writer, anything else as UTF-8 text. A **binary** message key field is sent through `keyBytes()` (base64 on the wire, flagged), never decoded into a `String`; a text one is read as UTF-8. A field name the records' schema does not have is warned about once per FlowFile, for both properties.
- **`PublisherLease`** — the key travels through every send path, including the KeyValue `SEPARATED` one, where the schema owns the message key but the ordering key is unaffected (as #196 notes). The existing `send`/`sendAsync`/`…WithKeyBytes` methods remain the extension point: the new ordering-key variants hand every message *without* an ordering key to them, so a subclass overriding the originals — the test suite does, to control the futures — keeps seeing those messages. The public `publish` overloads are kept and delegate.
- **Docs** — README's *Publisher message metadata* table gains the row and a paragraph on which key does what, with the reminder that *Batch Builder* = `Key based` is what keeps a batch from spanning keys; both publishers' `additionalDetails.html` say the same. A *Behaviour change since `2.11.0`* callout covers #226: a flow keying by an Avro `bytes` field starts routing and compacting by the real key, sent as a binary key. New `docs/release-notes/2.11.0.2.md` (the next connector revision under VERSIONING.md, `2.11.0.1` having shipped) lists the ordering key under *New* and #226 plus the missing-field warning under *Fixes*.

### Tests

**`PublishPulsarOrderingKeyTest`** (mocked client, 16 cases): the key set from the property and from an attribute expression, applied to every demarcated message, taken from the record field per record, skipped for a null/empty field, and — the fallback contract — never set when the property is blank or the expression resolves to nothing. Second commit: an Avro `bytes` field read by a real `AvroReader` yields the same ordering key for two records with the same content and the same bytes as the message key from the same field; a blank field sets no ordering key; *Ordering Key* is offered by `PublishPulsar` and not by `PublishPulsarRecord`. Fourth commit: two byte strings that decode to the same text (`FF FE 01` / `FE FF 01`) are sent as two different `keyBytes` and `key(String)` is never called; an empty `array<string>` field is not sent as key `""`; a misspelt *Ordering Key Field* or *Message Key Field* produces exactly one warning naming the property, the field and the schema's fields, and sets no key; a present field warns nothing.

**`PublishPulsarOrderingKeyIT`** (Testcontainers, `apachepulsar/pulsar:4.2.4`, 5 cases): the key arrives on the message alongside the message key; nothing is set when the property is unset; `PublishPulsarRecord` takes it from a field; and the one only a broker can answer — **on a two-consumer `Key_Shared` subscription, 40 messages with distinct message keys and one ordering key all land on a single consumer, in publish order**, while the control run with the same distinct message keys and no ordering key spreads them over both consumers. The control is what stops the assertion from also holding on a broker that ignored the ordering key. The two consumers own explicit sticky hash ranges (`KeySharedPolicy.stickyHashRange()`, `0–32767` and `32768–65535`), so which consumer a key lands on is `hash(key) % 65536` against those ranges on any broker rather than a property of the broker's AUTO_SPLIT ring; both runs assert that all 40 arrived before judging dispatch. Fourth commit adds the binary-key case: an Avro `bytes` key field arrives `hasBase64EncodedKey()` with `getKeyBytes()` equal to the field, and two byte strings that decode to the same text are two keys.

### Fails first

A new property has no "before" on `main` beyond a compile error, so the meaningful red is the mutation: with the ordering key dropped before `send` (the `orderingKey(...)` call removed) the 5 unit cases that assert the key fail and the 3 fallback cases keep passing —

```
Tests run: 8, Failures: 5, Errors: 0, Skipped: 0 -- in PublishPulsarOrderingKeyTest
  publishPulsarPutsTheOrderingKeyOnTheMessage:105->orderingKeysSent:88
  publishPulsarEvaluatesTheOrderingKeyAgainstFlowFileAttributes:117->orderingKeysSent:88
  publishPulsarAppliesTheOrderingKeyToEveryDemarcatedMessage:131->orderingKeysSent:88
  publishPulsarRecordTakesTheOrderingKeyFromTheNamedField:174->orderingKeysSent:88
  publishPulsarRecordSkipsTheOrderingKeyForARecordWithoutTheField:187->orderingKeysSent:88
```

— and the same mutation would fail the `Key_Shared` IT, since the distinct message keys then spread the messages.

Second commit, the Avro `bytes` case against the first commit's conversion (`toString()` on anything that is not a `byte[]`):

```
publishPulsarRecordUnboxesAnAvroBytesFieldLikeTheMessageKeyDoes
  typedMessageBuilder.orderingKey([... "[Ljava.lang.Object;@5cf57368" as bytes ...])
  typedMessageBuilder.key("[Ljava.lang.Object;@5cf57368")
```

Both keys were the identity hash — which is also why the fix is in the shared helper, see the thread.

Fourth commit, the five new unit cases against the third commit's `PublisherLease`:

```
Tests run: 16, Failures: 5 -- in PublishPulsarOrderingKeyTest
  aBinaryMessageKeyFieldIsSentAsKeyBytesSoDifferentValuesStayDifferentKeys:
    Wanted but not invoked: typedMessageBuilder.keyBytes(<Capturing argument: byte[]>)
  publishPulsarRecordUnboxesAnAvroBytesFieldUnderBothProperties:  (same: key(String) was used, not keyBytes)
  anEmptyArrayFieldIsNotABinaryKey:  NeverWantedButInvoked: typedMessageBuilder.key("")
  aMisspelledOrderingKeyFieldIsWarnedAboutOncePerFlowFile:  expected:<1> but was:<0>
  aMisspelledMessageKeyFieldIsWarnedAboutOncePerFlowFile:   expected:<1> but was:<0>
```

### Verification

- `mvn test` on the current head: **383/383** (on top of `main` after `2.11.0.1`: 367 + 16).
- Fourth commit: `PublishPulsarOrderingKeyIT` 5/5, `PublishPulsarMessageKeyIT` 4/4, `PublishPulsarRecordSchemaIT` 3/3, `KeyValueSchemaRoundTripIT` 7/7 against a real broker.
- Second commit: `PublishPulsarOrderingKeyIT` (three consecutive runs, 4/4 each), `PublishPulsarMessageKeyIT` 4/4 and `PublishPulsarRecordSchemaIT` 3/3 against a real broker.
- First commit:
- `mvn -B -ntp verify -Dgpg.skip=true -pl nifi-pulsar-processors -am` (the CI command) against a real broker via Testcontainers on rootless podman: 357 unit, **75 integration tests, 73 pass in the full run**. The 2 errors are `java.io.IOException: Broken pipe` from podman's exec endpoint inside `execInContainer` (`pulsar-admin` creating partitioned topics), thrown before any processor runs — the same environment problem noted on #220 and #221, not the tests. Re-run on their own, `NiFiRoundTripIT` and `PublishPulsarRoutingModeIT` both pass, so every integration test has passed against the branch at least once.

### Not done

- No behaviour-change callout for the ordering key itself: with the properties unset the message is byte-for-byte what it was. The one existing case the shared helper changes — *Message Key Field* naming an Avro `bytes` field — is #226, kept in this PR at the reviewer's request and documented as a fix in its own right.
- Release notes: `2.11.0.1` has shipped, so this PR's *New* (#196) and *Fixes* (#226) entries live in a new `docs/release-notes/2.11.0.2.md`; the released `2.11.0.1.md` is untouched. #228 creates the same file for its own entry; whichever lands second I rebase and fold together. Rebased onto `main` after `2.11.0.1` with no code conflicts.
- The nested-`Record` case of the ordering key goes through the same serialisation as the message key's, but has no test of its own.
- Text keys are now read as UTF-8 rather than the platform default charset. On a node whose `file.encoding` is not UTF-8 a non-ASCII text key changes to the correct, node-independent bytes; noted in the release notes.
- The missing-field warning checks the record set's schema. A reader that keeps unknown fields (`dropUnknownFields` off) can still supply a value for a name the schema lacks, in which case the warning is a false alarm; the message says "not a field of the records' schema", which stays true.
- The `Key_Shared` IT runs with batching off so each message is dispatched on its own key; the batched case is *Batch Builder*'s concern (#216) and is documented rather than tested here.
- `PublishPulsarLeaseReuseTest` verifies the processor's call into the lease and was updated to the new arity; that is the only existing test touched.
- The KeyValue `SEPARATED` path is covered by the unit-level plumbing, not by an IT with a KeyValue topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018d1wTGSM2aku8nyMyX7yhG

