### PR TITLE
docs: point the ordering key javadoc at keyBytes, not the method that was removed

### DIFF
--- a/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
+++ b/nifi-pulsar-processors/src/main/java/org/apache/nifi/processors/pulsar/utils/PublisherLease.java
@@ -690,9 +690,9 @@ public class PublisherLease implements Closeable {
     }
 
     /**
-     * The ordering key a record field yields, converted exactly as {@link #getMessageKey} converts the message key
-     * field - so the same field named by either property gives the same bytes. Null, blank text and empty byte
-     * arrays mean no ordering key.
+     * The ordering key a record field yields. {@link #keyBytes} converts it, exactly as it converts the
+     * message key field, so the same field named by either property gives the same bytes. Null, blank text
+     * and empty byte arrays mean no ordering key.
      */
     private byte[] getOrderingKey(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
                                   final Object fieldValue) throws IOException, SchemaNotFoundException {


### PR DESCRIPTION
`getOrderingKey`'s javadoc in `PublisherLease` still referenced `getMessageKey`, which #222 removed when a binary *Message Key Field* started going through `keyBytes()` rather than being decoded to text. Noted on #222 as a sweep-up item after that PR had already merged.

### Why it stayed green

`javadoc` does report it, but only as a warning, so the build succeeds:

```
PublisherLease.java:693: warning: reference not found: #getMessageKey
```

Confirmed against `main` before the change, and zero such warnings after it.

### The fix

`keyBytes` is the shared converter for both properties, and its own javadoc already spells out the contract this comment was pointing at, so the link goes there. Comment-only — no behaviour change, 426/426 unit tests unaffected.

### Worth considering separately

Nothing fails the build on a broken `{@link}`. If that is worth closing, `-Xdoclint:reference` with a failure threshold in the javadoc plugin config would catch the next one — but that belongs in its own change, since it may surface other pre-existing warnings across the modules.
