### PR TITLE
fix: stop truncating the consumer time properties to whole seconds (#225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,26 @@ on a `Key_Shared` subscription**: a consumer receives a whole batch at a time, s
 several keys hands one consumer messages belonging to another consumer's key range. It has no
 effect when batching is off.
 
+## Consumer time properties
+
+Two consumer properties are handed to the Pulsar client in units coarser than NiFi lets you type
+them in, and behave accordingly.
+
+*Auto Update Partition Interval* is kept by the client in **whole seconds**, and the client refuses
+zero. A value under one second is therefore rejected at validation — before this rule it validated
+and then failed on every trigger with the client's `interval needs to be > 0`, about an interval
+nobody typed. A value of a second or more with a fraction (`90500 millis`) runs, on the whole
+seconds the client keeps (`90`), and the processor logs a warning saying so when it starts.
+
+*Expire Time of Incomplete Chunked Message* is kept by the client in milliseconds and is applied
+exactly as configured.
+
+> **Behaviour change since `2.11.0`:** *Expire Time of Incomplete Chunked Message* used to be
+> converted to whole seconds on the way to the client, so a fraction was dropped and a sub-second
+> value became `0` — which the client reads as **never expire**: incomplete chunks were kept until
+> the pending-chunk queue evicted them. A flow that set `500 millis` now expires them after 500 ms,
+> and `1500 millis` means 1.5 s rather than 1 s. Whole-second values are unchanged.
+
 ## Consuming from topics that have a schema
 
 `ConsumePulsarRecord`'s **Message Schema Strategy** decides how a message becomes records.

--- a/README.md
+++ b/README.md
@@ -231,23 +231,32 @@ effect when batching is off.
 
 ## Consumer time properties
 
-Two consumer properties are handed to the Pulsar client in units coarser than NiFi lets you type
-them in, and behave accordingly.
+NiFi time-period values always carry a unit (`500 millis`, `90 sec`, `1 min`), so the only question
+for a property the Pulsar client stores in a coarser unit is whether the duration you typed is
+representable in the granularity the client keeps. Where it is not, the value is **rejected at
+validation** rather than silently applied as something else.
 
-*Auto Update Partition Interval* is kept by the client in **whole seconds**, and the client refuses
-zero. A value under one second is therefore rejected at validation — before this rule it validated
-and then failed on every trigger with the client's `interval needs to be > 0`, about an interval
-nobody typed. A value of a second or more with a fraction (`90500 millis`) runs, on the whole
-seconds the client keeps (`90`), and the processor logs a warning saying so when it starts.
+*Auto Update Partition Interval* is kept by the client as a whole number of **seconds**, in an `int`,
+and the client refuses zero. The value must therefore be a whole number of seconds between `1 sec`
+and `2147483647 sec`: `500 millis` would reach the client as `0` and be refused on every trigger,
+`90500 millis` would run as `90 sec` while the configuration says otherwise, and anything past the
+`int` range wrapped around — `30000 days` became a negative interval and failed, `10000 weeks` ran
+silently as about 55 years instead of 191. *Topics Pattern Discovery Interval* follows the same rule
+for the same reason.
 
-*Expire Time of Incomplete Chunked Message* is kept by the client in milliseconds and is applied
-exactly as configured.
+*Expire Time of Incomplete Chunked Message* is kept by the client as a whole number of
+**milliseconds**, so any whole-millisecond value is applied exactly as configured; a fraction of a
+millisecond is rejected. `0` is a deliberate value: it disables the expiry, and incomplete chunks are
+then kept until the pending-chunk queue evicts them.
 
-> **Behaviour change since `2.11.0`:** *Expire Time of Incomplete Chunked Message* used to be
-> converted to whole seconds on the way to the client, so a fraction was dropped and a sub-second
-> value became `0` — which the client reads as **never expire**: incomplete chunks were kept until
-> the pending-chunk queue evicted them. A flow that set `500 millis` now expires them after 500 ms,
-> and `1500 millis` means 1.5 s rather than 1 s. Whole-second values are unchanged.
+> **Behaviour change since `2.1.0`:** every release so far converted *Expire Time of Incomplete
+> Chunked Message* to whole seconds on the way to the client, so a fraction of a second was dropped
+> and a sub-second value became `0` — which the client reads as **never expire**. A flow that set
+> `500 millis` had no chunk expiry at all; it now expires incomplete chunks after 500 ms, and
+> `1500 millis` means 1.5 s rather than 1 s. Whole-second values are unchanged. On *Auto Update
+> Partition Interval*, a value that is not a whole number of seconds in the `int` range is now
+> invalid; a sub-second value was already failing every trigger, so the only flows this stops are
+> ones that ran on a different interval from the one configured.
 
 ## Consuming from topics that have a schema
 

--- a/docs/release-notes/2.11.0.2.md
+++ b/docs/release-notes/2.11.0.2.md
@@ -12,15 +12,21 @@ first: a fraction was dropped, and a sub-second value became `0`, which the clie
 expire** — incomplete chunks were kept until the pending-chunk queue evicted them. A flow that set
 `500 millis` now expires them after 500 ms, and `1500 millis` means 1.5 s rather than 1 s.
 
-*Auto Update Partition Interval* is kept by the client in whole seconds, and the client refuses
-zero, so a value under one second is now **rejected at validation**. This fails nothing that ran:
-such a value validated before and then failed the consumer creation on every trigger with the
-client's `interval needs to be > 0`. A value of a second or more with a fraction still runs, on the
-whole seconds the client keeps, and the processor logs the applied value when it starts.
+*Auto Update Partition Interval* is kept by the client as a whole number of seconds in an `int`,
+and the client refuses zero, so the value must now be a whole number of seconds between 1 and
+2147483647 — anything else is **rejected at validation**, the rule *Topics Pattern Discovery
+Interval* already follows. A sub-second value was already failing the consumer creation on every
+trigger with the client's `interval needs to be > 0`; a fractional value such as `90500 millis` ran
+as 90 s while the configuration said otherwise; a value past the `int` range wrapped around, to a
+negative interval the client refused or to a positive one far shorter than asked. A fraction of a
+millisecond in *Expire Time of Incomplete Chunked Message* is rejected for the same reason, and
+`0` there is the documented "never expire".
 
 ## Upgrading
 
 Drop in the new NARs; NiFi stays on 2.11.0. A consumer whose *Auto Update Partition Interval* is
-under one second must be given a whole second or more before it validates again — it was not running
-as configured. A consumer that set a sub-second *Expire Time of Incomplete Chunked Message* will
-start expiring incomplete chunks at that time instead of keeping them.
+not a whole number of seconds between 1 and 2147483647 goes invalid on the canvas with a message
+that says so, and must be given one before it validates again — a sub-second value was not running
+at all, and a fractional one was not running as configured. A consumer that set a sub-second
+*Expire Time of Incomplete Chunked Message* will start expiring incomplete chunks at that time
+instead of keeping them.

--- a/docs/release-notes/2.11.0.2.md
+++ b/docs/release-notes/2.11.0.2.md
@@ -1,0 +1,26 @@
+# 2.11.0.2
+
+Connector revision for **NiFi 2.11.0** against the **Pulsar 4.2.4** client. Java 21. Unreleased —
+these are the notes for the next tag on the `2.11.0` line.
+
+## Behaviour changes
+
+**Two consumer time properties no longer lose their fraction of a second in silence (#225).**
+*Expire Time of Incomplete Chunked Message* is now handed to the client in milliseconds, the unit
+the client keeps, so it is applied exactly as configured. It used to be converted to whole seconds
+first: a fraction was dropped, and a sub-second value became `0`, which the client reads as **never
+expire** — incomplete chunks were kept until the pending-chunk queue evicted them. A flow that set
+`500 millis` now expires them after 500 ms, and `1500 millis` means 1.5 s rather than 1 s.
+
+*Auto Update Partition Interval* is kept by the client in whole seconds, and the client refuses
+zero, so a value under one second is now **rejected at validation**. This fails nothing that ran:
+such a value validated before and then failed the consumer creation on every trigger with the
+client's `interval needs to be > 0`. A value of a second or more with a fraction still runs, on the
+whole seconds the client keeps, and the processor logs the applied value when it starts.
+
+## Upgrading
+
+Drop in the new NARs; NiFi stays on 2.11.0. A consumer whose *Auto Update Partition Interval* is
+under one second must be given a whole second or more before it validates again — it was not running
+as configured. A consumer that set a sub-second *Expire Time of Incomplete Chunked Message* will
+start expiring incomplete chunks at that time instead of keeping them.

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -163,9 +163,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .name("AUTO_UPDATE_PARTITION_INTERVAL")
             .displayName("Auto Update Partition Interval")
             .description("Set the interval of updating partitions (default: 1 minute). This only works if " +
-                    "autoUpdatePartitions is enabled. The Pulsar client keeps this interval in whole seconds: " +
-                    "the shortest interval it accepts is one second, and a fraction of a second is dropped - " +
-                    "the processor logs the value actually applied when it starts.")
+                    "autoUpdatePartitions is enabled. The Pulsar client keeps this interval as a whole number of " +
+                    "seconds, so the value must be a whole number of seconds between 1 second and 2147483647 seconds; " +
+                    "anything else is rejected at validation rather than silently applied as something different.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("1 min")
             .required(false)
@@ -250,7 +250,8 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .displayName("Expire Time of Incomplete Chunked Message")
             .description("If producer fails to publish all the chunks of a message then consumer can expire incomplete" +
                     " chunks if consumer won't be able to receive all chunks in expire times (default 1 minute). " +
-                    "Applied with millisecond precision.")
+                    "The Pulsar client keeps this as a whole number of milliseconds, so the value must be one; " +
+                    "0 disables the expiry, and incomplete chunks are then kept until the pending-chunk queue evicts them.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("60 sec")
             .required(false)
@@ -465,17 +466,36 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                "Acknowledgment Timeout needs to be greater than 10 seconds.").build());
         }
 
