### PR TITLE
chore: hold Testcontainers major updates until the JUnit 4 migration (#235)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,16 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
 
+      # Testcontainers 2.x is a JUnit 4 problem, like the parent POM above. It renames
+      # every module artifact (org.testcontainers:pulsar -> testcontainers-pulsar), so
+      # the BOM stops managing the coordinate we declare and no POM parses at all, and
+      # it drops JUnit 4 rule support, so AbstractPulsarIT's @ClassRule container fails
+      # with "must implement TestRule". Both were confirmed against 2.0.5 in #231.
+      # Blocked until #235 migrates the container lifecycle; 1.x patch/minor still flow.
+      - dependency-name: "org.testcontainers:*"
+        update-types:
+          - version-update:semver-major
+
   # All GitHub Actions updates collapse into a SINGLE grouped PR.
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Holds `org.testcontainers:*` major updates, mirroring the `nifi-extension-bundles` pin directly above it — same reason, a bump that silently requires a JUnit 4 migration.

### Why

#231 bundled `testcontainers 1.21.3 → 2.0.5` with five harmless bumps and all three real CI jobs failed. Two independent breaking changes, both confirmed against 2.0.5:

1. **Every module artifact is renamed** (`org.testcontainers:pulsar` → `org.testcontainers:testcontainers-pulsar`). The BOM stops managing the coordinate we declare without a version, so no POM parses — which is why the failure lands in the *Dockerfile base image* step: it runs `mvn help:evaluate` under `set -euo pipefail`, so Maven's exit code kills the step before its own error messages print. The Dockerfile is fine.
2. **Containers no longer implement JUnit 4's `TestRule`.** After the rename it compiles, then every IT fails with `The @ClassRule 'PULSAR' must implement TestRule`.

Full detail, evidence and repro steps are in **#235**, which tracks the migration.

### Effect

- Major testcontainers bumps stop being proposed, so the `maven-all` group is no longer held hostage by one incompatible member. The five safe bumps from #231 should reappear in the next group and auto-merge.
- `1.x` patch and minor updates are unaffected.

Config-only; no build change. The grouping/auto-merge design itself needed no fix — its comment already says a bundle containing a major is held for manual review, and that is exactly what happened.

### Follow-up

#231 can be closed once the regrouped bundle appears, or left for Dependabot to supersede.
