### PR TITLE
fix: acknowledge every message individually on every subscription type (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,27 @@ decides whether Pulsar ever delivers it again.
 | The Pulsar client itself failed | rolled back, left unacknowledged | Yes, after *Acknowledgment Timeout* |
 
 Acknowledgement happens only after the FlowFile carrying the message is committed, so a message
-is never acknowledged while its content could still be discarded.
+is never acknowledged while its content could still be discarded. It is also **per message, on every
+subscription type**: each acknowledgement names exactly the messages the committed FlowFile carried,
+and nothing else. The Pulsar client groups the acknowledgements of a batch into one command, so this
+costs no extra round trips.
+
+> **Behaviour change since `2.11.0`:** on an `Exclusive` or `Failover` subscription the processors
+> used to acknowledge a batch **cumulatively**, up to its last message. A cumulative acknowledgement
+> covers everything before that message on the subscription, not only the batch — including a
+> message the same task had just failed to write and negatively acknowledged, which was waiting for
+> redelivery, and a message a concurrent task was still holding. Those were acknowledged by a batch
+> they were not part of and never came back: a write failure followed by continued traffic lost the
+> failed message on a non-Shared subscription, with one task or several. Acknowledgement is now
+> individual on every subscription type; nothing about a flow's configuration needs to change. On the
+> broker the subscription keeps a set of individually acknowledged positions instead of a single
+> mark-delete position until the gaps close, which is bookkeeping rather than traffic.
+
+*Concurrent Tasks* and the subscription type are otherwise independent: every task of one processor
+receives from the **same** consumer — that is what keeps a second task from being refused with
+"Exclusive consumer is already connected" — so several tasks on an `Exclusive` or `Failover`
+subscription share one stream and work as one consumer with more writers. Use `Shared` or
+`Key_Shared` when you want more than one *consumer* on the subscription.
 
 The third row is the one to know about. When the processor cannot write a message into a FlowFile
 — a full content repository, a permissions problem, a disk fault — it rolls the session back and

--- a/docs/release-notes/2.11.0.2.md
+++ b/docs/release-notes/2.11.0.2.md
@@ -50,6 +50,17 @@ the message key exactly as before, so existing flows are byte-for-byte unchanged
 
 ## Fixes
 
+**A message a consumer failed to write could be lost on an `Exclusive` or `Failover` subscription
+(#223).** Those subscription types acknowledged a batch cumulatively, up to its last message, and a
+cumulative acknowledgement covers everything before that message on the subscription — not only the
+batch. Two kinds of message can be "before" it without belonging to it: one this task had just failed
+to write and negatively acknowledged, waiting for redelivery, and one a concurrent task was still
+holding. Either was acknowledged by a batch it was not part of, and when its own redelivery came due
+the broker had nothing to redeliver. The first route needs a single task: a write failure followed by
+continued traffic lost the failed message. Every message is now acknowledged individually on every
+subscription type; the client groups a batch's acknowledgements into one command, so the broker sees
+one round trip either way.
+
 **`PublishPulsarRecord` published an identity hash as the key for an Avro `bytes` field (#226).**
 *Message Key Field* converts the field's value to the message key, and had a branch for the boxed
 `Byte[]` the Record API was expected to produce. NiFi's `AvroTypeUtil` produces an `Object[]` of

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -1037,20 +1037,25 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
      * nor recoverable from Pulsar. The acknowledgement now runs in the commit callback, so a session that
      * is never committed acknowledges nothing and the broker redelivers its messages instead.
      * <p>
-     * Shared and Key_Shared subscriptions do not permit cumulative acknowledgements, so every message is
-     * acknowledged individually; the other subscription types acknowledge cumulatively up to the last
-     * message. In asynchronous mode the acknowledgements are submitted to the acknowledgement service and
-     * collected by {@link #drainAcknowledgments()}, as before. {@code messages} is emptied so the caller
-     * can keep collecting the messages of the next commit in the same list.
+     * Every message is acknowledged individually, on every subscription type. Exclusive and Failover
+     * subscriptions used to acknowledge cumulatively up to the last message of the batch, and a cumulative
+     * acknowledgement covers everything before that message on the subscription - not only this batch. Two
+     * things can be "before" it and not belong to the batch: a message a concurrent task is still holding,
+     * and a message this task received earlier, failed to write and negatively acknowledged, which is waiting
+     * for redelivery. Both were acknowledged along with the batch and never came back (#223). Acknowledging
+     * each message names exactly what was committed. The client groups the acknowledgements into one command
+     * anyway ({@code acknowledgementsGroupTimeMicros}), so a batch costs the broker one round trip either way.
+     * In asynchronous mode the acknowledgements are submitted to the acknowledgement service and collected by
+     * {@link #drainAcknowledgments()}, as before. {@code messages} is emptied so the caller can keep collecting
+     * the messages of the next commit in the same list.
      *
      * @param session  the session holding the FlowFiles the messages were written to
      * @param consumer the consumer the messages were received from
      * @param messages the messages carried by the FlowFiles in the session; cleared on return
-     * @param shared   whether the subscription is Shared or Key_Shared
      * @param async    whether to acknowledge through the asynchronous acknowledgement service
      */
     protected void commitAndAcknowledge(final ProcessSession session, final Consumer<GenericRecord> consumer,
-                                        final List<Message<GenericRecord>> messages, final boolean shared, final boolean async) {
+                                        final List<Message<GenericRecord>> messages, final boolean async) {
         if (messages.isEmpty()) {
             return;
         }
@@ -1058,7 +1063,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         final List<Message<GenericRecord>> committed = new ArrayList<>(messages);
         messages.clear();
 
-        session.commitAsync(() -> acknowledge(consumer, committed, shared, async));
+        session.commitAsync(() -> acknowledge(consumer, committed, async));
     }
 
     /**
@@ -1094,25 +1099,15 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
     }
 
     private void acknowledge(final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,
-                             final boolean shared, final boolean async) {
+                             final boolean async) {
         final ExecutorCompletionService<Object> service = async ? getAckService() : null;
 
         try {
-            if (shared) {
-                for (final Message<GenericRecord> message : messages) {
-                    if (service != null) {
-                        service.submit(() -> consumer.acknowledgeAsync(message).get());
-                    } else {
-                        consumer.acknowledge(message);
-                    }
-                }
-            } else {
-                final Message<GenericRecord> last = messages.get(messages.size() - 1);
-
+            for (final Message<GenericRecord> message : messages) {
                 if (service != null) {
-                    service.submit(() -> consumer.acknowledgeCumulativeAsync(last).get());
+                    service.submit(() -> consumer.acknowledgeAsync(message).get());
                 } else {
-                    consumer.acknowledgeCumulative(last);
+                    consumer.acknowledge(message);
                 }
             }
         } catch (final PulsarClientException e) {
@@ -1212,10 +1207,5 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
 
         return msg.getKey();
     }
-    
-    protected boolean isSharedSubscription(ProcessContext context) {
-    	final String subscriptionType = context.getProperty(SUBSCRIPTION_TYPE).getValue();
-    	
-    	return subscriptionType.equalsIgnoreCase(SHARED.getValue()) || subscriptionType.equalsIgnoreCase(KEY_SHARED.getValue());
-    }
+
 }

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -99,7 +99,6 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     .evaluateAttributeExpressions().getValue().getBytes(StandardCharsets.UTF_8) : null;
 
                 // Cumulative acks are NOT permitted on Shared subscriptions.
-                final boolean shared = isSharedSubscription(context);
                 
                 List<Message<GenericRecord>> messages = done.get();
 
@@ -139,7 +138,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                                 session.transfer(flowFile, REL_SUCCESS);
                             }
 
-                            commitAndAcknowledge(session, consumer, uncommitted, shared, true);
+                            commitAndAcknowledge(session, consumer, uncommitted, true);
 
                             lastAttributes = null;
                         }
@@ -193,10 +192,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                         session.transfer(flowFile, REL_SUCCESS);
                     }
 
-                    // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a
-                    // time otherwise. This has to stay inside the isNotEmpty() guard: on an idle topic the
-                    // list is empty and there is nothing to commit or acknowledge.
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, true);
+                    // Commits, then acknowledges each message. This has to stay inside the isNotEmpty() guard:
+                    // on an idle topic the list is empty and there is nothing to commit or acknowledge.
+                    commitAndAcknowledge(session, consumer, uncommitted, true);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
@@ -216,7 +214,6 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     .evaluateAttributeExpressions().getValue().getBytes(StandardCharsets.UTF_8) : null;
             
             // Cumulative acks are NOT permitted on Shared subscriptions.
-            final boolean shared = isSharedSubscription(context);
 
             FlowFile flowFile = null;
             OutputStream out = null;
@@ -255,7 +252,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             new Object[]{flowFile, msgCount.toString()});
                     }
 
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, false);
+                    commitAndAcknowledge(session, consumer, uncommitted, false);
 
                     lastAttributes = null;
                     lastMsg = null;
@@ -314,9 +311,9 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                    new Object[]{flowFile, msgCount.toString()});
             }
 
-            // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time
-            // otherwise. Nothing is committed or acknowledged when no message was received.
-            commitAndAcknowledge(session, consumer, uncommitted, shared, false);
+            // Commits, then acknowledges each message. Nothing is committed or acknowledged when no message
+            // was received.
+            commitAndAcknowledge(session, consumer, uncommitted, false);
 
         } catch (PulsarClientException e) {
             // Deliberately not negatively acknowledged: this is the client itself failing, so the call that

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -386,7 +386,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         int writtenRecords = 0;
 
         // Cumulative acks are NOT permitted on Shared subscriptions
-        final boolean shared = isSharedSubscription(context);
 
         final boolean useTopicSchema = usesTopicSchema(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
 
@@ -498,7 +497,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                     }
 
                     dropUnroutedFailures(session, parseFailures, demarcator, uncommitted);
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, async);
+                    commitAndAcknowledge(session, consumer, uncommitted, async);
 
                     writtenRecords = 0;
                     lastAttributes = null;
@@ -599,8 +598,8 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
             return;
         }
 
-        // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time otherwise.
-        commitAndAcknowledge(session, consumer, uncommitted, shared, async);
+        // Commits, then acknowledges each message.
+        commitAndAcknowledge(session, consumer, uncommitted, async);
     }
 
     /**

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -102,7 +102,14 @@
 <p>
     A consumed message leaves this processor by exactly one route, and which one it took decides whether
     Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
-    committed, so a message is never acknowledged while its content could still be discarded.
+    committed, so a message is never acknowledged while its content could still be discarded, and it is per
+    message on every subscription type: each acknowledgement names exactly the messages the committed FlowFile
+    carried. A cumulative acknowledgement - which <code>Exclusive</code> and <code>Failover</code> subscriptions
+    used to get - covers everything before the batch on the subscription as well, including a message this or
+    another task had just failed to write and negatively acknowledged, and that message was then never redelivered.
+    Every task of one processor receives from the same consumer, so several tasks on an <code>Exclusive</code> or
+    <code>Failover</code> subscription share one stream; use <code>Shared</code> or <code>Key_Shared</code> for
+    more than one consumer on the subscription.
 </p>
 <table>
     <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -101,7 +101,14 @@
 <p>
     A consumed message leaves this processor by exactly one route, and which one it took decides whether
     Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
-    committed, so a message is never acknowledged while its content could still be discarded.
+    committed, so a message is never acknowledged while its content could still be discarded, and it is per
+    message on every subscription type: each acknowledgement names exactly the messages the committed FlowFile
+    carried. A cumulative acknowledgement - which <code>Exclusive</code> and <code>Failover</code> subscriptions
+    used to get - covers everything before the batch on the subscription as well, including a message this or
+    another task had just failed to write and negatively acknowledged, and that message was then never redelivered.
+    Every task of one processor receives from the same consumer, so several tasks on an <code>Exclusive</code> or
+    <code>Failover</code> subscription share one stream; use <code>Shared</code> or <code>Key_Shared</code> for
+    more than one consumer on the subscription.
 </p>
 <table>
     <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarNonSharedAcknowledgementIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarNonSharedAcknowledgementIT.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Test;
+
+/**
+ * On an Exclusive or Failover subscription the processor used to acknowledge a batch cumulatively, up to its
+ * last message. A cumulative acknowledgement covers everything before that message on the subscription - not
+ * only the batch - and two kinds of message can be "before" it without belonging to the batch (#223):
+ * <ul>
+ *   <li>one this task received earlier, failed to write and negatively acknowledged, which is waiting for
+ *       redelivery - a single task is enough to lose it;</li>
+ *   <li>one a concurrent task is still holding and may yet fail to write.</li>
+ * </ul>
+ * Either way the message was acknowledged by a batch it was not part of, and when its own redelivery came due the
+ * broker had nothing to redeliver. Both sequences are run here on both subscription types; Shared is the control,
+ * since it has always acknowledged per message.
+ */
+public class ConsumePulsarNonSharedAcknowledgementIT extends AbstractPulsarIT {
+
+    private static final String[] NON_SHARED = {"Exclusive", "Failover"};
+
+    /** Well inside the write-failure loops below, and what a message nacked at t=0 has to survive. */
+    private static final long REDELIVERY_DELAY_SECONDS = 5;
+
+    private static final String WRITE_FAILED = "Unable to write the received messages";
+
+    private TestRunner runner(final String subscriptionType, final String topic) throws Exception {
+        final TestRunner runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, subscriptionType);
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "ack-sub");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        // one message per batch, so the batches of the two sequences are exactly the messages named below
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, REDELIVERY_DELAY_SECONDS + " sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "10 sec");
+        return runner;
+    }
+
+    private static String topic(final String name, final String subscriptionType) {
+        return "persistent://public/default/non-shared-ack-" + name + "-" + subscriptionType.toLowerCase() + "-" + System.nanoTime();
+    }
+
+    /**
+     * One task. {@code m1} is received and its write fails, so it is rolled back and negatively acknowledged.
+     * {@code m2} arrives before the redelivery delay elapses and is written, committed and acknowledged. That
+     * acknowledgement must not take {@code m1} with it: {@code m1} has to come back once its delay is up.
+     */
+    @Test
+    public void aNegativelyAcknowledgedMessageSurvivesTheAcknowledgementOfALaterOne() throws Exception {
+        for (final String subscriptionType : NON_SHARED) {
+            final String topic = topic("single-task", subscriptionType);
+            final TestRunner runner = runner(subscriptionType, topic);
+
+            runner.run(1, false, true);
+            publish(topic, "m1");
+            final long nackedAt = failWriteOfNextMessage(runner);
+
+            publish(topic, "m2");
+            await(subscriptionType + ": m2 to be consumed while m1 waits for redelivery", () -> {
+                runner.run(1, false, false);
+                return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
+            });
+            final long m2ConsumedAfterSeconds = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - nackedAt);
+            assertEquals(subscriptionType, List.of("m2"), received(runner));
+            assertTrue(subscriptionType + ": m2 was consumed " + m2ConsumedAfterSeconds + " s after the nack, not inside "
+                    + "the redelivery delay, so the sequence under test did not happen", m2ConsumedAfterSeconds < REDELIVERY_DELAY_SECONDS);
+            runner.clearTransferState();
+
+            // m1's redelivery is due; a cumulative acknowledgement of m2 would have taken it along
+            assertEquals(subscriptionType + ": m1 was negatively acknowledged and must be redelivered",
+                    List.of("m1"), consumeFor(runner, REDELIVERY_DELAY_SECONDS + 15));
+        }
+    }
+
+    /**
+     * Two tasks on one consumer, the interleaving from the issue. Task A receives {@code m1} and is still writing
+     * it when task B receives {@code m2}, writes it, commits and acknowledges. A's write then fails and A negatively
+     * acknowledges {@code m1}. B's acknowledgement must not have covered {@code m1}: it has to come back.
+     */
+    @Test
+    public void aMessageHeldByAConcurrentTaskSurvivesTheOtherTasksAcknowledgement() throws Exception {
+        for (final String subscriptionType : NON_SHARED) {
+            final String topic = topic("two-tasks", subscriptionType);
+            final TestRunner runner = runner(subscriptionType, topic);
+
+            runner.run(1, false, true);
+            publish(topic, "m1", "m2");
+
+            // task A: receives m1 and blocks inside the write until told to fail
+            final CountDownLatch aIsWriting = new CountDownLatch(1);
+            final CountDownLatch bHasAcknowledged = new CountDownLatch(1);
+            final Thread taskA = new Thread(() -> {
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+                while (aIsWriting.getCount() > 0 && System.nanoTime() < deadline) {
+                    ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(),
+                            failingSession(runner, aIsWriting, bHasAcknowledged));
+                }
+            }, "task-A");
+            taskA.start();
+            assertTrue(subscriptionType + ": task A never received m1", aIsWriting.await(30, TimeUnit.SECONDS));
+
+            // task B: receives m2, writes it, commits, acknowledges - while A still holds m1
+            await(subscriptionType + ": task B to consume m2 while task A holds m1", () -> {
+                runner.run(1, false, false);
+                return !runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS).isEmpty();
+            });
+            assertEquals(subscriptionType, List.of("m2"), received(runner));
+            runner.clearTransferState();
+
+            // now A's write fails: m1 is rolled back and negatively acknowledged
+            bHasAcknowledged.countDown();
+            taskA.join(TimeUnit.SECONDS.toMillis(30));
+            assertTrue(subscriptionType + ": task A did not fail its write", writeFailuresLogged(runner) > 0);
+
+            assertEquals(subscriptionType + ": m1, held by task A when task B acknowledged m2, must be redelivered",
+                    List.of("m1"), consumeFor(runner, REDELIVERY_DELAY_SECONDS + 15));
+        }
+    }
+
+    /** Healthy passes for the given time, collecting what arrives; a message the broker still holds shows up here. */
+    private static List<String> consumeFor(final TestRunner runner, final long seconds) throws Exception {
+        final List<String> all = new ArrayList<>();
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
+        while (System.nanoTime() < deadline) {
+            runner.run(1, false, false);
+            all.addAll(received(runner));
+            runner.clearTransferState();
+            Thread.sleep(200);
+        }
+        return all;
+    }
+
+    private static List<String> received(final TestRunner runner) {
+        final List<String> payloads = new ArrayList<>();
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS)) {
+            for (final String line : new String(flowFile.toByteArray(), UTF_8).split("\n")) {
+                if (!line.isEmpty()) {
+                    payloads.add(line);
+                }
+            }
+        }
+        return payloads;
+    }
+
+    /** Triggers with a session that cannot be written until a message has been received and refused. */
+    private static long failWriteOfNextMessage(final TestRunner runner) throws InterruptedException {
+        final long failuresBefore = writeFailuresLogged(runner);
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (System.nanoTime() < deadline) {
+            ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession(runner, null, null));
+            if (writeFailuresLogged(runner) > failuresBefore) {
+                return System.nanoTime();
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("the message never reached the pass whose write fails");
+    }
+
+    private static long writeFailuresLogged(final TestRunner runner) {
+        return runner.getLogger().getErrorMessages().stream().filter(m -> m.getMsg().contains(WRITE_FAILED)).count();
+    }
+
+    /**
+     * A session whose FlowFile content cannot be written. With latches, the write first announces that it has
+     * started and then waits to be told to fail, so another task can be run in between.
+     */
+    private static MockProcessSession failingSession(final TestRunner runner, final CountDownLatch writing,
+                                                     final CountDownLatch failWhen) {
+        final Processor processor = runner.getProcessor();
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        if (writing != null) {
+                            writing.countDown();
+                            try {
+                                if (!failWhen.await(60, TimeUnit.SECONDS)) {
+                                    throw new IOException("the other task never acknowledged");
+                                }
+                            } catch (final InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                        throw new IOException("Intentional Integration Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
@@ -79,12 +79,10 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
 
     private final boolean async;
     private final String subscriptionType;
-    private final boolean shared;
 
     public ConsumePulsarAcknowledgementTest(final boolean async, final String subscriptionType) {
         this.async = async;
         this.subscriptionType = subscriptionType;
-        this.shared = isSharedSubType(subscriptionType);
     }
 
     @Before
@@ -112,8 +110,7 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
         runner.run(1, true);
 
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
-        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+        assertEquals("one acknowledgement per message, whatever the subscription type (#223)", 3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }
@@ -205,13 +202,12 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
     private void verifyAcknowledged(final int messages) throws PulsarClientException {
         final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
 
-        if (shared) {
-            verify(consumer, times(async ? 0 : messages)).acknowledge(any(Message.class));
-            verify(consumer, times(async ? messages : 0)).acknowledgeAsync(any(Message.class));
-        } else {
-            verify(consumer, times(async ? 0 : 1)).acknowledgeCumulative(any(Message.class));
-            verify(consumer, times(async ? 1 : 0)).acknowledgeCumulativeAsync(any(Message.class));
-        }
+        // per message on every subscription type: a cumulative acknowledgement would also take whatever sits
+        // before the batch on the subscription - another task's messages, or this task's nacked ones (#223)
+        verify(consumer, times(async ? 0 : messages)).acknowledge(any(Message.class));
+        verify(consumer, times(async ? messages : 0)).acknowledgeAsync(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
     }
 
     private void verifyNothingAcknowledged() throws PulsarClientException {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
@@ -84,12 +84,10 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
 
     private final boolean async;
     private final String subscriptionType;
-    private final boolean shared;
 
     public ConsumePulsarRecordAcknowledgementTest(final boolean async, final String subscriptionType) {
         this.async = async;
         this.subscriptionType = subscriptionType;
-        this.shared = isSharedSubType(subscriptionType);
     }
 
     @Before
@@ -121,8 +119,7 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
         runner.run(1, true);
 
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 1);
-        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+        assertEquals("one acknowledgement per message, whatever the subscription type (#223)", 3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }
@@ -144,7 +141,7 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
         runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
         runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
         assertEquals("every unparseable message is acknowledged once its parse_failure FlowFile is committed",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+                3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -32,7 +32,9 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -181,24 +183,24 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         
         flowFiles.get(0).assertContentEquals(sb.toString());
 
-        boolean shared = isSharedSubType(subType);
-        
-        // Verify that every message was acknowledged
+        // Verify that every message was acknowledged, one by one, whatever the subscription type (#223)
         verify(mockClientService.getMockConsumer(), times(batchSize)).receive(0, TimeUnit.SECONDS);
-        
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledge(mockMessage);
-        	}
+        verifyAcknowledgedIndividually(batchSize, async);
+    }
+
+    /**
+     * Acknowledgement is per message on every subscription type: a cumulative acknowledgement would take along
+     * whatever else sits before the batch on the subscription - a concurrent task's messages, or this task's own
+     * negatively acknowledged ones waiting for redelivery (#223).
+     */
+    protected void verifyAcknowledgedIndividually(final int messages, final boolean async) throws PulsarClientException {
+        if (async) {
+            verify(mockClientService.getMockConsumer(), times(messages)).acknowledgeAsync(mockMessage);
         } else {
-        	if (async) {
-                verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);        		
-        	} else {
-                verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);        		
-        	}
+            verify(mockClientService.getMockConsumer(), times(messages)).acknowledge(mockMessage);
         }
+        verify(mockClientService.getMockConsumer(), never()).acknowledgeCumulative(any(Message.class));
+        verify(mockClientService.getMockConsumer(), never()).acknowledgeCumulativeAsync(any(Message.class));
     }
 
     protected void sendMessages(String msg, String topic, String sub, boolean async, int iterations) throws PulsarClientException {
@@ -228,22 +230,8 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
 
         verify(mockClientService.getMockConsumer(), times(iterations)).receive(0, TimeUnit.SECONDS);
 
-        boolean shared = isSharedSubType(subType);
-        
-        // Verify that every message was acknowledged
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify (mockClientService.getMockConsumer(), times(iterations)).acknowledge(mockMessage);
-        	}
-        } else {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulativeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulative(mockMessage);
-        	}
-        }        
+        // Verify that every message was acknowledged, one by one, whatever the subscription type (#223)
+        verifyAcknowledgedIndividually(iterations, async);
     }
 
     protected void doMappedAttributesTest() throws PulsarClientException {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -20,7 +20,9 @@ import static org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord.RECOR
 import static org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord.RECORD_WRITER;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -170,23 +172,15 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
 
         verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).receive(0, TimeUnit.SECONDS);
 