-        // The client stores the partition update interval in whole seconds and refuses zero
-        // ("interval needs to be > 0"), so a value under a second reached it as 0 and the consumer could not
-        // be created: every trigger failed with a message about an interval the user never typed (#225).
-        // Rejecting it here fails nothing that runs today.
+        // Two time properties are handed to the client in a coarser unit than NiFi lets the user type, and
+        // the rule for each is the same: the value must be representable in the granularity the client
+        // stores it in, or it is rejected - never silently applied as something else (#225).
+        //
+        // The partition update interval is an int of whole seconds on the client, which also refuses zero
+        // ("interval needs to be > 0"). So a value under a second reached it as 0 and the consumer could
+        // not be created; a fraction of a second was dropped; and a value past Integer.MAX_VALUE seconds
+        // wrapped in intValue() - negative, and refused, or positive and silently far shorter than asked.
         final long partitionUpdateIntervalMillis = validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL)
                 .asTimePeriod(TimeUnit.MILLISECONDS);
-        if (partitionUpdateIntervalMillis < TimeUnit.SECONDS.toMillis(1)) {
+        if (partitionUpdateIntervalMillis < TimeUnit.SECONDS.toMillis(1)
+                || partitionUpdateIntervalMillis % TimeUnit.SECONDS.toMillis(1) != 0
+                || TimeUnit.MILLISECONDS.toSeconds(partitionUpdateIntervalMillis) > Integer.MAX_VALUE) {
             results.add(new ValidationResult.Builder().valid(false).subject(AUTO_UPDATE_PARTITION_INTERVAL.getDisplayName())
-                .explanation("the Pulsar client keeps this interval in whole seconds and accepts nothing under one second; "
-                    + validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).getValue()
-                    + " would reach it as 0 and the consumer could not be created")
+                .explanation("the Pulsar client keeps this interval as a whole number of seconds between 1 and "
+                    + Integer.MAX_VALUE + "; " + validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).getValue()
+                    + " is not one, and would be applied as a different interval or refused by the client")
+                .build());
+        }
+
+        // The chunk expiry is a long of whole milliseconds on the client, and 0 means "never expire". A value
+        // between 0 and 1 ms would truncate to that 0 and disable the expiry for someone who asked for the
+        // shortest one; a fraction of a millisecond would be dropped.
+        final long expireTimeNanos = validationContext.getProperty(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE)
+                .asTimePeriod(TimeUnit.NANOSECONDS);
+        if (expireTimeNanos % TimeUnit.MILLISECONDS.toNanos(1) != 0) {
+            results.add(new ValidationResult.Builder().valid(false).subject(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE.getDisplayName())
+                .explanation("the Pulsar client keeps this as a whole number of milliseconds; "
+                    + validationContext.getProperty(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE).getValue()
+                    + " is not one (0 disables the expiry)")
                 .build());
         }
 
