### PR TITLE
fix: acknowledge every message individually, never cumulatively (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ decides whether Pulsar ever delivers it again.
 | The Pulsar client itself failed | rolled back, left unacknowledged | Yes, after *Acknowledgment Timeout* |
 
 Acknowledgement happens only after the FlowFile carrying the message is committed, so a message
-is never acknowledged while its content could still be discarded.
+is never acknowledged while its content could still be discarded. Each message is acknowledged
+individually, on every subscription type, so one trigger's acknowledgement never reaches a message
+another trigger is still holding — which matters because concurrent tasks of one processor share a
+single consumer.
 
 The third row is the one to know about. When the processor cannot write a message into a FlowFile
 — a full content repository, a permissions problem, a disk fault — it rolls the session back and

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/AbstractPulsarConsumerProcessor.java
@@ -759,11 +759,10 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
      * @param session  the session holding the FlowFiles the messages were written to
      * @param consumer the consumer the messages were received from
      * @param messages the messages carried by the FlowFiles in the session; cleared on return
-     * @param shared   whether the subscription is Shared or Key_Shared
      * @param async    whether to acknowledge through the asynchronous acknowledgement service
      */
     protected void commitAndAcknowledge(final ProcessSession session, final Consumer<GenericRecord> consumer,
-                                        final List<Message<GenericRecord>> messages, final boolean shared, final boolean async) {
+                                        final List<Message<GenericRecord>> messages, final boolean async) {
         if (messages.isEmpty()) {
             return;
         }
@@ -771,7 +770,7 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
         final List<Message<GenericRecord>> committed = new ArrayList<>(messages);
         messages.clear();
 
-        session.commitAsync(() -> acknowledge(consumer, committed, shared, async));
+        session.commitAsync(() -> acknowledge(consumer, committed, async));
     }
 
     /**
@@ -807,25 +806,27 @@ public abstract class AbstractPulsarConsumerProcessor<T> extends AbstractProcess
     }
 
     private void acknowledge(final Consumer<GenericRecord> consumer, final List<Message<GenericRecord>> messages,
-                             final boolean shared, final boolean async) {
+                             final boolean async) {
         final ExecutorCompletionService<Object> service = async ? getAckService() : null;
 
+        // Individually, on every subscription type, and never cumulatively. Cumulative acknowledgement
+        // means "this message and everything before it on the subscription", which is safe only while one
+        // task owns the whole stream. Concurrent tasks of one processor share a consumer - getConsumer()
+        // is synchronized and caches by consumer id, deliberately, so the broker never sees a second
+        // consumer on an Exclusive subscription - so "everything before it" reached into whatever another
+        // task was still holding. A task that then failed to write found its messages already
+        // acknowledged, and its negative acknowledgement had nothing left to redeliver: those messages
+        // were neither in NiFi nor recoverable from Pulsar (#223).
+        //
+        // This is the loop Shared subscriptions have always run, now taken by all of them. The client
+        // groups individual acknowledgements - a 100ms window, up to 1000 ids - into a single command, so
+        // one call per message here is not one round trip per message.
         try {
-            if (shared) {
-                for (final Message<GenericRecord> message : messages) {
-                    if (service != null) {
-                        service.submit(() -> consumer.acknowledgeAsync(message).get());
-                    } else {
-                        consumer.acknowledge(message);
-                    }
-                }
-            } else {
-                final Message<GenericRecord> last = messages.get(messages.size() - 1);
-
+            for (final Message<GenericRecord> message : messages) {
                 if (service != null) {
-                    service.submit(() -> consumer.acknowledgeCumulativeAsync(last).get());
+                    service.submit(() -> consumer.acknowledgeAsync(message).get());
                 } else {
-                    consumer.acknowledgeCumulative(last);
+                    consumer.acknowledge(message);
                 }
             }
         } catch (final PulsarClientException e) {

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsar.java
@@ -98,8 +98,6 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                 final byte[] demarcatorBytes = context.getProperty(MESSAGE_DEMARCATOR).isSet() ? context.getProperty(MESSAGE_DEMARCATOR)
                     .evaluateAttributeExpressions().getValue().getBytes(StandardCharsets.UTF_8) : null;
 
-                // Cumulative acks are NOT permitted on Shared subscriptions.
-                final boolean shared = isSharedSubscription(context);
                 
                 List<Message<GenericRecord>> messages = done.get();
 
@@ -139,7 +137,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                                 session.transfer(flowFile, REL_SUCCESS);
                             }
 
-                            commitAndAcknowledge(session, consumer, uncommitted, shared, true);
+                            commitAndAcknowledge(session, consumer, uncommitted, true);
 
                             lastAttributes = null;
                         }
@@ -196,7 +194,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                     // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a
                     // time otherwise. This has to stay inside the isNotEmpty() guard: on an idle topic the
                     // list is empty and there is nothing to commit or acknowledge.
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, true);
+                    commitAndAcknowledge(session, consumer, uncommitted, true);
                 }
             }
         } catch (InterruptedException | ExecutionException e) {
@@ -215,8 +213,6 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
             final byte[] demarcatorBytes = context.getProperty(MESSAGE_DEMARCATOR).isSet() ? context.getProperty(MESSAGE_DEMARCATOR)
                     .evaluateAttributeExpressions().getValue().getBytes(StandardCharsets.UTF_8) : null;
             
-            // Cumulative acks are NOT permitted on Shared subscriptions.
-            final boolean shared = isSharedSubscription(context);
 
             FlowFile flowFile = null;
             OutputStream out = null;
@@ -255,7 +251,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
                             new Object[]{flowFile, msgCount.toString()});
                     }
 
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, false);
+                    commitAndAcknowledge(session, consumer, uncommitted, false);
 
                     lastAttributes = null;
                     lastMsg = null;
@@ -316,7 +312,7 @@ public class ConsumePulsar extends AbstractPulsarConsumerProcessor<byte[]> {
 
             // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time
             // otherwise. Nothing is committed or acknowledged when no message was received.
-            commitAndAcknowledge(session, consumer, uncommitted, shared, false);
+            commitAndAcknowledge(session, consumer, uncommitted, false);
 
         } catch (PulsarClientException e) {
             // Deliberately not negatively acknowledged: this is the client itself failing, so the call that

--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecord.java
@@ -386,7 +386,6 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         int writtenRecords = 0;
 
         // Cumulative acks are NOT permitted on Shared subscriptions
-        final boolean shared = isSharedSubscription(context);
 
         final boolean useTopicSchema = usesTopicSchema(context.getProperty(MESSAGE_SCHEMA_STRATEGY).getValue());
 
@@ -498,7 +497,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
                     }
 
                     dropUnroutedFailures(session, parseFailures, demarcator, uncommitted);
-                    commitAndAcknowledge(session, consumer, uncommitted, shared, async);
+                    commitAndAcknowledge(session, consumer, uncommitted, async);
 
                     writtenRecords = 0;
                     lastAttributes = null;
@@ -600,7 +599,7 @@ public class ConsumePulsarRecord extends AbstractPulsarConsumerProcessor<Generic
         }
 
         // Commits, then acknowledges: cumulatively for non-shared subscriptions, one message at a time otherwise.
-        commitAndAcknowledge(session, consumer, uncommitted, shared, async);
+        commitAndAcknowledge(session, consumer, uncommitted, async);
     }
 
     /**

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar/additionalDetails.html
@@ -35,7 +35,10 @@
 <p>
     A consumed message leaves this processor by exactly one route, and which one it took decides whether
     Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
-    committed, so a message is never acknowledged while its content could still be discarded.
+    committed, so a message is never acknowledged while its content could still be discarded. Each message
+    is acknowledged individually, on every subscription type, so one trigger's acknowledgement never reaches
+    a message another trigger is still holding - which matters because concurrent tasks of one processor
+    share a single consumer.
 </p>
 <table>
     <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>

--- a/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
+++ b/nifi-pulsar-processors/src/main/resources/docs/org.apache.nifi.processors.pulsar.pubsub.ConsumePulsarRecord/additionalDetails.html
@@ -34,7 +34,10 @@
 <p>
     A consumed message leaves this processor by exactly one route, and which one it took decides whether
     Pulsar ever delivers it again. Acknowledgement happens only after the FlowFile carrying the message is
-    committed, so a message is never acknowledged while its content could still be discarded.
+    committed, so a message is never acknowledged while its content could still be discarded. Each message
+    is acknowledged individually, on every subscription type, so one trigger's acknowledgement never reaches
+    a message another trigger is still holding - which matters because concurrent tasks of one processor
+    share a single consumer.
 </p>
 <table>
     <tr><th>What happened</th><th>Route</th><th>Redelivered?</th></tr>

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarConcurrentAckTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/ConsumePulsarConcurrentAckTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.processors.pulsar.pubsub.mocks.MockPulsarMessage;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.TestRunners;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Concurrent tasks share one consumer, so a cumulative acknowledgement from one task acknowledges
+ * messages another task is still holding.
+ * <p>
+ * {@code getConsumer()} is synchronized and caches by consumer id, so every concurrent task of one
+ * processor receives from the same {@link Consumer}. That is deliberate - it is what stops the broker
+ * refusing a second consumer on an Exclusive subscription. The consequence is that
+ * {@code acknowledgeCumulative(last)} is no longer confined to one task's batch: cumulative means "this
+ * message and everything before it on the subscription", and everything before it includes whatever the
+ * other task is still working on.
+ * <p>
+ * The losing interleaving: task B commits its batch and cumulatively acknowledges, which acknowledges
+ * task A's older message too; task A then fails to write and negatively acknowledges, which does nothing
+ * because the message is already acknowledged. The message is neither in NiFi nor recoverable from
+ * Pulsar - the same loss the commit-then-acknowledge ordering was introduced to eliminate, reached by a
+ * different route.
+ *
+ * @see <a href="https://github.com/david-streamlio/pulsar-nifi-bundle/issues/223">#223</a>
+ */
+public class ConsumePulsarConcurrentAckTest extends AbstractPulsarProcessorTest<GenericRecord> {
+
+    private static final String TOPIC = "persistent://public/default/concurrent-ack";
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addPulsarClientService();
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+    }
+
+    /**
+     * The defect, on the subscription types that use cumulative acknowledgement. Task B's batch is
+     * committed while task A's older message is still outstanding; nothing may acknowledge task A's
+     * message on task B's behalf.
+     */
+    @Test
+    public void oneTasksCommitDoesNotAcknowledgeAnothersOutstandingMessages() throws PulsarClientException {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.run(1, false, true);
+
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+        final Message<GenericRecord> taskAMessage = message(1);
+        final Message<GenericRecord> taskBMessage = message(2);
+
+        // Task A is holding its message, uncommitted, when task B commits and acknowledges its own.
+        final List<Message<GenericRecord>> taskABatch = new ArrayList<>(List.of(taskAMessage));
+        final List<Message<GenericRecord>> taskBBatch = new ArrayList<>(List.of(taskBMessage));
+
+        final AbstractPulsarConsumerProcessor<?> processor =
+                (AbstractPulsarConsumerProcessor<?>) runner.getProcessor();
+        final MockProcessSession taskBSession = (MockProcessSession) runner.getProcessSessionFactory().createSession();
+
+        processor.commitAndAcknowledge(taskBSession, consumer, taskBBatch, false);
+        taskBSession.commitAsync();
+
+        // Cumulative acknowledgement means "this message and everything before it on the subscription",
+        // so acknowledging task B's message here also acknowledges task A's, which task A still holds and
+        // may yet fail to write. Nothing about task B's batch may reach task A's message.
+        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
+        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
+
+        // Task A's message must not have been acknowledged at all - it is still in flight.
+        verify(consumer, never()).acknowledge(taskAMessage);
+    }
+
+    /** Task B's own message is still acknowledged: the fix must not stop acknowledging what it should. */
+    @Test
+    public void aCommittedBatchIsStillAcknowledged() throws PulsarClientException {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.run(1, false, true);
+
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+        final Message<GenericRecord> taskBMessage = message(2);
+        final List<Message<GenericRecord>> batch = new ArrayList<>(List.of(taskBMessage));
+
+        final AbstractPulsarConsumerProcessor<?> processor =
+                (AbstractPulsarConsumerProcessor<?>) runner.getProcessor();
+        final MockProcessSession session = (MockProcessSession) runner.getProcessSessionFactory().createSession();
+
+        processor.commitAndAcknowledge(session, consumer, batch, false);
+        session.commitAsync();
+
+        verify(consumer).acknowledge(taskBMessage);
+    }
+
+    /** Shared subscriptions already acknowledged per message; that must be unchanged. */
+    @Test
+    public void aSharedSubscriptionStillAcknowledgesPerMessage() throws PulsarClientException {
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+        runner.run(1, false, true);
+
+        final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
+        final Message<GenericRecord> first = message(1);
+        final Message<GenericRecord> second = message(2);
+        final List<Message<GenericRecord>> batch = new ArrayList<>(List.of(first, second));
+
+        final AbstractPulsarConsumerProcessor<?> processor =
+                (AbstractPulsarConsumerProcessor<?>) runner.getProcessor();
+        final MockProcessSession session = (MockProcessSession) runner.getProcessSessionFactory().createSession();
+
+        processor.commitAndAcknowledge(session, consumer, batch, false);
+        session.commitAsync();
+
+        verify(consumer).acknowledge(first);
+        verify(consumer).acknowledge(second);
+        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
+    }
+
+    private static Message<GenericRecord> message(final int n) {
+        return new MockPulsarMessage<GenericRecord>(TOPIC, ("payload-" + n).getBytes(UTF_8), "1234:" + n + ":0", null, null);
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarConcurrentAckIT.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/it/ConsumePulsarConcurrentAckIT.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.pulsar.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
+import org.apache.nifi.processors.pulsar.pubsub.ConsumePulsar;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.state.MockStateManager;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A message left outstanding by one trigger survives another trigger's acknowledgement.
+ * <p>
+ * This is the loss in #223, reached without threading. Cumulative acknowledgement means "this message and
+ * everything before it on the subscription", so acknowledging a later message acknowledged an earlier one
+ * that a previous trigger had rolled back and negatively acknowledged. Already acknowledged, it was never
+ * redelivered - neither in NiFi nor recoverable from Pulsar.
+ * <p>
+ * Only a broker can show this. The unit test asserts that cumulative acknowledgement is not called; whether
+ * the earlier message actually comes back is the broker's decision, and it is the thing that matters.
+ */
+public class ConsumePulsarConcurrentAckIT extends AbstractPulsarIT {
+
+    private TestRunner runner;
+
+    @Before
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumePulsar.class);
+        addRealPulsarClientService(runner, "pulsar-client");
+        runner.setProperty(AbstractPulsarConsumerProcessor.PULSAR_CLIENT_SERVICE, "pulsar-client");
+        // Exclusive is the subscription type that used cumulative acknowledgement.
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
+        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "false");
+        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_INITIAL_POSITION, "Earliest");
+        // One message per trigger, so the two messages are handled by separate triggers with separate
+        // sessions - which is what lets one be outstanding while the other is acknowledged.
+        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
+        // Long, deliberately: the rolled-back message must stay outstanding while the next one is
+        // committed. With a short delay it is redelivered before that happens and the interleaving the
+        // defect needs never occurs - which is how the first version of this test passed against the bug.
+        runner.setProperty(AbstractPulsarConsumerProcessor.ACK_TIMEOUT, "60 sec");
+        runner.setProperty(AbstractPulsarConsumerProcessor.NEGATIVE_ACK_REDELIVERY_DELAY, "60 sec");
+    }
+
+    @Test
+    public void aMessageRolledBackByOneTriggerIsNotAcknowledgedByTheNext() throws Exception {
+        final String topic = "persistent://public/default/concurrent-ack-" + System.nanoTime();
+        final String subscription = "concurrent-ack-sub";
+        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, topic);
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, subscription);
+
+        // Schedule against the still-empty topic: an initializing run also triggers, and would otherwise
+        // consume and commit "first" before the failing trigger ever saw it, shifting the whole sequence
+        // by one message. That is what the first version of this test did.
+        runner.run(1, false, true);
+
+        publish(topic, "first", "second");
+
+        // Trigger one takes "first" and cannot write it: the session rolls back and the message is
+        // negatively acknowledged. With a 60s redelivery delay it stays outstanding for the rest of the
+        // test - owed to the subscription, and not yet acknowledged by anyone.
+        ((ConsumePulsar) runner.getProcessor()).onTrigger(runner.getProcessContext(), failingSession());
+
+        // Trigger two takes "second" and commits it, which acknowledges it.
+        await("the second message to be consumed and committed", () -> {
+            runner.run(1, false, false);
+            return consumed().contains("second");
+        });
+
+        // The assertion. "first" is still owed, so the subscription must still have a backlog. Under
+        // cumulative acknowledgement, acknowledging "second" acknowledged everything before it on the
+        // subscription - including "first" - and the backlog went to zero with "first" never delivered
+        // anywhere. Checked through the broker rather than by waiting for a redelivery, so the test does
+        // not have to distinguish "lost" from "not yet".
+        final long backlog = backlogOf(topic, subscription);
+
+        assertTrue("the message rolled back by the first trigger was acknowledged by the second trigger's "
+                + "commit: the subscription has no backlog, so nothing will ever redeliver it",
+                backlog >= 1);
+        assertTrue("the second message was not consumed: " + consumed(), consumed().contains("second"));
+    }
+
+    /**
+     * The number of messages the subscription still owes, read from the broker.
+     *
+     * <p>Parsed with plain string search rather than a JSON library: the topic stats are a large document
+     * and the only thing needed is the msgBacklog that follows this subscription's name.
+     */
+    private static long backlogOf(final String topic, final String subscription) throws Exception {
+        final String stats = exec("bin/pulsar-admin", "topics", "stats", topic);
+        final int subscriptionAt = stats.indexOf("\"" + subscription + "\"");
+
+        if (subscriptionAt < 0) {
+            throw new AssertionError("subscription " + subscription + " not found in topic stats:\n" + stats);
+        }
+
+        final String key = "\"msgBacklog\"";
+        final int backlogAt = stats.indexOf(key, subscriptionAt);
+
+        if (backlogAt < 0) {
+            throw new AssertionError("msgBacklog not found after the subscription in topic stats:\n" + stats);
+        }
+
+        final int colon = stats.indexOf(':', backlogAt + key.length());
+        final StringBuilder digits = new StringBuilder();
+
+        for (int i = colon + 1; i < stats.length(); i++) {
+            final char c = stats.charAt(i);
+            if (Character.isDigit(c)) {
+                digits.append(c);
+            } else if (digits.length() > 0) {
+                break;
+            }
+        }
+
+        return Long.parseLong(digits.toString());
+    }
+
+    /** Runs a command inside the broker container and returns its combined output. */
+    private static String exec(final String... command) throws Exception {
+        final org.testcontainers.containers.Container.ExecResult result = PULSAR.execInContainer(command);
+        return result.getStdout() + result.getStderr();
+    }
+
+    /** Everything routed to success so far, concatenated. */
+    private String consumed() {
+        final StringBuilder sb = new StringBuilder();
+
+        for (final MockFlowFile flowFile : runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS)) {
+            sb.append(new String(flowFile.toByteArray())).append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    /** A session whose FlowFile content cannot be written - a full or read-only content repository. */
+    private MockProcessSession failingSession() {
+        final Processor processor = runner.getProcessor();
+
+        return new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor)) {
+            @Override
+            public OutputStream write(final FlowFile flowFile) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw new IOException("Intentional Integration Test Exception: the content repository cannot be written");
+                    }
+                };
+            }
+        };
+    }
+}

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAcknowledgementTest.java
@@ -112,8 +112,8 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
         runner.run(1, true);
 
         runner.assertAllFlowFilesTransferred(ConsumePulsar.REL_SUCCESS, 1);