-        boolean shared = isSharedSubType(subType);
-        
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledge(mockMessage);
-        	}
+        // every message acknowledged one by one, whatever the subscription type (#223)
+        if (async) {
+            verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledgeAsync(mockMessage);
+        } else {
+            verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledge(mockMessage);
         }
-        else {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulativeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulative(mockMessage);
-        	}
-        }
-        
+        verify(mockClientService.getMockConsumer(), never()).acknowledgeCumulative(any(Message.class));
+        verify(mockClientService.getMockConsumer(), never()).acknowledgeCumulativeAsync(any(Message.class));
+
         return flowFiles;
     }
 

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
@@ -47,7 +47,7 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), times(0)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(0)).acknowledgeAsync(mockMessage);
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -55,7 +55,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeAsync(mockMessage);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeAsync(mockMessage);
     }
 
     /*

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
@@ -49,7 +49,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledge(mockMessage);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledge(mockMessage);
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
@@ -45,7 +45,7 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledge(mockMessage);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledge(mockMessage);
     }
 
     /*


### PR DESCRIPTION
Closes #223.

On an `Exclusive` or `Failover` subscription the consumers acknowledged a batch **cumulatively**, up to its last message. A cumulative acknowledgement covers everything before that message on the subscription, not only the batch. Two kinds of message can be "before" it without belonging to it:

- one **this task** received earlier, failed to write and negatively acknowledged, which is waiting for redelivery — so a single task suffices, as measured on the issue;
- one a **concurrent task** is still holding and may yet fail to write — the interleaving the issue describes.

Either was acknowledged by a batch it was not part of, and when its own redelivery came due the broker had nothing to redeliver. The message was neither in NiFi nor recoverable from Pulsar. The single-task route is reachable by any flow on a non-Shared subscription whose write fails once while traffic continues; with a plain rollback (2.10.0) instead of the nack the same acknowledgement took the rolled-back message along, so this predates #216.

### What changed

- **`AbstractPulsarConsumerProcessor`** — `acknowledge()` acknowledges each message individually on every subscription type; the `shared` branch and parameter are gone from it and from `commitAndAcknowledge`, and `isSharedSubscription()` with them (it had no other caller). The order — commit first, acknowledge in the commit callback — is unchanged. The Pulsar client groups the acknowledgements of a batch into one command (`acknowledgementsGroupTimeMicros` 100 ms, `maxAcknowledgmentGroupSize` 1000, both visible in the consumer configuration the bundle builds), so the broker sees one round trip per batch either way; what changes on the broker is bookkeeping — a set of individually acknowledged positions until the gaps close, instead of one mark-delete position.
- **`ConsumePulsar` / `ConsumePulsarRecord`** — call the new signature; no other change.
- **Docs** — README's *Failure handling and redelivery* section states per-message acknowledgement, with a *Behaviour change since `2.11.0`* callout, and adds a paragraph connecting *Concurrent Tasks* to the subscription type (every task of one processor receives from the same consumer, so several tasks on `Exclusive`/`Failover` are one consumer with more writers; `Shared`/`Key_Shared` are how to get more than one consumer). Both consumers' `additionalDetails.html` say the same.

### Tests

**`ConsumePulsarNonSharedAcknowledgementIT`** (new, real broker, `Exclusive` and `Failover`, one message per batch, redelivery delay 5 s, ack timeout 10 s):

- *a negatively acknowledged message survives the acknowledgement of a later one* — one task: `m1` received, write fails, nacked; `m2` published, consumed and acknowledged inside the delay (asserted); `m1` must then be redelivered.
- *a message held by a concurrent task survives the other task's acknowledgement* — two tasks on one processor: task A receives `m1` and blocks inside the write (latch); task B receives `m2`, commits and acknowledges; A's write then fails and nacks `m1`; `m1` must be redelivered.

Existing unit tests that asserted `acknowledgeCumulative` / `acknowledgeCumulativeAsync` on non-Shared subscriptions (`TestConsumePulsar`, `TestConsumePulsarRecord`, the sync/async variants, `ConsumePulsarAcknowledgementTest`, `ConsumePulsarRecordAcknowledgementTest`) now assert one acknowledgement per message and `never()` a cumulative one. `ConsumePulsarAcknowledgementTest`'s "acknowledged only after commit" check now records three acknowledgements on every subscription type instead of one-or-three.

### Fails first

The IT against `main` (`00a6eb8`), `apachepulsar/pulsar:4.2.4`:

```
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 56.81 s -- in ConsumePulsarNonSharedAcknowledgementIT
  aNegativelyAcknowledgedMessageSurvivesTheAcknowledgementOfALaterOne:
    Exclusive: m1 was negatively acknowledged and must be redelivered expected:<[m1]> but was:<[]>
  aMessageHeldByAConcurrentTaskSurvivesTheOtherTasksAcknowledgement:
    Exclusive: m1, held by task A when task B acknowledged m2, must be redelivered expected:<[m1]> but was:<[]>
```

(Each test loops `Exclusive` then `Failover` and stops at the first failure; the probe on the issue shows `Failover` losing the message the same way, and `Shared` recovering it.)

With the fix:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 98.20 s -- in ConsumePulsarNonSharedAcknowledgementIT
```

### Verification

- `mvn test`: **349/349**.
- `Consume*IT` + `NiFi*IT` against a real broker (rootless podman): **30 tests, 28 pass**. The 2 errors are `java.io.IOException: Broken pipe` from podman's exec endpoint inside `execInContainer` — `ConsumePulsarRecordIT.aPartitionedTopicIsReadAsOneLogicalTopic` and `NiFiRoundTripIT.bytesSurviveTheRoundTrip`, both thrown from `ExecCreateCmd` (`pulsar-admin` creating a partitioned topic / checking a schema) before any processor runs — the environment problem noted on #220–#222, reproducible here today on every attempt. `ConsumePulsarRestartIT` (6), `ConsumePulsarDeadLetterIT` (2), `ConsumePulsarTopicSchemaIT` (6), `NiFiSchemaRoundTripIT` (4) all pass, so the acknowledgement change is exercised end to end.

### Not done

- ~~No release note in this PR~~ — rebased onto `main` after `2.11.0.1` shipped and #222/#228/#217 landed; the entry is in `docs/release-notes/2.11.0.2.md` under *Fixes* (second commit). The rebase applied cleanly; `ConsumePulsarNonSharedAcknowledgementIT` 2/2 and `ConsumePulsarDeadLetterIT` 2/2 re-run against a real broker on the rebased tree, 426/426 unit.
- The third option on the issue — rejecting *Concurrent Tasks* > 1 on a non-Shared subscription — is not taken: the single-task sequence shows it would not have closed the loss, and the docs now explain what several tasks on one consumer mean instead.
- The IT runs the two sequences with *Consumer Batch Size* 1 so the batches are exactly the named messages; a batch spanning both a nacked and a fresh message is the same acknowledgement path.
- The IT takes ~100 s: each sequence waits out the redelivery delay plus a margin, twice per subscription type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FxYKxcaKpvRbJSYP3QYZ9