@@ -510,7 +530,6 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // Exclusive subscription with "Exclusive consumer is already connected". The cache is built
         // lazily below and disposed in cleanUp().
         this.consumerCacheSize = context.getProperty(CONSUMER_CACHE_SIZE).asInteger();
-        warnIfPartitionUpdateIntervalLosesAFraction(context);
 
         if (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean()) {
             setConsumerPool(Executors.newFixedThreadPool(context.getProperty(MAX_ASYNC_REQUESTS).asInteger()));
@@ -537,21 +556,6 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "no negative acknowledgement at all. Lower the delay unless the longer wait is intended.",
                     NEGATIVE_ACK_REDELIVERY_DELAY.getDisplayName(), context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY).getValue(),
                     ACK_TIMEOUT.getDisplayName(), context.getProperty(ACK_TIMEOUT).getValue());
-        }
-    }
-
-    /**
-     * The client keeps Auto Update Partition Interval in whole seconds, so a fraction of a second in the configured
-     * value is not applied. A value under a second is rejected by {@link #customValidate}; one of a second or more
-     * with a fraction runs, only coarser than asked, and this says so once per start rather than never (#225).
-     */
-    private void warnIfPartitionUpdateIntervalLosesAFraction(final ProcessContext context) {
-        final long configuredMillis = context.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).asTimePeriod(TimeUnit.MILLISECONDS);
-        if (configuredMillis % TimeUnit.SECONDS.toMillis(1) != 0) {
-            getLogger().warn("{} is set to {}, which the Pulsar client applies as {} seconds: it keeps this interval in "
-                    + "whole seconds, so the fraction of a second is dropped",
-                    AUTO_UPDATE_PARTITION_INTERVAL.getDisplayName(), context.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).getValue(),
-                    TimeUnit.MILLISECONDS.toSeconds(configuredMillis));
         }
     }
 

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -474,6 +474,13 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // ("interval needs to be > 0"). So a value under a second reached it as 0 and the consumer could
         // not be created; a fraction of a second was dropped; and a value past Integer.MAX_VALUE seconds
         // wrapped in intValue() - negative, and refused, or positive and silently far shorter than asked.