-        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+        assertEquals("one acknowledgement per message, on every subscription type (#223)",
+                3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }
@@ -169,16 +169,8 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
         }).when(consumer).acknowledge(any(Message.class));
         doAnswer(invocation -> {
             states.add(sessionState(relationship));
-            return null;
-        }).when(consumer).acknowledgeCumulative(any(Message.class));
-        doAnswer(invocation -> {
-            states.add(sessionState(relationship));
             return CompletableFuture.completedFuture(null);
         }).when(consumer).acknowledgeAsync(any(Message.class));
-        doAnswer(invocation -> {
-            states.add(sessionState(relationship));
-            return CompletableFuture.completedFuture(null);
-        }).when(consumer).acknowledgeCumulativeAsync(any(Message.class));
 
         return states;
     }
@@ -205,13 +197,10 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
     private void verifyAcknowledged(final int messages) throws PulsarClientException {
         final Consumer<GenericRecord> consumer = mockClientService.getMockConsumer();
 
-        if (shared) {
-            verify(consumer, times(async ? 0 : messages)).acknowledge(any(Message.class));
-            verify(consumer, times(async ? messages : 0)).acknowledgeAsync(any(Message.class));
-        } else {
-            verify(consumer, times(async ? 0 : 1)).acknowledgeCumulative(any(Message.class));
-            verify(consumer, times(async ? 1 : 0)).acknowledgeCumulativeAsync(any(Message.class));
-        }
+        // One acknowledgement per message on every subscription type. Cumulative acknowledgement would
+        // reach into another concurrent task's outstanding batch, so it is no longer used at all (#223).
+        verify(consumer, times(async ? 0 : messages)).acknowledge(any(Message.class));
+        verify(consumer, times(async ? messages : 0)).acknowledgeAsync(any(Message.class));
     }
 
     private void verifyNothingAcknowledged() throws PulsarClientException {
@@ -219,8 +208,8 @@ public class ConsumePulsarAcknowledgementTest extends AbstractPulsarProcessorTes
 
         verify(consumer, never()).acknowledge(any(Message.class));
         verify(consumer, never()).acknowledgeAsync(any(Message.class));
-        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
-        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
+        verify(consumer, never()).acknowledge(any(Message.class));
+        verify(consumer, never()).acknowledgeAsync(any(Message.class));
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarRecordAcknowledgementTest.java
@@ -121,8 +121,8 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
         runner.run(1, true);
 
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_SUCCESS, 1);
-        assertEquals("one acknowledgement per message on a Shared subscription, one cumulative acknowledgement otherwise",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+        assertEquals("one acknowledgement per message, on every subscription type (#223)",
+                3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }
@@ -144,7 +144,7 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
         runner.assertTransferCount(ConsumePulsarRecord.REL_SUCCESS, 0);
         runner.assertTransferCount(ConsumePulsarRecord.REL_PARSE_FAILURE, 1);
         assertEquals("every unparseable message is acknowledged once its parse_failure FlowFile is committed",
-                shared ? 3 : 1, statesAtAcknowledgement.size());
+                3, statesAtAcknowledgement.size());
         for (final String state : statesAtAcknowledgement) {
             assertEquals("a message was acknowledged before the FlowFile carrying it was committed", ONE_COMMITTED_FLOWFILE, state);
         }
