### PR TITLE
test: measure the ack-leak after the acknowledgements complete, not while they run (#233)

### DIFF
--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.pulsar.pubsub;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,7 +86,12 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
         long pendingAcks() {
             final ExecutorService pool = getAckPool();
             if (!(pool instanceof ThreadPoolExecutor)) {
-                return 0;
+                // Loud on purpose. Returning 0 here would make awaitSubmittedAcksToComplete() return without
+                // waiting and pass its own check trivially, and the gate would silently go back to measuring
+                // acks in flight on a loaded machine - the flake this test exists to be rid of (#233).
+                throw new AssertionError("the ack pool is a " + (pool == null ? "null" : pool.getClass().getName())
+                        + "; pendingAcks() can only measure a ThreadPoolExecutor, so this test cannot take the "
+                        + "machine out of the measurement (see #233)");
             }
             final ThreadPoolExecutor executor = (ThreadPoolExecutor) pool;
             return executor.getTaskCount() - executor.getCompletedTaskCount();
@@ -166,9 +172,15 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
      * The aggravating case: an idle topic. The cumulative-ack task used to be submitted outside the
      * "did we receive anything?" guard, so every trigger queued a Future holding an
      * IndexOutOfBoundsException from messages.get(-1) - an idle processor leaked fastest of all.
+     * <p>
+     * That is a defect of the cumulative path, which only Exclusive takes: a Shared subscription acknowledges
+     * per message and submits nothing on an idle topic, so its run of this test could only ever assert
+     * {@code 0 == 0}. Pinned to Exclusive; the gate test above is where both types earn their place.
      */
     @Test
     public void idleTopicDoesNotQueueFailedAcks() throws Exception {
+        assumeTrue("the idle-topic defect lives on the cumulative-ack path, which only Exclusive takes",
+                "Exclusive".equals(subscriptionType));
         mockClientService.setMockMessageQueue(new ArrayList<>());
 
         runner.run(TRIGGERS, false);

--- a/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
+++ b/nifi-pulsar-processors/src/test/java/org/apache/nifi/processors/pulsar/pubsub/ConsumePulsarAckLeakTest.java
@@ -17,11 +17,16 @@
 package org.apache.nifi.processors.pulsar.pubsub;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.nifi.processors.pulsar.AbstractPulsarConsumerProcessor;
@@ -33,41 +38,72 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Regression test for issue #53. Acknowledgements in async mode are submitted to an
  * ExecutorCompletionService, which retains the Future of every completed task until it is taken. Nothing
  * took them, so the queue grew by one Future per acknowledgement for the lifetime of the processor.
  * <p>
- * The test measures the leak behaviourally: after running the processor it counts how many completed
- * acknowledgement Futures are still sitting in the completion service. With the drain in place that count
- * stays near zero (only acks still in flight); without it, it grows with the number of triggers.
+ * The leak is a property of what happens <i>after</i> an acknowledgement completes: with the drain in
+ * place a completed Future is taken by the next trigger; without it, it stays queued for good. So the test
+ * waits for every submitted acknowledgement to complete, lets one more trigger drain, and asserts that
+ * nothing is left. That is the leak and nothing else - no allowance for "acks still in flight", which
+ * depends on how loaded the machine is and cannot be pinned (#233: a hard 3 failed in CI with 8, a quarter
+ * of the triggers failed with 26 and 21, on commits that could not touch retention).
+ * <p>
+ * Runs for both subscription types the consumers acknowledge differently on: Shared acknowledges every
+ * message, Exclusive cumulatively once per batch.
  */
+@RunWith(Parameterized.class)
 public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<GenericRecord> {
 
     private static final String TOPIC = "persistent://public/default/events";
     private static final int TRIGGERS = 40;
 
-    /**
-     * How many retained acknowledgements still count as "in flight" rather than leaked.
-     * <p>
-     * The drain collects Futures that have already completed, so acknowledgements outstanding when the
-     * last trigger returns are legitimately still queued. That number is NOT the ack pool's thread count:
-     * the pool is a fixed thread pool with an unbounded work queue, so an arbitrary number of acks can be
-     * submitted and not yet run. It depends on scheduling, and it goes up under load - which is exactly
-     * how an earlier version of this test, asserting a hard 3, failed in CI with 8.
-     * <p>
-     * What is actually invariant is that the count does not scale with how long the processor ran: the
-     * leak produced exactly one Future per acknowledgement, so it tracked the trigger count 1:1. This
-     * allowance is a quarter of the triggers, which leaves a 4x margin below the leak while tolerating
-     * scheduling noise. {@link #retainedAcksDoNotGrowWithTriggerCount()} tests the invariant directly.
-     */
-    private static int inFlightAllowance(final int triggers) {
-        return Math.max(4, triggers / 4);
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> subscriptionTypes() {
+        return Arrays.asList(new Object[][] {{"Shared"}, {"Exclusive"}});
     }
 
-    /** Exposes the ack completion service, which is protected on AbstractPulsarConsumerProcessor. */
+    private final String subscriptionType;
+
+    public ConsumePulsarAckLeakTest(final String subscriptionType) {
+        this.subscriptionType = subscriptionType;
+    }
+
+    /** Exposes the ack pool and completion service, which are protected on AbstractPulsarConsumerProcessor. */
     public static class AckProbeConsumePulsar extends ConsumePulsar {
+
+        /**
+         * How many submitted acknowledgements have not run yet. This is the number the old fixed allowance
+         * tried to bound, and it is a property of the machine, not of the processor: logged for the record,
+         * never asserted on.
+         */
+        long pendingAcks() {
+            final ExecutorService pool = getAckPool();
+            if (!(pool instanceof ThreadPoolExecutor)) {
+                return 0;
+            }
+            final ThreadPoolExecutor executor = (ThreadPoolExecutor) pool;
+            return executor.getTaskCount() - executor.getCompletedTaskCount();
+        }
+
+        /**
+         * Waits until every acknowledgement submitted so far has run. The pool is a ThreadPoolExecutor with an
+         * unbounded queue, so "submitted" and "completed" can be arbitrarily far apart on a loaded machine;
+         * this is the wait that takes the machine out of the measurement.
+         */
+        void awaitSubmittedAcksToComplete() throws InterruptedException {
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (pendingAcks() > 0 && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
+            assertEquals("acknowledgements still running after 30 s", 0L, pendingAcks());
+        }
+
         /** Drains and counts the acknowledgement Futures the processor left behind. */
         int countRetainedAcks() throws InterruptedException {
             if (getAckService() == null) {
@@ -75,8 +111,7 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
             }
 
             int retained = 0;
-            // a generous first wait lets any in-flight ack land, so we do not undercount the leak
-            Future<Object> ack = getAckService().poll(2, TimeUnit.SECONDS);
+            Future<Object> ack = getAckService().poll(500, TimeUnit.MILLISECONDS);
 
             while (ack != null) {
                 retained++;
@@ -99,82 +134,32 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
         runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "true");
         runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
         runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
+        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, subscriptionType);
     }
 
-    /** Shared subscriptions acknowledge every message individually - the worst case for the leak. */
+    /**
+     * The gate. After the triggers have run and every acknowledgement they submitted has completed, one
+     * trigger on the now-empty topic drains the completion service, and nothing may be left in it. With the
+     * leak, everything is left: one Future per acknowledgement, {@link #TRIGGERS} of them.
+     */
     @Test
-    public void sharedSubscriptionAcksAreNotRetained() throws Exception {
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
+    public void completedAcknowledgementsAreDrainedByTheNextTrigger() throws Exception {
         mockClientService.setMockMessageQueue(messages(TRIGGERS));
 
         // do not stop the processor: @OnUnscheduled tears the pools down, which would hide the leak
         runner.run(TRIGGERS, false);
+        // diagnostic only - the in-flight count at this instant is what a loaded runner inflates (#233)
+        System.out.println(subscriptionType + ": " + processor.pendingAcks() + " acknowledgement(s) still pending when the last of "
+                + TRIGGERS + " triggers returned");
+        processor.awaitSubmittedAcksToComplete();
+
+        // the topic is empty now; this trigger receives nothing and only drains
+        runner.run(1, false, false);
 
         final int retained = processor.countRetainedAcks();
-        assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
-                + " triggers. The leak produced one per acknowledgement; anything near the trigger count "
-                + "is that leak, not acks in flight (see issue #53)",
-                retained <= inFlightAllowance(TRIGGERS));
-    }
-
-    /** Exclusive subscriptions acknowledge cumulatively, once per batch. */
-    @Test
-    public void exclusiveSubscriptionAcksAreNotRetained() throws Exception {
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
-        mockClientService.setMockMessageQueue(messages(TRIGGERS));
-
-        runner.run(TRIGGERS, false);
-
-        final int retained = processor.countRetainedAcks();
-        assertTrue("Acknowledgement Futures are being retained: " + retained + " left after " + TRIGGERS
-                + " triggers. The leak produced one per acknowledgement; anything near the trigger count "
-                + "is that leak, not acks in flight (see issue #53)",
-                retained <= inFlightAllowance(TRIGGERS));
-    }
-
-    /**
-     * The property that actually separates "a few acks still in flight" from "a leak": the retained count
-     * must not scale with how long the processor has been running.
-     * <p>
-     * Measured at two scales in one test rather than against a fixed number, because the in-flight count
-     * depends on scheduling and rises under load. With the bug the queue grew one Future per
-     * acknowledgement, so quadrupling the triggers quadrupled the count - 40 and 160. Bounded, the two
-     * measurements stay in the same range no matter how far apart the trigger counts are.
-     */
-    @Test
-    public void retainedAcksDoNotGrowWithTriggerCount() throws Exception {
-        final int fewTriggers = TRIGGERS;
-        final int manyTriggers = TRIGGERS * 4;
-
-        final int afterFew = retainedAfter(fewTriggers);
-        final int afterMany = retainedAfter(manyTriggers);
-
-        assertTrue("Retained acknowledgements track the trigger count: " + afterMany + " left after "
-                + manyTriggers + " triggers, which is the one-Future-per-acknowledgement leak rather than "
-                + "acks in flight (see issue #53)", afterMany <= inFlightAllowance(manyTriggers));
-
-        // 4x the triggers must not mean anything like 4x the retained futures
-        assertTrue("Retained acknowledgements scaled with the trigger count: " + afterFew + " after "
-                + fewTriggers + " triggers but " + afterMany + " after " + manyTriggers
-                + " (see issue #53)", afterMany < afterFew + (manyTriggers - fewTriggers) / 4);
-    }
-
-    /** Runs a fresh processor for the given number of triggers and returns what it left queued. */
-    private int retainedAfter(final int triggers) throws Exception {
-        processor = new AckProbeConsumePulsar();
-        runner = TestRunners.newTestRunner(processor);
-        addPulsarClientService();
-        runner.setProperty(AbstractPulsarConsumerProcessor.TOPICS, TOPIC);
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_NAME, "nifi-subscription");
-        runner.setProperty(AbstractPulsarConsumerProcessor.ASYNC_ENABLED, "true");
-        runner.setProperty(AbstractPulsarConsumerProcessor.CONSUMER_BATCH_SIZE, "1");
-        runner.setProperty(AbstractPulsarConsumerProcessor.MESSAGE_DEMARCATOR, "\n");
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Shared");
-        mockClientService.setMockMessageQueue(messages(triggers));
-
-        runner.run(triggers, false);
-
-        return processor.countRetainedAcks();
+        assertEquals("Acknowledgement Futures are being retained after they completed: " + retained + " left after "
+                + TRIGGERS + " triggers and a draining one. The leak kept one per acknowledgement (see issue #53)",
+                0, retained);
     }
 
     /**
@@ -184,10 +169,10 @@ public class ConsumePulsarAckLeakTest extends AbstractPulsarProcessorTest<Generi
      */
     @Test
     public void idleTopicDoesNotQueueFailedAcks() throws Exception {
-        runner.setProperty(AbstractPulsarConsumerProcessor.SUBSCRIPTION_TYPE, "Exclusive");
         mockClientService.setMockMessageQueue(new ArrayList<>());
 
         runner.run(TRIGGERS, false);
+        processor.awaitSubmittedAcksToComplete();
 
         runner.assertTransferCount(ConsumePulsar.REL_SUCCESS, 0);
         final int retained = processor.countRetainedAcks();


### PR DESCRIPTION
Closes #233.

`ConsumePulsarAckLeakTest` bounded how many acknowledgement `Future`s may still be queued at the instant the last trigger returns. That number is how far the ack pool lags behind the trigger thread — a property of the machine, not of the processor — and the history in #233 shows it cannot be pinned: a hard 3 failed in CI with 8 (#164), a quarter of the triggers failed with 26 on a comment-only commit and with 21 on a Dependabot bundle, in one of two concurrent jobs on the same tree.

### What changed

The leak is a property of what happens **after** an acknowledgement completes: with the drain in place the next trigger takes the completed `Future`; without it the `Future` stays queued for good. So the gate now measures exactly that, and nothing else:

1. run the triggers;
2. wait until every acknowledgement they submitted has completed (`ThreadPoolExecutor.getTaskCount() == getCompletedTaskCount()`, 30 s ceiling);
3. run one more trigger on the now-empty topic — it receives nothing and only drains;
4. assert that **zero** `Future`s are left.

No allowance to tune. With the drain removed the assertion fails with exactly 40 retained after 40 triggers, for both subscription types.

- **Parameterised by subscription type** (`Shared`, `Exclusive`), so the cumulative-ack path keeps its coverage — your point on #233 that the old invariant test ran `Shared` only.
- **The in-flight count at the moment the last trigger returns is printed, not asserted** — the diagnostic you suggested keeping, so a loaded runner still shows in the log (`Exclusive: 1 acknowledgement(s) still pending when the last of 40 triggers returned` here).
- **Removed:** `sharedSubscriptionAcksAreNotRetained` and `exclusiveSubscriptionAcksAreNotRetained` (the flaky assertions), and `retainedAcksDoNotGrowWithTriggerCount`. I went one step past the proposal on the last one: its first assertion was itself a fixed allowance (`afterMany <= 40` at 160 triggers), and its shape assertion tolerated 30 extra `Future`s at four times the triggers — with 26 observed at 40 triggers on a loaded runner, that margin is of the same kind. Once the measurement waits for completion the shape comparison has nothing left to distinguish, so the deterministic gate replaces it rather than sitting beside it.
- **Kept:** `idleTopicDoesNotQueueFailedAcks`, with the same wait before counting.

### Fails first

With `drainAcknowledgments()` removed from `ConsumePulsar`'s `finally`:

```
Tests run: 4, Failures: 2, Errors: 0 -- in ConsumePulsarAckLeakTest
  completedAcknowledgementsAreDrainedByTheNextTrigger[Shared]:    expected:<0> but was:<40>
  completedAcknowledgementsAreDrainedByTheNextTrigger[Exclusive]: expected:<0> but was:<40>
```

### Verification

- `mvn test`: **426/426**.
- The new class, 5 consecutive runs with 40 busy-loop processes on a 20-core machine (the class took 16–22 s instead of 4 s): 4/4 every time.
- What I could **not** do: reproduce the old test's CI failure locally. Under the same load the previous version passed 3/3 here. A 20-core box does not starve the ack threads the way a 2–4 vCPU runner does, so the fix is argued from the measurement's construction (it no longer depends on lag at all) and the mutation, not from a local red of the old assertion.

### Not done

- `ConsumePulsarRecord` has the same drain in its `finally` and no test of its own for the leak; this class tests `ConsumePulsar` only, as before.
- The 30 s ceiling on the completion wait is a guard against a hung pool, not a tuning knob; on every run here the wait was under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FxYKxcaKpvRbJSYP3QYZ9