+        //
+        // Unconditional on purpose, whatever Auto Update Partitions says: the client's precondition runs
+        // when the consumer is BUILT, for every consumer, while the value is only read at runtime under
+        // that flag. TIME_PERIOD_VALIDATOR already guarantees a non-negative duration, so the int overflow
+        // is the only way the builder can be handed a negative interval - which makes the upper bound a
+        // correctness requirement, not a sanity limit. The floor stays at one second, not zero, because
+        // that is what this setter enforces; the sibling Topics Pattern Discovery Interval accepts zero.
         final long partitionUpdateIntervalMillis = validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL)
                 .asTimePeriod(TimeUnit.MILLISECONDS);
         if (partitionUpdateIntervalMillis < TimeUnit.SECONDS.toMillis(1)

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -163,7 +163,9 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .name("AUTO_UPDATE_PARTITION_INTERVAL")
             .displayName("Auto Update Partition Interval")
             .description("Set the interval of updating partitions (default: 1 minute). This only works if " +
-                    "autoUpdatePartitions is enabled.")
+                    "autoUpdatePartitions is enabled. The Pulsar client keeps this interval in whole seconds: " +
+                    "the shortest interval it accepts is one second, and a fraction of a second is dropped - " +
+                    "the processor logs the value actually applied when it starts.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("1 min")
             .required(false)
@@ -247,7 +249,8 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
             .name("EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE")
             .displayName("Expire Time of Incomplete Chunked Message")
             .description("If producer fails to publish all the chunks of a message then consumer can expire incomplete" +
-                    " chunks if consumer won't be able to receive all chunks in expire times (default 1 minute).")
+                    " chunks if consumer won't be able to receive all chunks in expire times (default 1 minute). " +
+                    "Applied with millisecond precision.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("60 sec")
             .required(false)
@@ -462,6 +465,20 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                "Acknowledgment Timeout needs to be greater than 10 seconds.").build());
         }
 
+        // The client stores the partition update interval in whole seconds and refuses zero
+        // ("interval needs to be > 0"), so a value under a second reached it as 0 and the consumer could not
+        // be created: every trigger failed with a message about an interval the user never typed (#225).
+        // Rejecting it here fails nothing that runs today.
+        final long partitionUpdateIntervalMillis = validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL)
+                .asTimePeriod(TimeUnit.MILLISECONDS);
+        if (partitionUpdateIntervalMillis < TimeUnit.SECONDS.toMillis(1)) {
+            results.add(new ValidationResult.Builder().valid(false).subject(AUTO_UPDATE_PARTITION_INTERVAL.getDisplayName())
+                .explanation("the Pulsar client keeps this interval in whole seconds and accepts nothing under one second; "
+                    + validationContext.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).getValue()
+                    + " would reach it as 0 and the consumer could not be created")
+                .build());
+        }
+
         final boolean deadLetterEnabled = validationContext.getProperty(MAX_REDELIVER_COUNT).isSet();
         final String subscriptionType = validationContext.getProperty(SUBSCRIPTION_TYPE).getValue();
 
@@ -493,6 +510,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         // Exclusive subscription with "Exclusive consumer is already connected". The cache is built
         // lazily below and disposed in cleanUp().
         this.consumerCacheSize = context.getProperty(CONSUMER_CACHE_SIZE).asInteger();
+        warnIfPartitionUpdateIntervalLosesAFraction(context);
 
         if (context.getProperty(ASYNC_ENABLED).isSet() && context.getProperty(ASYNC_ENABLED).asBoolean()) {
             setConsumerPool(Executors.newFixedThreadPool(context.getProperty(MAX_ASYNC_REQUESTS).asInteger()));
@@ -519,6 +537,21 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                     + "no negative acknowledgement at all. Lower the delay unless the longer wait is intended.",
                     NEGATIVE_ACK_REDELIVERY_DELAY.getDisplayName(), context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY).getValue(),
                     ACK_TIMEOUT.getDisplayName(), context.getProperty(ACK_TIMEOUT).getValue());
+        }
+    }
+
+    /**
+     * The client keeps Auto Update Partition Interval in whole seconds, so a fraction of a second in the configured
+     * value is not applied. A value under a second is rejected by {@link #customValidate}; one of a second or more
+     * with a fraction runs, only coarser than asked, and this says so once per start rather than never (#225).
+     */
+    private void warnIfPartitionUpdateIntervalLosesAFraction(final ProcessContext context) {
+        final long configuredMillis = context.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).asTimePeriod(TimeUnit.MILLISECONDS);
+        if (configuredMillis % TimeUnit.SECONDS.toMillis(1) != 0) {
+            getLogger().warn("{} is set to {}, which the Pulsar client applies as {} seconds: it keeps this interval in "
+                    + "whole seconds, so the fraction of a second is dropped",
+                    AUTO_UPDATE_PARTITION_INTERVAL.getDisplayName(), context.getProperty(AUTO_UPDATE_PARTITION_INTERVAL).getValue(),
+                    TimeUnit.MILLISECONDS.toSeconds(configuredMillis));
         }
     }
 
@@ -668,8 +701,11 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
                 .negativeAckRedeliveryDelay(context.getProperty(NEGATIVE_ACK_REDELIVERY_DELAY)
                         .asTimePeriod(TimeUnit.MICROSECONDS), TimeUnit.MICROSECONDS)
                 .autoAckOldestChunkedMessageOnQueueFull(context.getProperty(AUTO_ACK_OLDEST_CHUNKED_ON_QUEUE_FULL).asBoolean())