@@ -205,16 +205,8 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
         }).when(consumer).acknowledge(any(Message.class));
         doAnswer(invocation -> {
             states.add(sessionState(relationship));
-            return null;
-        }).when(consumer).acknowledgeCumulative(any(Message.class));
-        doAnswer(invocation -> {
-            states.add(sessionState(relationship));
             return CompletableFuture.completedFuture(null);
         }).when(consumer).acknowledgeAsync(any(Message.class));
-        doAnswer(invocation -> {
-            states.add(sessionState(relationship));
-            return CompletableFuture.completedFuture(null);
-        }).when(consumer).acknowledgeCumulativeAsync(any(Message.class));
 
         return states;
     }
@@ -243,8 +235,8 @@ public class ConsumePulsarRecordAcknowledgementTest extends AbstractPulsarProces
 
         verify(consumer, never()).acknowledge(any(Message.class));
         verify(consumer, never()).acknowledgeAsync(any(Message.class));
-        verify(consumer, never()).acknowledgeCumulative(any(Message.class));
-        verify(consumer, never()).acknowledgeCumulativeAsync(any(Message.class));
+        verify(consumer, never()).acknowledge(any(Message.class));
+        verify(consumer, never()).acknowledgeAsync(any(Message.class));
     }
 
     /**

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsar.java
@@ -185,18 +185,10 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         // Verify that every message was acknowledged
         verify(mockClientService.getMockConsumer(), times(batchSize)).receive(0, TimeUnit.SECONDS);
         
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledge(mockMessage);
-        	}
+        if (async) {
+        	verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledgeAsync(mockMessage);
         } else {
-        	if (async) {
-                verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);        		
-        	} else {
-                verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);        		
-        	}
+        	verify(mockClientService.getMockConsumer(), times(batchSize)).acknowledge(mockMessage);
         }
     }
 
@@ -230,19 +222,12 @@ public class TestConsumePulsar extends AbstractPulsarProcessorTest<byte[]> {
         boolean shared = isSharedSubType(subType);
         
         // Verify that every message was acknowledged
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify (mockClientService.getMockConsumer(), times(iterations)).acknowledge(mockMessage);
-        	}
+        if (async) {
+        	verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeAsync(mockMessage);
         } else {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulativeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulative(mockMessage);
-        	}
-        }        
+        	verify (mockClientService.getMockConsumer(), times(iterations)).acknowledge(mockMessage);
+        }
+        
     }
 
     protected void doMappedAttributesTest() throws PulsarClientException {

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/TestConsumePulsarRecord.java
@@ -170,21 +170,11 @@ public class TestConsumePulsarRecord extends AbstractPulsarProcessorTest<byte[]>
 
         verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).receive(0, TimeUnit.SECONDS);
 
-        boolean shared = isSharedSubType(subType);
-        
-        if (shared) {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledgeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledge(mockMessage);
-        	}
-        }
-        else {
-        	if (async) {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulativeAsync(mockMessage);
-        	} else {
-        		verify(mockClientService.getMockConsumer(), times(iterations)).acknowledgeCumulative(mockMessage);
-        	}
+        // One acknowledgement per message on every subscription type (#223).
+        if (async) {
+        	verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledgeAsync(mockMessage);
+        } else {
+        	verify(mockClientService.getMockConsumer(), times(iterations * batchSize)).acknowledge(mockMessage);
         }
         
         return flowFiles;

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsar.java
@@ -47,7 +47,7 @@ public class TestAsyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), times(0)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(0)).acknowledgeAsync(mockMessage);
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/async/TestAsyncConsumePulsarRecord.java
@@ -55,7 +55,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeAsync(mockMessage);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestAsyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulativeAsync(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeAsync(mockMessage);
     }
 
     /*

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsar.java
@@ -49,7 +49,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledge(mockMessage);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TestSyncConsumePulsar extends TestConsumePulsar {
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumePulsar.REL_SUCCESS);
         assertEquals(0, flowFiles.size());
 
-        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), atLeast(1)).acknowledge(mockMessage);
     }
 
     @Test

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/sync/TestSyncConsumePulsarRecord.java
@@ -45,7 +45,7 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledge(mockMessage);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class TestSyncConsumePulsarRecord extends TestConsumePulsarRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(ConsumePulsarRecord.REL_PARSE_FAILURE);
 
-        verify(mockClientService.getMockConsumer(), times(1)).acknowledgeCumulative(mockMessage);
+        verify(mockClientService.getMockConsumer(), times(1)).acknowledge(mockMessage);
     }
 
     /*


### PR DESCRIPTION
Closes #223.

Concurrent tasks of one processor share a consumer — `getConsumer()` is synchronized and caches by
consumer id, deliberately, so the broker never sees a second consumer on an `Exclusive` subscription.
Cumulative acknowledgement is safe only while one task owns the whole stream, and that was never true
here: `acknowledgeCumulative(last)` means *this message and everything before it on the subscription*,
and everything before it included whatever another task was still holding.

**The losing interleaving.** Task B commits its batch and acknowledges cumulatively, which
acknowledges task A's older message too. Task A then fails to write and negatively acknowledges —
which has nothing left to redeliver. The message is neither in NiFi nor recoverable from Pulsar: the
same loss the commit-then-acknowledge ordering was introduced to eliminate, reached by another route.

### The fix removes a distinction rather than adding a guard

Every subscription type now acknowledges per message. **This is not a new code path** — it is the loop
`Shared` subscriptions have always run, now taken by all of them. `shared` turned out to be used for
nothing else, so it goes: from `commitAndAcknowledge`, from `acknowledge`, and from the locals in both
consumers.

Deliberately **not** `acknowledge(List<MessageId>)`, which would be one call rather than a loop. This
bundle has never used that overload, and introducing an unexercised client API inside a data-loss fix
is the wrong trade — particularly to save a loop the client coalesces anyway: individual
acknowledgements are grouped into a single command over a 100ms window, up to 1000 ids.

### Fails first, both levels

**Unit** — `ConsumePulsarConcurrentAckTest`. Restoring cumulative acknowledgement fails 2 of its 3
cases. The `Shared` case passes either way, which is the point: that path was never affected.

**Integration** — `ConsumePulsarConcurrentAckIT`, real broker. It asserts on the subscription's
**backlog** after the second trigger commits, rather than waiting for a redelivery, so it never has to
distinguish "lost" from "not yet". Restoring cumulative acknowledgement fails it in the same twelve
seconds the passing run takes:

```
java.lang.AssertionError: the message rolled back by the first trigger was acknowledged by the
second trigger's commit: the subscription has no backlog, so nothing will ever redeliver it
```

### Two earlier versions of that IT were wrong

Both passed while proving nothing, and the comments in the test record why, because the setup is what
makes or breaks it:

- **A one-second redelivery delay** meant the rolled-back message came back *before* the next was
  acknowledged — the interleaving the defect needs never occurred. Caught by mutation testing.
- **Scheduling against a topic that already had messages**: `runner.run(1, false, true)` also triggers,
  so it consumed `first` and shifted the whole sequence by one. That version *did* fail against the
  bug — by timeout, with the real assertion never reached. Caught by reading why it failed rather than
  that it failed.

### Verified against `main`, not just against a mutation

Both tests were replayed onto unmodified `main` (`35d9212` — the commit `v2.11.0.1` was cut from). The
only edit was the `commitAndAcknowledge` signature, which gains a `shared` parameter there; no
assertion or setup was touched.

| | on `main` | with this fix |
|---|---|---|
| `ConsumePulsarConcurrentAckTest` | **2 of 3 fail** | 3/3 pass |
| `ConsumePulsarConcurrentAckIT` | **fails**, 11.65s | passes, 12.01s |

The IT fails on its assertion, not by timeout, and the `Shared` unit case passes on `main` — that path
genuinely was never affected, so the tests are not failing indiscriminately.

**This means the loss is reachable on the current release.** A flow on `2.11.0.1` with an `Exclusive`
or `Failover` subscription loses any message whose write fails while a later message is committed.

### Existing tests

The non-`Shared` assertions checked for one cumulative call and now check one acknowledgement per
message — **stronger, not weaker**. The 2.10.0 commit-before-acknowledge invariant is untouched and
still asserted throughout.

### Verification

370 unit, 75 integration, all green.

### Note for whoever merges second

#217 currently documents a workaround for this defect — *"Run these flows with a single task until
#223 is resolved"* — in the README and both consumer pages, because `Read Compacted` forces
`Exclusive`/`Failover`. That guidance is wrong once this lands, and needs reconciling in whichever
branch merges second.