+                // The client stores this in milliseconds, so hand it over in milliseconds: converting to whole
+                // seconds here dropped any fraction, and turned a sub-second value into 0, which disables the
+                // expiry altogether (#225).
                 .expireTimeOfIncompleteChunkedMessage(context.getProperty(EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE)
-                        .asTimePeriod(TimeUnit.SECONDS), TimeUnit.SECONDS)
+                        .asTimePeriod(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
                 .maxPendingChunkedMessage(context.getProperty(MAX_PENDING_CHUNKED_MESSAGE).asInteger())
                 .priorityLevel(context.getProperty(PRIORITY_LEVEL).asInteger())
                 .receiverQueueSize(context.getProperty(RECEIVER_QUEUE_SIZE).asInteger())

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarTimePropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarTimePropertiesTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.pulsar.StandardPulsarClientService;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.LogMessage;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.ConsumerBuilderImpl;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Two consumer time properties reach the Pulsar client through a unit conversion, and what the client ends up
+ * configured with is not always what was typed (#225). These tests build the consumer configuration through a
+ * real {@code PulsarClient} - one that never connects; the client is lazy about that - and assert against the
+ * {@link ConsumerConfigurationData} the builder holds, which is the value the consumer would run with.
+ * <p>
+ * <i>Expire Time of Incomplete Chunked Message</i> is stored by the client in milliseconds, so every value can
+ * be honoured exactly. <i>Auto Update Partition Interval</i> is stored in whole seconds and the client refuses
+ * zero, so a value under a second cannot be applied at all and a fraction of a second above that is dropped;
+ * the first is rejected at validation and the second is warned about when the processor is scheduled.
+ */
+public class ConsumePulsarTimePropertiesTest {
+
+    private TestRunner runner;
+    private StandardPulsarClientService clientService;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        // A real client against a broker that does not exist: building it opens no connection, and nothing
+        // here subscribes, so the configuration can be read without a broker.
+        clientService = new StandardPulsarClientService();
+        runner.addControllerService("pulsar-client", clientService);
+        runner.setProperty(clientService, StandardPulsarClientService.PULSAR_SERVICE_URL, "pulsar://localhost:1");
+        runner.enableControllerService(clientService);
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, "persistent://public/default/time-properties");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+    }
+
+    @After
+    public void closeClient() {
+        runner.disableControllerService(clientService);
+    }
+
+    /** The configuration the consumer would be created with, read from the builder the processor prepares. */
+    @SuppressWarnings("unchecked")
+    private ConsumerConfigurationData<GenericRecord> consumerConfiguration() throws PulsarClientException {
+        final AbstractPulsarConsumerProcessor<GenericRecord> processor =
+                (AbstractPulsarConsumerProcessor<GenericRecord>) runner.getProcessor();
+        processor.init(runner.getProcessContext());
+        return ((ConsumerBuilderImpl<GenericRecord>) processor.getConsumerBuilder(runner.getProcessContext())).getConf();
+    }
+
+    // --- Expire Time of Incomplete Chunked Message ---------------------------------------------------------
+
+    /** The client keeps milliseconds, so there is no reason to lose the fraction on the way. */
+    @Test
+    public void theChunkExpiryKeepsItsFractionOfASecond() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE, "1500 millis");
+
+        assertEquals(1500L, consumerConfiguration().getExpireTimeOfIncompleteChunkedMessageMillis());
+    }
+
+    /**
+     * The case that mattered most: converted to whole seconds, a sub-second value became 0, and the client
+     * schedules chunk expiry only for a value above 0 - so "expire quickly" silently meant "never expire".
+     */
+    @Test
+    public void aSubSecondChunkExpiryIsAppliedRatherThanDisablingExpiry() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE, "500 millis");
+
+        assertEquals(500L, consumerConfiguration().getExpireTimeOfIncompleteChunkedMessageMillis());
+    }
+
+    @Test
+    public void theDefaultChunkExpiryIsOneMinute() throws Exception {
+        assertEquals(TimeUnit.MINUTES.toMillis(1), consumerConfiguration().getExpireTimeOfIncompleteChunkedMessageMillis());
+    }
+
+    // --- Auto Update Partition Interval ------------------------------------------------------------------
+
+    /**
+     * Below a second the client cannot be given the value at all: it refuses zero. Before the rule the processor
+     * validated and then failed on every trigger with the client's message about an interval nobody typed.
+     */
+    @Test
+    public void aPartitionUpdateIntervalUnderOneSecondIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "500 millis");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void aPartitionUpdateIntervalOfExactlyOneSecondIsValid() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "1000 millis");
+
+        runner.assertValid();
+    }
+
+    /** The reason for the floor, pinned against the client itself so a client that relaxes it is noticed. */
+    @Test
+    public void theClientRefusesAZeroSecondPartitionUpdateInterval() {
+        try {
+            clientService.getPulsarClient().newConsumer(Schema.BYTES).autoUpdatePartitionsInterval(0, TimeUnit.SECONDS);
+            fail("the client accepted a zero-second partition update interval; the validation floor may no longer be needed");
+        } catch (final IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("> 0"));
+        }
+    }
+
+    /**
+     * A second or more with a fraction runs, only coarser than asked: the client keeps whole seconds. That is
+     * allowed - it worked before and works now - but the processor says what it applied, once per start.
+     */
+    @Test
+    public void aFractionalPartitionUpdateIntervalIsAppliedAsWholeSecondsAndWarnsWhenScheduled() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "90500 millis");
+
+        runner.assertValid();
+        assertEquals(90L, consumerConfiguration().getAutoUpdatePartitionsIntervalSeconds());
+
+        assertEquals("one warning about the dropped fraction, got " + runner.getLogger().getWarnMessages(),
+                1, runner.getLogger().getWarnMessages().size());
+        final LogMessage warning = runner.getLogger().getWarnMessages().get(0);
+        final String rendered = String.format(warning.getMsg().replace("{}", "%s"), warning.getArgs());
+        assertTrue(rendered, rendered.contains("Auto Update Partition Interval") && rendered.contains("90500 millis")
+                && rendered.contains("90 seconds"));
+    }
+
+    /** Whole seconds are applied as given, and nothing is logged about them. */
+    @Test
+    public void aWholeSecondPartitionUpdateIntervalIsAppliedAsGivenWithoutAWarning() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "90 sec");
+
+        assertEquals(90L, consumerConfiguration().getAutoUpdatePartitionsIntervalSeconds());
+        assertEquals(0, runner.getLogger().getWarnMessages().size());
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarTimePropertiesTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarTimePropertiesTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
 import org.apache.nifi.pulsar.StandardPulsarClientService;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -43,10 +42,11 @@ import org.junit.Test;
  * real {@code PulsarClient} - one that never connects; the client is lazy about that - and assert against the
  * {@link ConsumerConfigurationData} the builder holds, which is the value the consumer would run with.
  * <p>
- * <i>Expire Time of Incomplete Chunked Message</i> is stored by the client in milliseconds, so every value can
- * be honoured exactly. <i>Auto Update Partition Interval</i> is stored in whole seconds and the client refuses
- * zero, so a value under a second cannot be applied at all and a fraction of a second above that is dropped;
- * the first is rejected at validation and the second is warned about when the processor is scheduled.
+ * The rule is the same for both: the value must be representable in the granularity the client stores it in,
+ * or it is rejected at validation rather than applied as something else. <i>Expire Time of Incomplete Chunked
+ * Message</i> is a long of whole milliseconds, with 0 meaning "never expire". <i>Auto Update Partition
+ * Interval</i> is an int of whole seconds, and the client refuses zero, so the value must be a whole number of
+ * seconds between 1 and {@link Integer#MAX_VALUE}.
  */
 public class ConsumePulsarTimePropertiesTest {
 
@@ -107,6 +107,33 @@ public class ConsumePulsarTimePropertiesTest {
         assertEquals(TimeUnit.MINUTES.toMillis(1), consumerConfiguration().getExpireTimeOfIncompleteChunkedMessageMillis());
     }
 
+    /**
+     * Below a millisecond the same trap would reappear one unit down: {@code 0.5 millis} truncates to 0, and 0 is
+     * "never expire" - the opposite of the shortest expiry the user asked for. Not a whole millisecond, so rejected.
+     */
+    @Test
+    public void aChunkExpiryUnderOneMillisecondIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE, "0.5 millis");
+
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void aChunkExpiryWithAFractionOfAMillisecondIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE, "1500000 nanos");
+
+        runner.assertNotValid();
+    }
+
+    /** Zero is the documented "never expire", chosen deliberately rather than arrived at by truncation. */
+    @Test
+    public void aZeroChunkExpiryIsValidAndDisablesTheExpiry() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE, "0 sec");
+
+        runner.assertValid();
+        assertEquals(0L, consumerConfiguration().getExpireTimeOfIncompleteChunkedMessageMillis());
+    }
+
     // --- Auto Update Partition Interval ------------------------------------------------------------------
 
     /**
@@ -139,29 +166,49 @@ public class ConsumePulsarTimePropertiesTest {
     }
 
     /**
-     * A second or more with a fraction runs, only coarser than asked: the client keeps whole seconds. That is
-     * allowed - it worked before and works now - but the processor says what it applied, once per start.
+     * A second or more with a fraction is not representable: the client keeps whole seconds, so {@code 90500 millis}
+     * would run as 90 s while the configuration says 90.5. Rejected, like the sibling Topics Pattern Discovery
+     * Interval, rather than silently applied as something else.
      */
     @Test
-    public void aFractionalPartitionUpdateIntervalIsAppliedAsWholeSecondsAndWarnsWhenScheduled() throws Exception {
+    public void aFractionalPartitionUpdateIntervalIsRejected() {
         runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "90500 millis");
 
-        runner.assertValid();
-        assertEquals(90L, consumerConfiguration().getAutoUpdatePartitionsIntervalSeconds());
-
-        assertEquals("one warning about the dropped fraction, got " + runner.getLogger().getWarnMessages(),
-                1, runner.getLogger().getWarnMessages().size());
-        final LogMessage warning = runner.getLogger().getWarnMessages().get(0);
-        final String rendered = String.format(warning.getMsg().replace("{}", "%s"), warning.getArgs());
-        assertTrue(rendered, rendered.contains("Auto Update Partition Interval") && rendered.contains("90500 millis")
-                && rendered.contains("90 seconds"));
+        runner.assertNotValid();
     }
 
-    /** Whole seconds are applied as given, and nothing is logged about them. */
+    /**
+     * The client takes the seconds as an int, and the processor used {@code intValue()} on the long: past
+     * {@link Integer#MAX_VALUE} seconds the value wrapped - negative and refused by the client on every trigger, or
+     * positive and silently far shorter than asked ({@code 10000 weeks} ran as about 55 years, not 191).
+     */
     @Test
-    public void aWholeSecondPartitionUpdateIntervalIsAppliedAsGivenWithoutAWarning() throws Exception {
+    public void aPartitionUpdateIntervalPastTheIntRangeIsRejected() {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "30000 days");
+        runner.assertNotValid();
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "10000 weeks");
+        runner.assertNotValid();
+
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, (Integer.MAX_VALUE + 1L) + " sec");
+        runner.assertNotValid();
+    }
+
+    /** The top of the range is representable and applied as given. */
+    @Test
+    public void thePartitionUpdateIntervalAtTheTopOfTheIntRangeIsValid() throws Exception {
+        runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, Integer.MAX_VALUE + " sec");
+
+        runner.assertValid();
+        assertEquals((long) Integer.MAX_VALUE, consumerConfiguration().getAutoUpdatePartitionsIntervalSeconds());
+    }
+
+    /** Whole seconds are applied as given. */
+    @Test
+    public void aWholeSecondPartitionUpdateIntervalIsAppliedAsGiven() throws Exception {
         runner.setProperty(AbstractPulsarConsumerProcessor.AUTO_UPDATE_PARTITION_INTERVAL, "90 sec");
 
+        runner.assertValid();
         assertEquals(90L, consumerConfiguration().getAutoUpdatePartitionsIntervalSeconds());
         assertEquals(0, runner.getLogger().getWarnMessages().size());
     }

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -141,7 +141,8 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         runner.run(10, true);
 
         verify(mockClientService.getMockConsumerBuilder(), times(1)).autoAckOldestChunkedMessageOnQueueFull(true);
-        verify(mockClientService.getMockConsumerBuilder(), times(1)).expireTimeOfIncompleteChunkedMessage(120, TimeUnit.SECONDS);
+        // handed over in milliseconds, the unit the client stores, so no fraction is lost on the way (#225)
+        verify(mockClientService.getMockConsumerBuilder(), times(1)).expireTimeOfIncompleteChunkedMessage(120_000, TimeUnit.MILLISECONDS);
         verify(mockClientService.getMockConsumerBuilder(), times(1)).maxPendingChunkedMessage(20);
     }
     


### PR DESCRIPTION
Closes #225.

Two consumer time properties reached the Pulsar client as whole seconds, so any fraction the user typed was dropped in silence. Reading the client (4.2.4) showed the two are not the same case.

> **Revised after review** (third commit): one rule for both properties, the one #217 applies to *Topics Pattern Discovery Interval* — a value must be representable in the granularity the client stores it in, or it is rejected at validation. *Auto Update Partition Interval*: whole seconds, 1 to `Integer.MAX_VALUE` (the `intValue()` wrap past that range is closed). *Expire Time of Incomplete Chunked Message*: whole milliseconds, `0` kept as the documented "never expire". The `@OnScheduled` warning is gone, since a rejected value never reaches it. README callout re-scoped from `2.11.0` to every release since `2.1.0`. Details in the review thread.

### What changed

- **`AbstractPulsarConsumerProcessor.getConsumerBuilder`** — *Expire Time of Incomplete Chunked Message* is passed as `asTimePeriod(MILLISECONDS), MILLISECONDS`. `ConsumerBuilder.expireTimeOfIncompleteChunkedMessage(long, TimeUnit)` stores `unit.toMillis(duration)`, so the whole-seconds conversion was entirely ours and every configured value is now applied exactly. What the truncated `0` did: `ConsumerImpl` schedules the chunk-expiry task only when the value is `> 0`, so a flow that set `500 millis` has been running with expiry **disabled**, not fast.
- **`customValidate`** — *Auto Update Partition Interval* must be a whole number of seconds between 1 and `Integer.MAX_VALUE`. The client keeps this interval as an `int` of whole seconds (`ConsumerConfigurationData.setAutoUpdatePartitionsIntervalSeconds` → `unit.toSeconds`) and begins with `checkArgument(interval > 0, "interval needs to be > 0")`, so: `asTimePeriod(SECONDS).intValue()` handed it `0` for a sub-second value and the builder threw on every trigger (see the probe below); a fractional value such as `90500 millis` ran as 90 s while the configuration said otherwise; and a value past the `int` range wrapped — `30000 days` to a negative interval the client refused, `10000 weeks` to a positive one about 55 years long instead of 191. One condition rejects all three. *Expire Time of Incomplete Chunked Message* must be a whole number of milliseconds, since that is the `long` the client keeps; `0.5 millis` would otherwise truncate to the `0` the client reads as "never expire", the opposite of what was asked. `0` itself stays valid as the documented sentinel.
- **No `@OnScheduled` warning.** The first version warned about a fractional interval at scheduling; under the rule above a fractional value is invalid, and a processor that fails validation is never scheduled, so the warning could not fire. The validation message carries the explanation: the property, the value, and what the client can represent.
- **Descriptions** of both properties say what the client keeps and what is therefore valid.
- **README** — new *Consumer time properties* section stating the rule and the two granularities, with a *Behaviour change since `2.1.0`* callout: the whole-seconds conversion of the chunk expiry dates from `4ed35de` (2024) and is in every release, so an operator coming from `2.10.0.1` is exactly who it addresses.

Passing milliseconds to `autoUpdatePartitionsInterval` was considered and rejected: `500` passes the `> 0` check, `toSeconds(500)` is `0`, and the partition-update timer would then fire continuously — worse than the exception it replaces.

### Tests

**`ConsumePulsarTimePropertiesTest`** (new, 13 cases) builds the consumer configuration through a real `PulsarClient` (`pulsar://localhost:1`; building a client opens no connection and nothing here subscribes) and asserts against the `ConsumerConfigurationData` the builder holds — the same idea as `PublishPulsarProducerConfigurationTest`: what the client actually ends up with, not what the processor thinks it passed.

- chunk expiry keeps its fraction (`1500 millis` → 1500 ms), a sub-second value is applied rather than disabling expiry (`500 millis` → 500 ms), the default is one minute;
- a partition update interval under a second is rejected, exactly one second is valid; `90500 millis` is rejected; `30000 days`, `10000 weeks` and `Integer.MAX_VALUE + 1` seconds are rejected; `Integer.MAX_VALUE` seconds is valid and applied; `90 sec` is applied as given with no warning;
- the client refuses a zero-second interval (pins the reason for the floor, so a client that relaxes it is noticed);
- a chunk expiry of `0.5 millis` or `1500000 nanos` is rejected; `0 sec` is valid and applied as 0.

`TestConsumePulsar.chunkedMessageConfigTest` verified the old `expireTimeOfIncompleteChunkedMessage(120, SECONDS)` call and now verifies `(120_000, MILLISECONDS)`.

### Fails first

The new test class against `main` (`00a6eb8`) — 4 of 8 fail:

```
Tests run: 8, Failures: 4, Errors: 0, Skipped: 0 -- in ConsumePulsarTimePropertiesTest
  theChunkExpiryKeepsItsFractionOfASecond:                        expected:<1500> but was:<1000>
  aSubSecondChunkExpiryIsAppliedRatherThanDisablingExpiry:        expected:<500> but was:<0>
  aPartitionUpdateIntervalUnderOneSecondIsRejected:               Processor appears to be valid but expected it to be invalid
  aFractionalPartitionUpdateIntervalIsAppliedAsWholeSecondsAndWarnsWhenScheduled:
                                                                  one warning about the dropped fraction, got [] expected:<1> but was:<0>
```

And what a `500 millis` partition update interval did on `main`, from a throwaway probe (validation, then `getConsumerBuilder` with the real client):

```
PROBE validation results=[]
PROBE builder threw java.lang.IllegalArgumentException: interval needs to be > 0
```

Third commit, the new cases against the second commit's rules:

```
Tests run: 13, Failures: 4 -- in ConsumePulsarTimePropertiesTest
  aFractionalPartitionUpdateIntervalIsRejected:            Processor appears to be valid but expected it to be invalid
  aPartitionUpdateIntervalPastTheIntRangeIsRejected:       Processor appears to be valid but expected it to be invalid
  aChunkExpiryUnderOneMillisecondIsRejected:               Processor appears to be valid but expected it to be invalid
  aChunkExpiryWithAFractionOfAMillisecondIsRejected:       Processor appears to be valid but expected it to be invalid
```

### Verification

- `mvn test` on the current head: **381/381** (on top of `main` after `2.11.0.1`: 367 + 13 + the one updated verification).
- Third commit: `ConsumePulsarIT` (4) and `ConsumePulsarTopicSchemaIT` (6) against a real broker.
- `ConsumePulsarIT` (4), `ConsumePulsarRestartIT` (6), `ConsumePulsarTopicSchemaIT` (6) against a real broker (Testcontainers, `apachepulsar/pulsar:4.2.4`): all pass; the consumer configuration the client logs shows `expireTimeOfIncompleteChunkedMessageMillis: 60000` for the default, as before.

### Not done

- ~~No release-notes entry in this PR~~ — added in the second commit: since `2.11.0.1` has shipped, the entry goes in a new `docs/release-notes/2.11.0.2.md` (*Behaviour changes*: chunk expiry honoured to the millisecond; sub-second partition update interval rejected, with the note that such flows were failing at run time; plus *Upgrading*). #222 creates the same file for its own entries; whichever lands second I rebase and fold together. Rebased onto `main` after `2.11.0.1`; the only code conflict was the two `@OnScheduled` helpers landing on the same lines, both kept.
- The property descriptions are the only per-processor documentation for these two; neither had an `additionalDetails` paragraph before and I did not add one — the README section covers the reasoning.
- The producer-side *Auto Update Partition Interval* has the same truncation and, because it goes through `loadConf()`, skips the client's zero guard entirely; filed as #230, not touched here.
- `Ack Timeout` and *Negative Acknowledgment Redelivery Delay* are passed in milliseconds and microseconds respectively and do not truncate; I checked and left them alone. *Topics Pattern Discovery Interval* is #217's and already rejects a fraction.
- The new test builds a real `PulsarClient` per case (about 2 s each, ~17 s for the class); a shared client would be faster but would carry state between cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FxYKxcaKpvRbJSYP3QYZ9
